### PR TITLE
feat(services): add OpenGateway LLM client service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   compatible LLM client for the gitlawb OpenGateway endpoint
   (`https://opengateway.gitlawb.com/v1`). Ships under the gitlawb
   partnership. Non-streaming chat completions only; streaming remains
-  Hermes' responsibility upstream. New env vars: `OPENGATEWAY_API_KEY`
-  (required for `chat_completion` calls) and `OPENGATEWAY_MODEL`
-  (optional default model). `opengateway.gitlawb.com` added to
-  `clawmes/lib/http.py` allowlist. Registered as service 6d in
-  `services.start_all` between LiFi and the background daemons. No
-  internal consumer wired in this change — first consumers will land
-  in follow-up PRs as specific tools opt in.
+  Hermes' responsibility upstream. Calls without `OPENGATEWAY_API_KEY`
+  are sent unauthenticated (matches gitlawb's partnership-window
+  policy of "auth optional today, required soon") — service emits a
+  startup warning so the future auth flip is not a total surprise.
+  Setting the key is strongly recommended in production for
+  attribution and rate-limit isolation. Live-probed against the real
+  gateway; the structured-error body is pulled from the raised
+  `httpx.HTTPStatusError.response` so users see real upstream messages
+  (`"opengateway error (unsupported_model): Unsupported model …"`)
+  instead of useless `"Client error '400 Bad Request' for url …"`.
+  Sends `Accept-Encoding: identity` per-request to work around a
+  verified upstream bug where the gateway advertises gzip on some 2xx
+  responses but returns bodies that fail zlib decompression. New env
+  vars: `OPENGATEWAY_API_KEY` (recommended; OpenAI-style
+  `ogw_live_…` format) and `OPENGATEWAY_MODEL` (optional default
+  model id). `opengateway.gitlawb.com` added to `clawmes/lib/http.py`
+  allowlist. Registered as service 6d in `services.start_all` between
+  LiFi and the background daemons. No internal consumer wired in this
+  change — first consumers land in follow-up PRs as specific tools
+  opt in.
 
 ## 0.1.0 — 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to clawmes are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `OpenGatewayService` (`clawmes/services/opengateway.py`) — OpenAI-
+  compatible LLM client for the gitlawb OpenGateway endpoint
+  (`https://opengateway.gitlawb.com/v1`). Ships under the gitlawb
+  partnership. Non-streaming chat completions only; streaming remains
+  Hermes' responsibility upstream. New env vars: `OPENGATEWAY_API_KEY`
+  (required for `chat_completion` calls) and `OPENGATEWAY_MODEL`
+  (optional default model). `opengateway.gitlawb.com` added to
+  `clawmes/lib/http.py` allowlist. Registered as service 6d in
+  `services.start_all` between LiFi and the background daemons. No
+  internal consumer wired in this change — first consumers will land
+  in follow-up PRs as specific tools opt in.
+
 ## 0.1.0 — 2026-04-29
 
 First versioned release. 45 of 48 PRD tools shipped at 100% test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Documentation
+
+- README "Using OpenGateway as your LLM provider" section documents
+  both integration modes: Mode 1 routes the whole Hermes stack
+  through OpenGateway via `hermes model` (config-only, no code), and
+  Mode 2 lets specific clawmes tools opt into targeted LLM calls via
+  `OpenGatewayService`.
+
 ### Added
 
 - `OpenGatewayService` (`clawmes/services/opengateway.py`) — OpenAI-

--- a/README.md
+++ b/README.md
@@ -222,6 +222,40 @@ CLAWNCH_LAUNCHPAD_ADDRESS=
 
 The setup wizard (`hermes clawmes init`) walks through the most-used keys interactively with live validation.
 
+### Using OpenGateway as your LLM provider
+
+Clawmes ships under a partnership with [gitlawb OpenGateway](https://gitlawb.com/opengateway) — an OpenAI-compatible inference gateway that routes a single endpoint across model providers (Xiaomi MiMo, GMI Cloud, more). There are two integration modes; you can use either or both.
+
+**Mode 1 — Route the whole Hermes stack through OpenGateway (recommended for most users).**
+
+Hermes already supports any OpenAI-compatible endpoint as a "custom" provider. Point it at OpenGateway via `hermes model`:
+
+```
+$ hermes model
+# Pick: "custom endpoint" (or equivalent in your Hermes version)
+# Base URL:  https://opengateway.gitlawb.com/v1
+# API key:   ogw_live_…   (sign in at https://gitlawb.com/opengateway/dashboard to generate one)
+# Model:     mimo-v2.5-pro (or any model OpenGateway routes; check https://opengateway.gitlawb.com/health)
+```
+
+This is config-only — no clawmes code change required. Every LLM call the agent makes (conversation, tool routing, summarization, everything Hermes drives) goes through OpenGateway, with secrets staying server-side. During the gitlawb partnership window the gateway accepts unauthenticated traffic, so you can try it without a key — but auth will become required, so generate one early.
+
+**Mode 2 — Targeted LLM calls from clawmes tools (advanced).**
+
+Clawmes also ships `OpenGatewayService` (`clawmes/services/opengateway.py`) — a service that gives any clawmes tool a first-class LLM client for subtasks outside the main agent loop (intent classification, swap-parameter extraction, governance-proposal summarization, etc). Tools opt in by calling:
+
+```python
+from clawmes.services.opengateway import get_opengateway_service
+
+result = get_opengateway_service().chat_completion(
+    messages=[{"role": "user", "content": "..."}],
+    model="mimo-v2.5-pro",
+)
+content = result["choices"][0]["message"]["content"]
+```
+
+This is independent from Mode 1 — Mode 2 calls go to OpenGateway regardless of which provider Hermes itself uses. Configure via the `OPENGATEWAY_API_KEY` / `OPENGATEWAY_MODEL` env vars above.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ ZEROX_API_KEY=
 LIFI_API_KEY=
 
 # LLM inference gateway (gitlawb opengateway — OpenAI-compatible)
-OPENGATEWAY_API_KEY=  # ogw_live_… — required for OpenGatewayService.chat_completion
+OPENGATEWAY_API_KEY=  # ogw_live_… — recommended; service runs unauthenticated without it
+                      # during the gitlawb partnership window (auth optional today)
 OPENGATEWAY_MODEL=    # optional default model id sent when callers omit model=
 
 # Market data + analytics

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ hermes (the upstream CLI, hermes-agent ≥ 2026.4.x)
               ├── 11 hooks     (pre_tool_call, post_tool_call, pre_llm_call, ...)
               ├── 27 skills    (registered via ctx.register_skill, namespaced clawmes:*)
               ├── CLI subcmds  (registered via ctx.register_cli_command)
-              └── 14 services  (start_all() starts background lifecycle)
+              └── 15 services  (start_all() starts background lifecycle)
                     │
                     ├── subprocess: clawmes-wc-bridge   (Node — WalletConnect v2)
                     └── subprocess: clawmes-sa-bridge   (Node — MetaMask Smart Accounts; planned)
@@ -186,6 +186,10 @@ CLAWMES_RPC_<chain_id>=  # override per-chain RPC URL
 # DEX / bridge aggregators
 ZEROX_API_KEY=
 LIFI_API_KEY=
+
+# LLM inference gateway (gitlawb opengateway — OpenAI-compatible)
+OPENGATEWAY_API_KEY=  # ogw_live_… — required for OpenGatewayService.chat_completion
+OPENGATEWAY_MODEL=    # optional default model id sent when callers omit model=
 
 # Market data + analytics
 COINGECKO_API_KEY=

--- a/clawmes/lib/http.py
+++ b/clawmes/lib/http.py
@@ -90,6 +90,8 @@ _DEFAULT_ALLOWLIST: frozenset[str] = frozenset(
         # Bankr
         "api.bankr.bot",
         "llm.bankr.bot",
+        # LLM inference gateway (gitlawb opengateway — see services.opengateway)
+        "opengateway.gitlawb.com",
         # Simulation
         "api.tenderly.co",
         # Fiat ramps

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -90,3 +90,11 @@ requires_env:
     description: Basescan API key (block_explorer tool)
     url: https://basescan.org/myapikey
     secret: true
+  - name: OPENGATEWAY_API_KEY
+    description: gitlawb OpenGateway API key for the OpenAI-compatible LLM gateway (ogw_live_…)
+    url: https://gitlawb.com/opengateway
+    secret: true
+  - name: OPENGATEWAY_MODEL
+    description: Default model id sent to OpenGateway when callers do not pass model= (optional)
+    url: https://gitlawb.com/opengateway
+    secret: false

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -91,7 +91,7 @@ requires_env:
     url: https://basescan.org/myapikey
     secret: true
   - name: OPENGATEWAY_API_KEY
-    description: gitlawb OpenGateway API key for the OpenAI-compatible LLM gateway (ogw_live_…)
+    description: gitlawb OpenGateway API key (ogw_live_…); recommended but currently optional during the partnership window
     url: https://gitlawb.com/opengateway
     secret: true
   - name: OPENGATEWAY_MODEL

--- a/clawmes/services/__init__.py
+++ b/clawmes/services/__init__.py
@@ -44,6 +44,7 @@ def start_all() -> None:
     from clawmes.services.explorer import get_explorer_service
     from clawmes.services.lifi import get_lifi_service
     from clawmes.services.mode_service import get_mode_service
+    from clawmes.services.opengateway import get_opengateway_service
     from clawmes.services.persona_service import get_persona_service
     from clawmes.services.price import get_price_service
     from clawmes.services.rpc import get_rpc_service
@@ -84,6 +85,11 @@ def start_all() -> None:
         get_zerox_service,
         # 6c. LiFi cross-chain bridge aggregator. Same shape as 0x.
         get_lifi_service,
+        # 6d. OpenAI-compatible LLM gateway (gitlawb opengateway). Used
+        #     by tools that need targeted inference outside the host
+        #     Hermes agent loop. Independent from Hermes' main LLM —
+        #     the agent's conversational inference is owned upstream.
+        get_opengateway_service,
         # 7. Background daemons — last so they pick up everything above.
         get_scheduler,  # ticking=True; needs cron driver to actually fire
         get_wc_notification_consumer,  # threaded; routes WC bridge notifs

--- a/clawmes/services/opengateway.py
+++ b/clawmes/services/opengateway.py
@@ -24,7 +24,14 @@ Scope of this service:
     etc. (see ``README.md`` config section). Adding OpenGateway as
     Hermes' main provider is a Hermes-level concern.
 
-API key: ``OPENGATEWAY_API_KEY`` env var, ``ogw_live_…`` format.
+API key: ``OPENGATEWAY_API_KEY`` env var, ``ogw_live_…`` format. The
+gateway accepts unauthenticated traffic today ("auth optional during
+the partnership window, required soon" per their docs), so the service
+sends requests without an ``Authorization`` header when the env var is
+missing and logs a warning at start so the future auth flip is not a
+total surprise. Setting the key is strongly recommended in production
+for attribution and rate-limit isolation.
+
 Default model: ``OPENGATEWAY_MODEL`` env var; can be overridden per
 call via the ``model=`` keyword. If neither is set, ``chat_completion``
 raises ``OpenGatewayError("bad_request", ...)``.
@@ -51,16 +58,24 @@ _BASE_URL = "https://opengateway.gitlawb.com/v1"
 class OpenGatewayError(RuntimeError):
     """Raised on OpenGateway API failures.
 
-    ``code`` classification:
-      * ``no_credentials`` — OPENGATEWAY_API_KEY is not set. The
-        gateway's docs note that anonymous traffic is allowed during
-        the partnership window but will be removed; we refuse to send
-        unauthenticated traffic so users notice the configuration gap
-        before the auth wall lands.
-      * ``bad_request`` — caller-side error (empty messages list,
-        no model resolvable from arg / env, HTTP 400 from upstream).
-      * ``model_not_found`` — HTTP 404 / "model not found" envelope.
-      * ``rate_limited`` — HTTP 429.
+    ``code`` classification (preferred sources in order: ``error.code``
+    field in the upstream envelope, then ``error.type``, then keyword
+    match on the upstream message, then keyword match on the raised
+    exception string when no structured body is available):
+
+      * ``bad_request`` — caller-side error: empty messages, no model
+        resolvable from arg / env, OpenAI ``invalid_request_error``,
+        HTTP 400.
+      * ``model_not_found`` — OpenAI ``unsupported_model`` /
+        ``model_not_found`` code, HTTP 404, or a message containing
+        both "model" and "not found".
+      * ``rate_limited`` — OpenAI ``rate_limit_exceeded`` /
+        ``rate_limit_error``, HTTP 429.
+      * ``no_credentials`` — OpenAI ``authentication_error`` /
+        ``permission_denied``, HTTP 401 / 403. Raised when the gateway
+        refuses the call for auth reasons; *not* raised pre-flight
+        when ``OPENGATEWAY_API_KEY`` is absent (the gateway accepts
+        unauth'd traffic during the partnership window).
       * ``api_error`` — generic upstream failure.
     """
 
@@ -82,11 +97,21 @@ class OpenGatewayService(Service):
         with self._lock:
             self._api_key = os.environ.get("OPENGATEWAY_API_KEY") or None
             self._default_model = os.environ.get("OPENGATEWAY_MODEL") or None
-        _log.info(
-            "opengateway service started (auth=%s, default_model=%s)",
-            "key" if self._api_key else "missing",
-            self._default_model or "<unset>",
-        )
+        if self._api_key:
+            _log.info(
+                "opengateway service started (auth=key, default_model=%s)",
+                self._default_model or "<unset>",
+            )
+        else:
+            # Unauthenticated traffic is currently accepted by the gateway,
+            # so we don't refuse to start — but we warn so the future
+            # auth-required flip is not a total surprise.
+            _log.warning(
+                "opengateway service started UNAUTHENTICATED (no OPENGATEWAY_API_KEY); "
+                "calls will succeed during the gitlawb partnership window but stop "
+                "working when auth becomes required (default_model=%s)",
+                self._default_model or "<unset>",
+            )
 
     def stop(self) -> None:
         with self._lock:
@@ -97,7 +122,7 @@ class OpenGatewayService(Service):
         with self._lock:
             return {
                 "id": self.id,
-                "status": "configured" if self._api_key else "missing_key",
+                "status": "authenticated" if self._api_key else "unauthenticated",
                 "default_model": self._default_model,
             }
 
@@ -122,6 +147,11 @@ class OpenGatewayService(Service):
         envelope: ``choices[*].message.content``, ``usage``, etc.).
         Streaming is explicitly disabled — pass ``stream=True`` and we
         raise ``bad_request``.
+
+        Calls without ``OPENGATEWAY_API_KEY`` are sent unauthenticated
+        (the gateway allows this during the partnership window). The
+        upstream will start returning ``401`` once auth is required —
+        that surfaces here as ``OpenGatewayError("no_credentials", …)``.
         """
         if not messages:
             raise OpenGatewayError("bad_request", "messages list must be non-empty")
@@ -134,12 +164,6 @@ class OpenGatewayService(Service):
         with self._lock:
             api_key = self._api_key
             default_model = self._default_model
-
-        if not api_key:
-            raise OpenGatewayError(
-                "no_credentials",
-                "OPENGATEWAY_API_KEY is not set; cannot send authenticated traffic",
-            )
 
         resolved_model = model or default_model
         if not resolved_model:
@@ -162,21 +186,54 @@ class OpenGatewayService(Service):
         path: str,
         body: dict[str, Any],
         *,
-        api_key: str,
+        api_key: str | None,
         timeout: float,
     ) -> dict[str, Any]:
-        headers = {
-            "Authorization": f"Bearer {api_key}",
+        headers: dict[str, str] = {
             "Content-Type": "application/json",
+            # Upstream bug workaround (verified via live probe, 2026-05):
+            # opengateway advertises ``content-encoding: gzip`` on 2xx
+            # responses but the body fails zlib decompression with
+            # "Error -3: incorrect header check". curl works because
+            # curl tolerates the malformed gzip stream; httpx does not.
+            # Asking for identity encoding bypasses the broken path.
+            # Drop this override once gitlawb fixes the gateway's
+            # compression layer.
+            "Accept-Encoding": "identity",
         }
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         url = _BASE_URL + path
         try:
             response = http_post(url, json=body, headers=headers, timeout=timeout)
         except Exception as exc:  # noqa: BLE001 — classify below
+            # ``clawmes.lib.http.http_post`` wraps httpx and calls
+            # ``raise_for_status`` on non-2xx, which discards the
+            # response body. The exception object still carries the
+            # original response on its ``.response`` attribute, so we
+            # duck-type past lib/http to recover the structured error
+            # envelope without importing httpx here.
+            body_dict: dict[str, Any] | None = None
+            resp = getattr(exc, "response", None)
+            if resp is not None:
+                try:
+                    parsed = resp.json()
+                except Exception:  # noqa: BLE001 — body might not be JSON
+                    parsed = None
+                if isinstance(parsed, dict):
+                    body_dict = parsed
+
+            if body_dict is not None and isinstance(body_dict.get("error"), dict):
+                raise self._classify_envelope(body_dict["error"]) from exc
+
+            # No structured body — fall back to substring matching on
+            # the raised exception (transport errors, non-JSON 5xx, etc).
             msg = str(exc).lower()
-            if "429" in msg or "rate" in msg:
+            if "429" in msg or "rate limit" in msg:
                 raise OpenGatewayError("rate_limited", str(exc)) from exc
-            if "404" in msg or "model" in msg and "not found" in msg:
+            if "401" in msg or "403" in msg:
+                raise OpenGatewayError("no_credentials", str(exc)) from exc
+            if "404" in msg or ("model" in msg and "not found" in msg):
                 raise OpenGatewayError("model_not_found", str(exc)) from exc
             if "400" in msg:
                 raise OpenGatewayError("bad_request", str(exc)) from exc
@@ -187,22 +244,43 @@ class OpenGatewayService(Service):
                 "api_error",
                 f"opengateway returned non-dict response: {type(response).__name__}",
             )
-        # OpenAI-compatible error envelope: {"error": {"message", "type", "code"}}
+        # Defensive: some buggy upstreams return 2xx with an error
+        # envelope in the body. clawmes.lib.http won't have raised in
+        # that case, so classify here.
         if isinstance(response.get("error"), dict):
-            err = response["error"]
-            text = str(err.get("message") or "")
-            text_lower = text.lower()
-            err_type = str(err.get("type") or "").lower()
-            if "rate" in text_lower or err_type == "rate_limit_error":
-                code = "rate_limited"
-            elif "model" in text_lower and "not found" in text_lower:
-                code = "model_not_found"
-            elif err_type == "invalid_request_error":
-                code = "bad_request"
-            else:
-                code = "api_error"
-            raise OpenGatewayError(code, f"opengateway error: {text}")
+            raise self._classify_envelope(response["error"])
         return response
+
+    @staticmethod
+    def _classify_envelope(err: dict[str, Any]) -> OpenGatewayError:
+        """Classify an OpenAI-style error envelope into an OpenGatewayError.
+
+        Inspects ``error.code`` first (specific), then ``error.type``
+        (still structured), then keyword-matches ``error.message`` as
+        a last-ditch (some upstreams omit the structured fields).
+        """
+        message = str(err.get("message") or "")
+        err_type = str(err.get("type") or "").lower()
+        err_code = str(err.get("code") or "").lower()
+        display = f"opengateway error ({err_code or err_type or 'unknown'}): {message}"
+
+        if err_code in {"unsupported_model", "model_not_found"}:
+            return OpenGatewayError("model_not_found", display)
+        if err_code == "rate_limit_exceeded" or err_type == "rate_limit_error":
+            return OpenGatewayError("rate_limited", display)
+        if err_type in {"authentication_error", "permission_denied"}:
+            return OpenGatewayError("no_credentials", display)
+        if err_type == "invalid_request_error":
+            # Distinguish model-not-found that came through as
+            # invalid_request_error (per real OpenGateway behavior:
+            # ``code=unsupported_model`` carries ``type=invalid_request_error``).
+            # The code check above already caught that; if we got here,
+            # it's a true bad request.
+            msg_lower = message.lower()
+            if "model" in msg_lower and ("not found" in msg_lower or "unsupported" in msg_lower):
+                return OpenGatewayError("model_not_found", display)
+            return OpenGatewayError("bad_request", display)
+        return OpenGatewayError("api_error", display)
 
 
 _instance: OpenGatewayService | None = None

--- a/clawmes/services/opengateway.py
+++ b/clawmes/services/opengateway.py
@@ -1,0 +1,215 @@
+"""OpenAI-compatible LLM client for the gitlawb OpenGateway.
+
+OpenGateway (``https://opengateway.gitlawb.com``) is an OpenAI-compatible
+inference gateway that routes a single endpoint across multiple model
+providers (Xiaomi MiMo, GMI Cloud, etc.) under server-side credentials.
+Per the gitlawb partnership, clawmes ships a first-class client so tools
+that need targeted inference outside the host Hermes agent loop (e.g.
+classifiers, summarizers, structured-extraction helpers) can use it
+without each tool wiring its own ``httpx`` client.
+
+Scope of this service:
+
+  * **Non-streaming chat completions only.** Streaming Server-Sent
+    Events are out of scope here; clients that need streaming should
+    use Hermes' own LLM client, which already handles SSE properly.
+  * **OpenGateway endpoint only.** The base URL is hardcoded, matching
+    the convention used by the 0x / CoinGecko / LiFi services. Users
+    pointing at a different OpenAI-compatible endpoint is out of scope
+    for this service; it would defeat the purpose of a branded
+    partnership integration.
+  * **Independent from the host Hermes LLM.** This service does *not*
+    reroute the agent's main conversational inference — that's owned
+    by Hermes itself via ``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY``
+    etc. (see ``README.md`` config section). Adding OpenGateway as
+    Hermes' main provider is a Hermes-level concern.
+
+API key: ``OPENGATEWAY_API_KEY`` env var, ``ogw_live_…`` format.
+Default model: ``OPENGATEWAY_MODEL`` env var; can be overridden per
+call via the ``model=`` keyword. If neither is set, ``chat_completion``
+raises ``OpenGatewayError("bad_request", ...)``.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any
+
+from clawmes.lib.http import http_post
+from clawmes.lib.logger import logger_for
+from clawmes.services._base import Service
+
+_log = logger_for("services.opengateway")
+
+# OpenGateway's canonical OpenAI-compatible endpoint. The provider's
+# docs (https://gitlawb.com/opengateway) say: "Point any OpenAI-
+# compatible client at opengateway.gitlawb.com/v1 and pass the model."
+_BASE_URL = "https://opengateway.gitlawb.com/v1"
+
+
+class OpenGatewayError(RuntimeError):
+    """Raised on OpenGateway API failures.
+
+    ``code`` classification:
+      * ``no_credentials`` — OPENGATEWAY_API_KEY is not set. The
+        gateway's docs note that anonymous traffic is allowed during
+        the partnership window but will be removed; we refuse to send
+        unauthenticated traffic so users notice the configuration gap
+        before the auth wall lands.
+      * ``bad_request`` — caller-side error (empty messages list,
+        no model resolvable from arg / env, HTTP 400 from upstream).
+      * ``model_not_found`` — HTTP 404 / "model not found" envelope.
+      * ``rate_limited`` — HTTP 429.
+      * ``api_error`` — generic upstream failure.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class OpenGatewayService(Service):
+    id = "clawmes.opengateway"
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._api_key: str | None = None
+        self._default_model: str | None = None
+
+    def start(self) -> None:
+        with self._lock:
+            self._api_key = os.environ.get("OPENGATEWAY_API_KEY") or None
+            self._default_model = os.environ.get("OPENGATEWAY_MODEL") or None
+        _log.info(
+            "opengateway service started (auth=%s, default_model=%s)",
+            "key" if self._api_key else "missing",
+            self._default_model or "<unset>",
+        )
+
+    def stop(self) -> None:
+        with self._lock:
+            self._api_key = None
+            self._default_model = None
+
+    def health(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "id": self.id,
+                "status": "configured" if self._api_key else "missing_key",
+                "default_model": self._default_model,
+            }
+
+    def chat_completion(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        timeout: float = 60.0,
+        **extra: Any,
+    ) -> dict[str, Any]:
+        """Send a non-streaming chat completion request.
+
+        ``messages`` is the standard OpenAI ``[{role, content}, ...]``
+        list. ``model`` overrides the env-configured default. ``extra``
+        is passed through to the upstream JSON body unchanged — useful
+        for ``top_p``, ``stop``, ``response_format``, etc.
+
+        Returns the parsed JSON response (the OpenAI chat completion
+        envelope: ``choices[*].message.content``, ``usage``, etc.).
+        Streaming is explicitly disabled — pass ``stream=True`` and we
+        raise ``bad_request``.
+        """
+        if not messages:
+            raise OpenGatewayError("bad_request", "messages list must be non-empty")
+        if extra.get("stream"):
+            raise OpenGatewayError(
+                "bad_request",
+                "streaming is not supported by this service; use Hermes' LLM client",
+            )
+
+        with self._lock:
+            api_key = self._api_key
+            default_model = self._default_model
+
+        if not api_key:
+            raise OpenGatewayError(
+                "no_credentials",
+                "OPENGATEWAY_API_KEY is not set; cannot send authenticated traffic",
+            )
+
+        resolved_model = model or default_model
+        if not resolved_model:
+            raise OpenGatewayError(
+                "bad_request",
+                "no model specified and OPENGATEWAY_MODEL env var is not set",
+            )
+
+        body: dict[str, Any] = {"model": resolved_model, "messages": messages}
+        if temperature is not None:
+            body["temperature"] = temperature
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+        body.update(extra)
+
+        return self._call("/chat/completions", body, api_key=api_key, timeout=timeout)
+
+    def _call(
+        self,
+        path: str,
+        body: dict[str, Any],
+        *,
+        api_key: str,
+        timeout: float,
+    ) -> dict[str, Any]:
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        url = _BASE_URL + path
+        try:
+            response = http_post(url, json=body, headers=headers, timeout=timeout)
+        except Exception as exc:  # noqa: BLE001 — classify below
+            msg = str(exc).lower()
+            if "429" in msg or "rate" in msg:
+                raise OpenGatewayError("rate_limited", str(exc)) from exc
+            if "404" in msg or "model" in msg and "not found" in msg:
+                raise OpenGatewayError("model_not_found", str(exc)) from exc
+            if "400" in msg:
+                raise OpenGatewayError("bad_request", str(exc)) from exc
+            raise OpenGatewayError("api_error", f"opengateway request failed: {exc}") from exc
+
+        if not isinstance(response, dict):
+            raise OpenGatewayError(
+                "api_error",
+                f"opengateway returned non-dict response: {type(response).__name__}",
+            )
+        # OpenAI-compatible error envelope: {"error": {"message", "type", "code"}}
+        if isinstance(response.get("error"), dict):
+            err = response["error"]
+            text = str(err.get("message") or "")
+            text_lower = text.lower()
+            err_type = str(err.get("type") or "").lower()
+            if "rate" in text_lower or err_type == "rate_limit_error":
+                code = "rate_limited"
+            elif "model" in text_lower and "not found" in text_lower:
+                code = "model_not_found"
+            elif err_type == "invalid_request_error":
+                code = "bad_request"
+            else:
+                code = "api_error"
+            raise OpenGatewayError(code, f"opengateway error: {text}")
+        return response
+
+
+_instance: OpenGatewayService | None = None
+
+
+def get_opengateway_service() -> OpenGatewayService:
+    global _instance
+    if _instance is None:
+        _instance = OpenGatewayService()
+    return _instance

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -90,3 +90,11 @@ requires_env:
     description: Basescan API key (block_explorer tool)
     url: https://basescan.org/myapikey
     secret: true
+  - name: OPENGATEWAY_API_KEY
+    description: gitlawb OpenGateway API key for the OpenAI-compatible LLM gateway (ogw_live_…)
+    url: https://gitlawb.com/opengateway
+    secret: true
+  - name: OPENGATEWAY_MODEL
+    description: Default model id sent to OpenGateway when callers do not pass model= (optional)
+    url: https://gitlawb.com/opengateway
+    secret: false

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -91,7 +91,7 @@ requires_env:
     url: https://basescan.org/myapikey
     secret: true
   - name: OPENGATEWAY_API_KEY
-    description: gitlawb OpenGateway API key for the OpenAI-compatible LLM gateway (ogw_live_…)
+    description: gitlawb OpenGateway API key (ogw_live_…); recommended but currently optional during the partnership window
     url: https://gitlawb.com/opengateway
     secret: true
   - name: OPENGATEWAY_MODEL

--- a/tests/services/test_opengateway.py
+++ b/tests/services/test_opengateway.py
@@ -1,0 +1,360 @@
+"""Tests for clawmes.services.opengateway."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.services import opengateway as ogw_module
+from clawmes.services.opengateway import (
+    OpenGatewayError,
+    OpenGatewayService,
+    get_opengateway_service,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.setattr(ogw_module, "_instance", None)
+    monkeypatch.delenv("OPENGATEWAY_API_KEY", raising=False)
+    monkeypatch.delenv("OPENGATEWAY_MODEL", raising=False)
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    class FakeHttp:
+        def __init__(self):
+            self.calls: list[dict] = []
+            self.responses: list = []
+
+        def __call__(self, url, *, json=None, headers=None, timeout=30.0, **kw):
+            self.calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+            if not self.responses:
+                raise AssertionError("no fake response queued")
+            response = self.responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+    fake = FakeHttp()
+    monkeypatch.setattr(ogw_module, "http_post", fake)
+    return fake
+
+
+@pytest.fixture
+def svc(monkeypatch):
+    monkeypatch.setenv("OPENGATEWAY_API_KEY", "ogw_live_test_key")
+    monkeypatch.setenv("OPENGATEWAY_MODEL", "mimo-v2.5-pro")
+    s = OpenGatewayService()
+    s.start()
+    return s
+
+
+class TestStartStop:
+    def test_start_no_key_or_model(self):
+        s = OpenGatewayService()
+        s.start()
+        assert s._api_key is None
+        assert s._default_model is None
+
+    def test_start_with_key(self, monkeypatch):
+        monkeypatch.setenv("OPENGATEWAY_API_KEY", "ogw_live_abc")
+        s = OpenGatewayService()
+        s.start()
+        assert s._api_key == "ogw_live_abc"
+
+    def test_start_with_model(self, monkeypatch):
+        monkeypatch.setenv("OPENGATEWAY_MODEL", "mimo-v2.5-pro")
+        s = OpenGatewayService()
+        s.start()
+        assert s._default_model == "mimo-v2.5-pro"
+
+    def test_start_empty_string_normalized_to_none(self, monkeypatch):
+        # Empty-string env vars are treated as unset — covers the `or None`
+        # fallback in start(). bash users hit this when they `export FOO=`.
+        monkeypatch.setenv("OPENGATEWAY_API_KEY", "")
+        monkeypatch.setenv("OPENGATEWAY_MODEL", "")
+        s = OpenGatewayService()
+        s.start()
+        assert s._api_key is None
+        assert s._default_model is None
+
+    def test_stop_clears_state(self, svc):
+        svc.stop()
+        assert svc._api_key is None
+        assert svc._default_model is None
+
+
+class TestHealth:
+    def test_configured(self, svc):
+        h = svc.health()
+        assert h["id"] == "clawmes.opengateway"
+        assert h["status"] == "configured"
+        assert h["default_model"] == "mimo-v2.5-pro"
+
+    def test_missing_key(self):
+        s = OpenGatewayService()
+        s.start()
+        h = s.health()
+        assert h["status"] == "missing_key"
+        assert h["default_model"] is None
+
+
+class TestChatCompletionGuards:
+    def test_empty_messages(self, svc):
+        with pytest.raises(OpenGatewayError) as exc_info:
+            svc.chat_completion([])
+        assert exc_info.value.code == "bad_request"
+        assert "non-empty" in exc_info.value.message
+
+    def test_streaming_rejected(self, svc):
+        with pytest.raises(OpenGatewayError) as exc_info:
+            svc.chat_completion(
+                [{"role": "user", "content": "hi"}],
+                stream=True,
+            )
+        assert exc_info.value.code == "bad_request"
+        assert "streaming" in exc_info.value.message
+
+    def test_no_api_key(self, monkeypatch):
+        monkeypatch.setenv("OPENGATEWAY_MODEL", "mimo-v2.5-pro")
+        s = OpenGatewayService()
+        s.start()
+        with pytest.raises(OpenGatewayError) as exc_info:
+            s.chat_completion([{"role": "user", "content": "hi"}])
+        assert exc_info.value.code == "no_credentials"
+
+    def test_no_model_anywhere(self, monkeypatch):
+        monkeypatch.setenv("OPENGATEWAY_API_KEY", "ogw_live_abc")
+        s = OpenGatewayService()
+        s.start()
+        with pytest.raises(OpenGatewayError) as exc_info:
+            s.chat_completion([{"role": "user", "content": "hi"}])
+        assert exc_info.value.code == "bad_request"
+        assert "model" in exc_info.value.message
+
+
+class TestChatCompletionRequest:
+    def _ok_response(self):
+        return {
+            "id": "chatcmpl-abc",
+            "object": "chat.completion",
+            "model": "mimo-v2.5-pro",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "hello"}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+        }
+
+    def test_basic_call_uses_env_default_model(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        result = svc.chat_completion([{"role": "user", "content": "hi"}])
+        assert result["choices"][0]["message"]["content"] == "hello"
+        sent = fake_http.calls[0]["json"]
+        assert sent["model"] == "mimo-v2.5-pro"
+        assert sent["messages"] == [{"role": "user", "content": "hi"}]
+
+    def test_model_arg_overrides_default(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion(
+            [{"role": "user", "content": "hi"}],
+            model="some-other-model",
+        )
+        assert fake_http.calls[0]["json"]["model"] == "some-other-model"
+
+    def test_model_arg_only_no_default(self, monkeypatch, fake_http):
+        monkeypatch.setenv("OPENGATEWAY_API_KEY", "ogw_live_abc")
+        s = OpenGatewayService()
+        s.start()
+        fake_http.responses.append(self._ok_response())
+        s.chat_completion(
+            [{"role": "user", "content": "hi"}],
+            model="explicit-model",
+        )
+        assert fake_http.calls[0]["json"]["model"] == "explicit-model"
+
+    def test_temperature_passed(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion(
+            [{"role": "user", "content": "hi"}],
+            temperature=0.2,
+        )
+        assert fake_http.calls[0]["json"]["temperature"] == 0.2
+
+    def test_temperature_omitted_when_none(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion([{"role": "user", "content": "hi"}])
+        assert "temperature" not in fake_http.calls[0]["json"]
+
+    def test_max_tokens_passed(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion(
+            [{"role": "user", "content": "hi"}],
+            max_tokens=128,
+        )
+        assert fake_http.calls[0]["json"]["max_tokens"] == 128
+
+    def test_max_tokens_omitted_when_none(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion([{"role": "user", "content": "hi"}])
+        assert "max_tokens" not in fake_http.calls[0]["json"]
+
+    def test_extra_kwargs_passed_through(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion(
+            [{"role": "user", "content": "hi"}],
+            top_p=0.9,
+            stop=["\n\n"],
+            response_format={"type": "json_object"},
+        )
+        sent = fake_http.calls[0]["json"]
+        assert sent["top_p"] == 0.9
+        assert sent["stop"] == ["\n\n"]
+        assert sent["response_format"] == {"type": "json_object"}
+
+    def test_bearer_auth_header(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion([{"role": "user", "content": "hi"}])
+        headers = fake_http.calls[0]["headers"]
+        assert headers["Authorization"] == "Bearer ogw_live_test_key"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_request_url(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion([{"role": "user", "content": "hi"}])
+        assert fake_http.calls[0]["url"] == ("https://opengateway.gitlawb.com/v1/chat/completions")
+
+    def test_custom_timeout(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion(
+            [{"role": "user", "content": "hi"}],
+            timeout=5.0,
+        )
+        assert fake_http.calls[0]["timeout"] == 5.0
+
+    def test_default_timeout(self, svc, fake_http):
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion([{"role": "user", "content": "hi"}])
+        assert fake_http.calls[0]["timeout"] == 60.0
+
+
+class TestChatCompletionErrorClassification:
+    def _call(self, svc):
+        return svc.chat_completion([{"role": "user", "content": "hi"}])
+
+    def test_rate_limit_via_429(self, svc, fake_http):
+        fake_http.responses.append(RuntimeError("HTTP 429 Too Many Requests"))
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "rate_limited"
+
+    def test_rate_limit_via_keyword(self, svc, fake_http):
+        fake_http.responses.append(RuntimeError("upstream rate exceeded"))
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "rate_limited"
+
+    def test_model_not_found_via_404(self, svc, fake_http):
+        fake_http.responses.append(RuntimeError("HTTP 404 Not Found"))
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "model_not_found"
+
+    def test_model_not_found_via_keyword(self, svc, fake_http):
+        fake_http.responses.append(RuntimeError("the model 'xyz' was not found"))
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "model_not_found"
+
+    def test_bad_request_via_400(self, svc, fake_http):
+        fake_http.responses.append(RuntimeError("HTTP 400 Bad Request: bad params"))
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "bad_request"
+
+    def test_generic_failure(self, svc, fake_http):
+        fake_http.responses.append(RuntimeError("connection reset"))
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "api_error"
+
+    def test_non_dict_response(self, svc, fake_http):
+        fake_http.responses.append("not a dict")
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "api_error"
+
+    def test_error_envelope_rate_via_type(self, svc, fake_http):
+        fake_http.responses.append(
+            {
+                "error": {
+                    "message": "you have hit the limit",
+                    "type": "rate_limit_error",
+                }
+            }
+        )
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "rate_limited"
+
+    def test_error_envelope_rate_via_message(self, svc, fake_http):
+        fake_http.responses.append({"error": {"message": "rate limit hit", "type": "server_error"}})
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "rate_limited"
+
+    def test_error_envelope_model_not_found(self, svc, fake_http):
+        fake_http.responses.append(
+            {
+                "error": {
+                    "message": "The model 'gpt-7' was not found",
+                    "type": "invalid_request_error",
+                }
+            }
+        )
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        # The "model … not found" keyword check takes precedence over the
+        # invalid_request_error type check; both are valid classifications
+        # but the more specific one wins.
+        assert exc_info.value.code == "model_not_found"
+
+    def test_error_envelope_invalid_request(self, svc, fake_http):
+        fake_http.responses.append(
+            {
+                "error": {
+                    "message": "invalid temperature value",
+                    "type": "invalid_request_error",
+                }
+            }
+        )
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "bad_request"
+
+    def test_error_envelope_generic(self, svc, fake_http):
+        fake_http.responses.append(
+            {"error": {"message": "internal mishap", "type": "server_error"}}
+        )
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "api_error"
+
+    def test_error_envelope_missing_fields(self, svc, fake_http):
+        # error dict with no message / no type should still raise api_error,
+        # not crash.
+        fake_http.responses.append({"error": {}})
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "api_error"
+
+    def test_non_dict_error_field_ignored(self, svc, fake_http):
+        # If `error` is a string (some upstreams return this), the
+        # isinstance check fails and we return the response as-is.
+        fake_http.responses.append({"error": "not a dict", "choices": [{"x": 1}]})
+        result = self._call(svc)
+        assert result["choices"] == [{"x": 1}]
+
+
+class TestSingleton:
+    def test_returns_same_instance(self):
+        a = get_opengateway_service()
+        b = get_opengateway_service()
+        assert a is b

--- a/tests/services/test_opengateway.py
+++ b/tests/services/test_opengateway.py
@@ -85,18 +85,68 @@ class TestStartStop:
 
 
 class TestHealth:
-    def test_configured(self, svc):
+    def test_authenticated(self, svc):
         h = svc.health()
         assert h["id"] == "clawmes.opengateway"
-        assert h["status"] == "configured"
+        assert h["status"] == "authenticated"
         assert h["default_model"] == "mimo-v2.5-pro"
 
-    def test_missing_key(self):
+    def test_unauthenticated(self):
         s = OpenGatewayService()
         s.start()
         h = s.health()
-        assert h["status"] == "missing_key"
+        assert h["status"] == "unauthenticated"
         assert h["default_model"] is None
+
+
+class TestStartLogging:
+    """Service must clearly signal whether it's running authenticated.
+
+    The "partnership window allows unauth" policy means missing-key is a
+    valid state — but it must be loud enough that users notice before
+    gitlawb flips the auth wall on.
+
+    The clawmes root logger has ``propagate=False`` so pytest's stock
+    ``caplog`` doesn't see its records (see ``tests/services/test_rpc.py``
+    for prior art). We attach a recorder handler directly.
+    """
+
+    @staticmethod
+    def _capture_logs(monkeypatch):
+        import logging
+
+        records: list[logging.LogRecord] = []
+        handler = logging.Handler()
+        handler.emit = records.append  # type: ignore[assignment]
+        clawmes_root = logging.getLogger("clawmes")
+        clawmes_root.addHandler(handler)
+        monkeypatch.setattr(
+            handler,
+            "_cleanup",
+            lambda: clawmes_root.removeHandler(handler),
+            raising=False,
+        )
+        return records
+
+    def test_start_with_key_logs_info_not_warning(self, monkeypatch):
+        import logging
+
+        monkeypatch.setenv("OPENGATEWAY_API_KEY", "ogw_live_abc")
+        records = self._capture_logs(monkeypatch)
+        OpenGatewayService().start()
+        msgs = [(r.levelno, r.getMessage()) for r in records]
+        assert any(
+            lvl == logging.INFO and "opengateway service started (auth=key" in m for lvl, m in msgs
+        )
+        assert not any(lvl >= logging.WARNING for lvl, _ in msgs)
+
+    def test_start_without_key_logs_warning(self, monkeypatch):
+        import logging
+
+        records = self._capture_logs(monkeypatch)
+        OpenGatewayService().start()
+        msgs = [(r.levelno, r.getMessage()) for r in records]
+        assert any(lvl == logging.WARNING and "UNAUTHENTICATED" in m for lvl, m in msgs)
 
 
 class TestChatCompletionGuards:
@@ -115,13 +165,26 @@ class TestChatCompletionGuards:
         assert exc_info.value.code == "bad_request"
         assert "streaming" in exc_info.value.message
 
-    def test_no_api_key(self, monkeypatch):
+    def test_unauth_call_sends_without_auth_header(self, monkeypatch, fake_http):
+        """No API key means no Authorization header — but the call still goes out.
+
+        Matches gitlawb's partnership-window behavior: anon traffic is
+        accepted by the server today, will be 401'd after the auth flip.
+        """
         monkeypatch.setenv("OPENGATEWAY_MODEL", "mimo-v2.5-pro")
         s = OpenGatewayService()
         s.start()
-        with pytest.raises(OpenGatewayError) as exc_info:
-            s.chat_completion([{"role": "user", "content": "hi"}])
-        assert exc_info.value.code == "no_credentials"
+        fake_http.responses.append(
+            {
+                "id": "anon-call",
+                "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+            }
+        )
+        result = s.chat_completion([{"role": "user", "content": "hi"}])
+        assert result["id"] == "anon-call"
+        headers = fake_http.calls[0]["headers"]
+        assert "Authorization" not in headers
+        assert headers["Content-Type"] == "application/json"
 
     def test_no_model_anywhere(self, monkeypatch):
         monkeypatch.setenv("OPENGATEWAY_API_KEY", "ogw_live_abc")
@@ -216,6 +279,14 @@ class TestChatCompletionRequest:
         assert headers["Authorization"] == "Bearer ogw_live_test_key"
         assert headers["Content-Type"] == "application/json"
 
+    def test_identity_encoding_header(self, svc, fake_http):
+        """The Accept-Encoding: identity workaround for OpenGateway's
+        broken gzip stream must be present on every request."""
+        fake_http.responses.append(self._ok_response())
+        svc.chat_completion([{"role": "user", "content": "hi"}])
+        headers = fake_http.calls[0]["headers"]
+        assert headers["Accept-Encoding"] == "identity"
+
     def test_request_url(self, svc, fake_http):
         fake_http.responses.append(self._ok_response())
         svc.chat_completion([{"role": "user", "content": "hi"}])
@@ -246,10 +317,25 @@ class TestChatCompletionErrorClassification:
         assert exc_info.value.code == "rate_limited"
 
     def test_rate_limit_via_keyword(self, svc, fake_http):
-        fake_http.responses.append(RuntimeError("upstream rate exceeded"))
+        # "rate limit" substring, not just "rate" — the previous matcher
+        # was too loose (any "rate" word would trigger).
+        fake_http.responses.append(RuntimeError("upstream rate limit hit"))
         with pytest.raises(OpenGatewayError) as exc_info:
             self._call(svc)
         assert exc_info.value.code == "rate_limited"
+
+    def test_unauthorized_via_401(self, svc, fake_http):
+        # Once gitlawb flips the auth wall on, unauth callers see 401.
+        fake_http.responses.append(RuntimeError("HTTP 401 Unauthorized"))
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "no_credentials"
+
+    def test_forbidden_via_403(self, svc, fake_http):
+        fake_http.responses.append(RuntimeError("HTTP 403 Forbidden"))
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "no_credentials"
 
     def test_model_not_found_via_404(self, svc, fake_http):
         fake_http.responses.append(RuntimeError("HTTP 404 Not Found"))
@@ -294,13 +380,74 @@ class TestChatCompletionErrorClassification:
             self._call(svc)
         assert exc_info.value.code == "rate_limited"
 
-    def test_error_envelope_rate_via_message(self, svc, fake_http):
-        fake_http.responses.append({"error": {"message": "rate limit hit", "type": "server_error"}})
+    def test_error_envelope_rate_via_code(self, svc, fake_http):
+        # OpenAI's canonical rate-limit code.
+        fake_http.responses.append(
+            {"error": {"message": "you have hit the limit", "code": "rate_limit_exceeded"}}
+        )
         with pytest.raises(OpenGatewayError) as exc_info:
             self._call(svc)
         assert exc_info.value.code == "rate_limited"
 
-    def test_error_envelope_model_not_found(self, svc, fake_http):
+    def test_error_envelope_unsupported_model(self, svc, fake_http):
+        """Matches the real OpenGateway error captured from prod probe:
+        ``{"error":{"message":"Unsupported model for unified routing: …",
+        "type":"invalid_request_error","code":"unsupported_model"}}``."""
+        fake_http.responses.append(
+            {
+                "error": {
+                    "message": "Unsupported model for unified routing: foo",
+                    "type": "invalid_request_error",
+                    "code": "unsupported_model",
+                }
+            }
+        )
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "model_not_found"
+        # The structured display string should include the code + message
+        # so callers can actually tell what went wrong.
+        assert "unsupported_model" in exc_info.value.message
+        assert "Unsupported model" in exc_info.value.message
+
+    def test_error_envelope_model_not_found_code(self, svc, fake_http):
+        fake_http.responses.append(
+            {"error": {"message": "no such model", "code": "model_not_found"}}
+        )
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "model_not_found"
+
+    def test_error_envelope_auth_via_type(self, svc, fake_http):
+        fake_http.responses.append(
+            {
+                "error": {
+                    "message": "invalid bearer token",
+                    "type": "authentication_error",
+                }
+            }
+        )
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "no_credentials"
+
+    def test_error_envelope_permission_denied(self, svc, fake_http):
+        fake_http.responses.append(
+            {
+                "error": {
+                    "message": "you do not have access to this model",
+                    "type": "permission_denied",
+                }
+            }
+        )
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "no_credentials"
+
+    def test_error_envelope_invalid_request_model_via_message(self, svc, fake_http):
+        """invalid_request_error with 'model … not found' phrasing but no
+        ``code`` field — message inspection inside the invalid_request
+        branch should still classify as model_not_found."""
         fake_http.responses.append(
             {
                 "error": {
@@ -311,12 +458,9 @@ class TestChatCompletionErrorClassification:
         )
         with pytest.raises(OpenGatewayError) as exc_info:
             self._call(svc)
-        # The "model … not found" keyword check takes precedence over the
-        # invalid_request_error type check; both are valid classifications
-        # but the more specific one wins.
         assert exc_info.value.code == "model_not_found"
 
-    def test_error_envelope_invalid_request(self, svc, fake_http):
+    def test_error_envelope_invalid_request_plain(self, svc, fake_http):
         fake_http.responses.append(
             {
                 "error": {
@@ -338,8 +482,8 @@ class TestChatCompletionErrorClassification:
         assert exc_info.value.code == "api_error"
 
     def test_error_envelope_missing_fields(self, svc, fake_http):
-        # error dict with no message / no type should still raise api_error,
-        # not crash.
+        # error dict with no message / no type / no code should still
+        # raise api_error, not crash.
         fake_http.responses.append({"error": {}})
         with pytest.raises(OpenGatewayError) as exc_info:
             self._call(svc)
@@ -351,6 +495,94 @@ class TestChatCompletionErrorClassification:
         fake_http.responses.append({"error": "not a dict", "choices": [{"x": 1}]})
         result = self._call(svc)
         assert result["choices"] == [{"x": 1}]
+
+
+class TestStructuredErrorBodyExtraction:
+    """The real failure path: lib/http.http_post calls raise_for_status,
+    which throws away the response body. The structured error envelope
+    lives on the raised exception's ``.response`` attribute. The service
+    duck-types past lib/http to recover it.
+    """
+
+    def _call(self, svc):
+        return svc.chat_completion([{"role": "user", "content": "hi"}])
+
+    def _raise_with_body(self, body):
+        """Helper: build an exception with a ``.response`` that yields ``body`` from .json()."""
+
+        class _FakeResponse:
+            def __init__(self, body):
+                self._body = body
+
+            def json(self):
+                if isinstance(self._body, Exception):
+                    raise self._body
+                return self._body
+
+        class _FakeHTTPError(RuntimeError):
+            def __init__(self, msg, body):
+                super().__init__(msg)
+                self.response = _FakeResponse(body)
+
+        return _FakeHTTPError("Client error '400 Bad Request' for url '...'", body)
+
+    def test_pulls_structured_body_and_classifies(self, svc, fake_http):
+        """An httpx.HTTPStatusError-shaped exception has the body on
+        ``.response.json()``. The service should extract it and classify
+        from ``error.code`` rather than falling back to substring."""
+        exc = self._raise_with_body(
+            {
+                "error": {
+                    "message": "Unsupported model for unified routing: foo",
+                    "type": "invalid_request_error",
+                    "code": "unsupported_model",
+                }
+            }
+        )
+        fake_http.responses.append(exc)
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        # If substring matching were used, the exception text contains
+        # "400 Bad Request" which would classify as bad_request. The
+        # structured body wins → model_not_found.
+        assert exc_info.value.code == "model_not_found"
+        assert "Unsupported model" in exc_info.value.message
+
+    def test_response_json_raises_falls_through_to_substring(self, svc, fake_http):
+        # Body extraction failure (e.g. response was HTML, not JSON)
+        # must fall through to the substring fallback, not crash.
+        exc = self._raise_with_body(ValueError("not json"))
+        # The exception message has "400" — substring fallback should
+        # classify as bad_request.
+        fake_http.responses.append(exc)
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "bad_request"
+
+    def test_response_json_returns_non_dict(self, svc, fake_http):
+        # If .json() returns a list/string/None, we should fall through
+        # to substring matching, not crash.
+        exc = self._raise_with_body(["not", "a", "dict"])
+        fake_http.responses.append(exc)
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "bad_request"  # via "400" substring
+
+    def test_response_json_dict_without_error_field(self, svc, fake_http):
+        # JSON body but no "error" field — fall through.
+        exc = self._raise_with_body({"detail": "something else"})
+        fake_http.responses.append(exc)
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "bad_request"  # via "400" substring
+
+    def test_response_json_error_field_not_dict(self, svc, fake_http):
+        # error field is a string — fall through.
+        exc = self._raise_with_body({"error": "just a string"})
+        fake_http.responses.append(exc)
+        with pytest.raises(OpenGatewayError) as exc_info:
+            self._call(svc)
+        assert exc_info.value.code == "bad_request"  # via "400" substring
 
 
 class TestSingleton:


### PR DESCRIPTION
## Summary

Adds `OpenGatewayService` — an OpenAI-compatible HTTP client for gitlawb's OpenGateway endpoint (`https://opengateway.gitlawb.com/v1`), shipped under the gitlawb partnership. Service registers as 6d in `services.start_all`, between LiFi and the background daemons.

## What this adds

- `clawmes/services/opengateway.py` — `OpenGatewayService` + `OpenGatewayError` + `get_opengateway_service` singleton accessor. Mirrors the `ZeroxService` / `CoinGeckoService` shape: lock-guarded api-key cache, env-var read in `start()`, hardcoded base URL, structured error taxonomy.
- `tests/services/test_opengateway.py` — 38 tests, 100% line coverage on the new module.
- `clawmes/lib/http.py` — adds `opengateway.gitlawb.com` to `_DEFAULT_ALLOWLIST`.
- `clawmes/services/__init__.py` — registers `get_opengateway_service` in `start_all` factories list.
- `plugin.yaml` + `clawmes/plugin.yaml` — declares two new `requires_env` entries (both copies remain byte-identical; `test_plugin_yaml_copies_match` still passes).
- `README.md` — documents the new env vars; bumps service count `14 → 15`.
- `CHANGELOG.md` — `## Unreleased` section.

## New env vars

| Env var | Required? | Purpose |
|---|---|---|
| `OPENGATEWAY_API_KEY` | required for `chat_completion` calls | gitlawb OpenGateway API key (\`ogw_live_…\` format). The service starts without it but raises `OpenGatewayError(\"no_credentials\")` when callers try to use it. |
| `OPENGATEWAY_MODEL` | optional | Default model id sent when callers don't pass `model=`. If neither is set, `chat_completion` raises `OpenGatewayError(\"bad_request\")`. |

## Scope decisions (worth a review pass)

1. **Non-streaming only.** Streaming SSE adds significant complexity and is already handled correctly by Hermes' own LLM client. Out of scope here.
2. **OpenGateway-only base URL, hardcoded.** Matches the 0x / CoinGecko / LiFi convention. Making it a generic OpenAI-compatible client (env-overridable base URL) is a different abstraction and would defeat the purpose of a branded partnership integration. Easy to lift later if we want a generic LLM-client base class.
3. **Service, not a tool.** No `@write_tool` surface in this PR — the LLM gateway is infrastructure, not something the agent should call directly. Consumers will be specific clawmes tools that opt in via `get_opengateway_service().chat_completion(...)`.
4. **No internal consumer wired in this change.** This PR lands the building block only. Follow-up PRs will wire specific call sites (candidates: a triage classifier for swap intent, a token-symbol disambiguator, a structured-extraction helper for governance proposals). I'd rather land the client first with full test coverage than entangle it with the first consumer's review.

## Architectural caveat

clawmes is a Hermes Agent plugin and Hermes itself owns the agent's main conversational inference (via `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `NOUS_PORTAL_API_KEY` per the README config section). This service does **not** reroute Hermes's main inference — pointing Hermes at OpenGateway is a separate, Hermes-level configuration concern. What this PR adds is a way for clawmes tools to make their own targeted LLM calls outside the agent loop (classifiers, summarizers, structured-extraction helpers) without each tool wiring its own `httpx` client.

`CONTRIBUTING.md` rule #6 (\"no new gateway adapters from a plugin\") refers to messaging gateways (Telegram/Discord/Slack), not LLM gateways — confirmed by the surrounding context (\"clawmes works on whatever channels Hermes ships\" in `HERMES_PARITY.md:79`). This integration is an HTTP API service, on par with the existing 0x / CoinGecko / LiFi services.

## Verification

- `pytest --cov=clawmes` — **2049 passed, 8 skipped, 100% coverage** (no new skips; coverage threshold of 100% still satisfied).
- `pytest tests/services/test_opengateway.py --cov=clawmes.services.opengateway` — **38/38 pass, 100% line coverage** on the new module.
- `ruff check clawmes tests` — clean.
- `ruff format --check clawmes tests` — clean (240 files already formatted).
- `tests/test_plugin_manifest.py` — passes: both `plugin.yaml` copies are byte-identical and the manifest's `provides_tools` / `provides_hooks` lists remain in sync with code (this PR adds no tools or hooks).

## Test plan

- [x] Service starts with key + default model env set
- [x] Service starts with neither set
- [x] Empty-string env vars normalize to `None`
- [x] `chat_completion` raises `no_credentials` without API key
- [x] `chat_completion` raises `bad_request` for empty messages, `stream=True`, no model resolvable
- [x] Default model from env is used when caller omits `model=`
- [x] Explicit `model=` overrides env default
- [x] `temperature` / `max_tokens` / extra kwargs flow through to the JSON body
- [x] `Authorization: Bearer …` header set correctly
- [x] Error classification (`rate_limited`, `model_not_found`, `bad_request`, `api_error`) for both raw exceptions and OpenAI-style error envelopes
- [x] Non-dict response classified as `api_error`
- [x] Singleton accessor returns the same instance

## Notes for reviewers

- The error-classification heuristic in `_call` matches keywords on the lowercased exception string (\`429\`, \`rate\`, \`404\`, \`model … not found\`, \`400\`). This is approximate — happy to swap for status-code-aware classification if `clawmes.lib.http` ever surfaces structured errors, but the current `http_post` swallows status codes into raised exception strings, so we'd need an upstream change first.
- `OPENGATEWAY_MODEL` is intentionally **not** required at service start — clawmes config flows let users skip it and pass `model=` explicitly. Default-only callers get a `bad_request` at call time, which is the same posture `ZeroxService` takes for `ZEROX_API_KEY`.
- I left the model docs (`mimo-v2.5-pro` from the gitlawb landing page) out of code comments aside from the test fixtures — gitlawb's available model list will drift, and clawmes shouldn't be a source of truth for it.