### PR TITLE
feat(safety+commands): evolution-mode gate + balance/portfolio wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the default + per-call `extra_hosts` checks, and records blocks for
   audit. Defensive import — if the services subsystem hasn't started
   yet, the existing default-allowlist behavior continues to work.
+- **Evolution-mode gate** for self-modifying tools
+  (`clawmes/services/evolution_mode.py`). Default OFF. When OFF,
+  the write actions of `agent_memory` (`add` / `replace` / `remove`)
+  and `skill_evolve` (`propose` / `update` / `revert`) return
+  `evolution_gate` errors. Read actions (`query`, `list`) are always
+  allowed. Closes a safety hole: previously the agent could rewrite
+  its own memory and skills with no gate, which made
+  prompt-injection drift much easier. Equivalent to OpenClawnch's
+  `wrapWithEvoGate` (`extensions/crypto/index.ts:402-419`).
+- 3 commands wrapping the new service: `/evolve` (enable),
+  `/stable` (disable, the safe default), `/evolution` (status).
+- 2 wrapper commands over `defi_balance`: `/balance [chain]` (native
+  balance) and `/portfolio [chain]` (native + curated common-token
+  list). Both pick up the wallet address + chain from
+  `wallet_service`; both are pure surface deltas over an existing
+  read-only tool.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Clawmes is a [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin. Wallets, DEX trading, lending and staking, governance, on-chain automation. Python rewrite of [`@clawnch/openclaw-crypto`](https://github.com/clawnchdev/openclawnch) targeting Hermes.
 
-46 tools. 60 commands. 17 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
+46 tools. 65 commands. 18 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
 
 ## Quick start
 
@@ -137,11 +137,11 @@ hermes (the upstream CLI, hermes-agent ≥ 2026.4.x)
   └── PluginManager.discover_and_load()
         └── clawmes.register(ctx)
               ├── 46 tools     (registered via ctx.register_tool, write-gated)
-              ├── 60 commands  (registered via ctx.register_command)
+              ├── 65 commands  (registered via ctx.register_command)
               ├── 11 hooks     (pre_tool_call, post_tool_call, pre_llm_call, ...)
               ├── 27 skills    (registered via ctx.register_skill, namespaced clawmes:*)
               ├── CLI subcmds  (registered via ctx.register_cli_command)
-              └── 17 services  (start_all() starts background lifecycle)
+              └── 18 services  (start_all() starts background lifecycle)
                     │
                     ├── subprocess: clawmes-wc-bridge   (Node — WalletConnect v2)
                     └── subprocess: clawmes-sa-bridge   (Node — MetaMask Smart Accounts; planned)

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 
 from clawmes.commands import (
     allowlist,
+    balance,
     discovery,
     doctor,
+    evolve,
     onboarding,
     plans,
     policy,
@@ -43,6 +45,8 @@ def register_all(ctx) -> None:
     discovery.register(ctx)
     onboarding.register(ctx)
     allowlist.register(ctx)
+    balance.register(ctx)
+    evolve.register(ctx)
     # TODO(v0.1.0+): model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
     # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/balance.py
+++ b/clawmes/commands/balance.py
@@ -1,0 +1,118 @@
+"""Balance / portfolio slash commands.
+
+Two thin wrappers over the ``defi_balance`` tool's existing actions:
+
+  * ``/balance [chain]`` — native-token balance on the current (or
+    specified) chain. Wraps ``defi_balance.native``.
+  * ``/portfolio [chain]`` — native + curated common-token list
+    (USDC, WETH, USDT, DAI) on the chain. Wraps
+    ``defi_balance.summary``.
+
+Both grab the active wallet address from :mod:`clawmes.services.wallet`
+so the user doesn't have to retype it. If no wallet is connected,
+both return an actionable error pointing at ``/connect``.
+
+These are pure surface deltas — every byte of behavior already exists
+in the ``defi_balance`` tool. The slash commands exist so users don't
+have to ask the LLM to run an explicit tool call for a read this
+routine.
+"""
+
+from __future__ import annotations
+
+import json
+
+from clawmes.lib.addr import short
+from clawmes.services.wallet import get_wallet_state
+
+
+def _resolve_chain(raw_args: str, current_chain_id: int | None) -> str | None:
+    """Resolve the chain argument for either command.
+
+    Returns the string clawmes' chain helper accepts (an int-as-str or
+    a name like ``ethereum``). Falls back to the wallet's current chain
+    id when no arg is given. Returns ``None`` if neither is available —
+    caller must surface an error.
+    """
+    arg = raw_args.strip()
+    if arg:
+        return arg
+    if current_chain_id is not None:
+        return str(current_chain_id)
+    return None
+
+
+async def handle_balance(raw_args: str) -> str:
+    state = get_wallet_state()
+    if not state.connected or not state.address:
+        return "No wallet connected. Run /connect or /connect_local first."
+
+    chain = _resolve_chain(raw_args, state.chain_id)
+    if chain is None:
+        return "No chain specified and no active chain set. Pass a chain id."
+
+    from clawmes.tools.defi_balance import defi_balance
+
+    raw = defi_balance(
+        {
+            "action": "native",
+            "address": state.address,
+            "chain": chain,
+        }
+    )
+    payload = json.loads(raw)
+    if payload.get("isError"):
+        return payload.get("content", [{}])[0].get("text", "balance query failed")
+
+    details = payload.get("details") or {}
+    chain_label = details.get("chain") or chain
+    pretty = details.get("native_balance") or details.get("native_balance_wei", "?")
+    return f"Native balance for {short(state.address)} on {chain_label}: {pretty}"
+
+
+async def handle_portfolio(raw_args: str) -> str:
+    state = get_wallet_state()
+    if not state.connected or not state.address:
+        return "No wallet connected. Run /connect or /connect_local first."
+
+    chain = _resolve_chain(raw_args, state.chain_id)
+    if chain is None:
+        return "No chain specified and no active chain set. Pass a chain id."
+
+    from clawmes.tools.defi_balance import defi_balance
+
+    raw = defi_balance(
+        {
+            "action": "summary",
+            "address": state.address,
+            "chain": chain,
+        }
+    )
+    payload = json.loads(raw)
+    if payload.get("isError"):
+        return payload.get("content", [{}])[0].get("text", "portfolio query failed")
+
+    # The defi_balance summary already produces a chat-friendly multi-line
+    # rendering in payload["content"][0]["text"]. Use it directly.
+    content = payload.get("content") or []
+    if content and content[0].get("text"):
+        return content[0]["text"]
+    # Defensive fallback if the tool ever changes its envelope.
+    details = payload.get("details") or {}
+    return f"Portfolio for {short(state.address)} on {chain}: {details!r}"
+
+
+def register(ctx) -> None:
+    """Wire balance and portfolio commands into Hermes."""
+    ctx.register_command(
+        name="balance",
+        handler=handle_balance,
+        description="Show native-token balance for the connected wallet",
+        args_hint="[chain]",
+    )
+    ctx.register_command(
+        name="portfolio",
+        handler=handle_portfolio,
+        description="Show native + common ERC-20 balances on the active chain",
+        args_hint="[chain]",
+    )

--- a/clawmes/commands/evolve.py
+++ b/clawmes/commands/evolve.py
@@ -1,0 +1,82 @@
+"""Evolution-mode slash commands.
+
+Three commands wrapping :class:`clawmes.services.evolution_mode.EvolutionModeService`:
+
+  * ``/evolve``    — enable self-modification (memory + skill writes)
+  * ``/stable``    — disable self-modification (default)
+  * ``/evolution`` — show current state
+
+When disabled (the default), write actions on ``agent_memory`` and
+``skill_evolve`` are gated with an ``evolution_gate`` error. Read
+actions (``query``, ``list``) are always allowed.
+
+The toggle is global / in-memory and resets to ``stable`` on
+restart. This is intentional: an attacker who gets the agent to
+flip the bit can't keep it set across sessions.
+"""
+
+from __future__ import annotations
+
+
+async def handle_evolve(raw_args: str) -> str:
+    from clawmes.services.evolution_mode import get_evolution_mode_service
+
+    state = get_evolution_mode_service().set_evolving(True)
+    if not state:
+        # Defensive — should not be reachable with set_evolving(True).
+        return "Evolution mode toggle failed."
+    return (
+        "Evolution mode ENABLED. The agent can now write to its own memory "
+        "(/agent_memory add/replace/remove) and self-modify its skills "
+        "(skill_evolve propose/update/revert). Use /stable to lock back."
+    )
+
+
+async def handle_stable(raw_args: str) -> str:
+    from clawmes.services.evolution_mode import get_evolution_mode_service
+
+    get_evolution_mode_service().set_evolving(False)
+    return (
+        "Evolution mode DISABLED. Memory writes and skill self-modification "
+        "are blocked. Read actions (query / list) still work. Use /evolve "
+        "to re-enable when you're ready."
+    )
+
+
+async def handle_evolution(raw_args: str) -> str:
+    from clawmes.services.evolution_mode import get_evolution_mode_service
+
+    state = get_evolution_mode_service().is_evolving()
+    label = "ENABLED" if state else "DISABLED"
+    return "\n".join(
+        [
+            f"Evolution mode: {label}",
+            "",
+            "When disabled (the safe default), the following actions are blocked:",
+            "  * agent_memory: add, replace, remove",
+            "  * skill_evolve: propose, update, revert",
+            "",
+            "When enabled, all actions are permitted. Toggle:",
+            "  /evolve  — turn ON  (allow self-modification)",
+            "  /stable  — turn OFF (block self-modification, default)",
+        ]
+    )
+
+
+def register(ctx) -> None:
+    """Wire evolution-mode commands into Hermes."""
+    ctx.register_command(
+        name="evolve",
+        handler=handle_evolve,
+        description="Enable self-modifying writes (memory + skill_evolve)",
+    )
+    ctx.register_command(
+        name="stable",
+        handler=handle_stable,
+        description="Disable self-modifying writes — the safe default",
+    )
+    ctx.register_command(
+        name="evolution",
+        handler=handle_evolution,
+        description="Show evolution-mode status",
+    )

--- a/clawmes/services/__init__.py
+++ b/clawmes/services/__init__.py
@@ -42,6 +42,7 @@ def start_all() -> None:
     from clawmes.services.coingecko import get_coingecko_service
     from clawmes.services.credential_redactor import get_credential_redactor
     from clawmes.services.endpoint_allowlist import get_endpoint_allowlist_service
+    from clawmes.services.evolution_mode import get_evolution_mode_service
     from clawmes.services.explorer import get_explorer_service
     from clawmes.services.lifi import get_lifi_service
     from clawmes.services.mode_service import get_mode_service
@@ -73,6 +74,9 @@ def start_all() -> None:
         #     picks, and step history for /skip and /back. Pure in-memory;
         #     persisted-to-disk variant is future work.
         get_onboarding_service,
+        # 2c. Evolution-mode gate — read by agent_memory / skill_evolve
+        #     write actions. Default disabled; user opts in via /evolve.
+        get_evolution_mode_service,
         # 3. RPC client — read-side foundation; many other services
         #    (token_decimals, wallet, balance tools) depend on it.
         get_rpc_service,

--- a/clawmes/services/evolution_mode.py
+++ b/clawmes/services/evolution_mode.py
@@ -1,0 +1,87 @@
+"""Evolution-mode service — gate for self-modifying tools.
+
+The ``agent_memory`` and ``skill_evolve`` tools let the agent rewrite
+its own persistent memory and skills. Without a gate, an LLM that
+gets prompt-injected (or that misreads ambient context) can mutate
+the user's long-term state without explicit consent.
+
+This service holds a single boolean: ``is_evolving()``. When ``False``
+(the default), the write actions of ``agent_memory`` and
+``skill_evolve`` should return an ``evolution_gate`` error rather
+than executing. Read actions (``query`` / ``list``) are always
+allowed.
+
+The user toggles via ``/evolve`` (enable), ``/stable`` (disable),
+``/evolution`` (status). State is in-memory only — matches
+``mode_service`` and ``persona_service`` posture; a process restart
+returns to the safe default.
+
+This is the clawmes equivalent of OpenClawnch's ``wrapWithEvoGate``
+(``extensions/crypto/index.ts:402-419``). We implement it inside each
+gated tool's handler rather than as a decorator wrapper to keep the
+existing ``@write_tool`` decorator pipeline unchanged.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from clawmes.lib.logger import logger_for
+from clawmes.services._base import Service
+
+_log = logger_for("services.evolution_mode")
+
+
+class EvolutionModeService(Service):
+    id = "clawmes.evolution_mode"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # Disabled by default — the safe posture. Users opt in.
+        self._evolving: bool = False
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        with self._lock:
+            self._evolving = False
+
+    def is_evolving(self) -> bool:
+        """Return True iff self-modification is currently enabled."""
+        with self._lock:
+            return self._evolving
+
+    def set_evolving(self, enabled: bool) -> bool:
+        """Set the evolution flag. Returns the new state."""
+        with self._lock:
+            previous = self._evolving
+            self._evolving = bool(enabled)
+            now = self._evolving
+        if previous != now:
+            _log.info(
+                "evolution mode %s",
+                "enabled" if now else "disabled",
+            )
+        return now
+
+    def health(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "status": "evolving" if self.is_evolving() else "stable",
+        }
+
+
+_instance: EvolutionModeService | None = None
+
+
+def get_evolution_mode_service() -> EvolutionModeService:
+    global _instance
+    if _instance is None:
+        _instance = EvolutionModeService()
+    return _instance
+
+
+def is_evolving() -> bool:
+    """Module-level convenience wrapper used by gated tool handlers."""
+    return get_evolution_mode_service().is_evolving()

--- a/clawmes/tools/agent_memory.py
+++ b/clawmes/tools/agent_memory.py
@@ -58,6 +58,17 @@ _SCHEMA: dict[str, Any] = {
 )
 def agent_memory(args: dict[str, Any], **kwargs: Any) -> str:
     action = read_str(args, "action", required=True)
+    if action in ("add", "replace", "remove"):
+        from clawmes.services.evolution_mode import is_evolving
+
+        if not is_evolving():
+            return error_result(
+                "Evolution mode is disabled. agent_memory write actions "
+                "(add / replace / remove) require /evolve. Use /evolution "
+                "to check status; the safe default is OFF so a "
+                "prompt-injected LLM can't silently rewrite your memory.",
+                code="evolution_gate",
+            )
     provider = _resolve_provider()
     if provider is None:
         return error_result(

--- a/clawmes/tools/skill_evolve.py
+++ b/clawmes/tools/skill_evolve.py
@@ -82,6 +82,17 @@ _SCHEMA: dict[str, Any] = {
 )
 def skill_evolve(args: dict[str, Any], **kwargs: Any) -> str:
     action = read_str(args, "action", required=True)
+    if action in ("propose", "update", "revert"):
+        from clawmes.services.evolution_mode import is_evolving
+
+        if not is_evolving():
+            return error_result(
+                "Evolution mode is disabled. skill_evolve write actions "
+                "(propose / update / revert) require /evolve. Use "
+                "/evolution to check status; the safe default is OFF so "
+                "a prompt-injected LLM can't silently rewrite your skills.",
+                code="evolution_gate",
+            )
     base = _evolution_dir()
 
     if action == "list":

--- a/tests/commands/test_balance.py
+++ b/tests/commands/test_balance.py
@@ -1,0 +1,256 @@
+"""Tests for /balance and /portfolio slash commands."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from clawmes.commands import balance as balance_cmd
+from clawmes.wallet.state import WalletState
+
+
+@pytest.fixture
+def disconnected_state():
+    return WalletState.disconnected()
+
+
+@pytest.fixture
+def connected_state():
+    return WalletState.for_chain(
+        mode="local",
+        address="0x" + "a" * 40,
+        chain_id=8453,
+    )
+
+
+# --- /balance -----------------------------------------------------------
+
+
+class TestHandleBalance:
+    async def test_no_wallet(self, disconnected_state):
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=disconnected_state,
+        ):
+            out = await balance_cmd.handle_balance("")
+        assert "No wallet connected" in out
+
+    async def test_no_chain_when_disconnected_chain(self):
+        # Wallet "connected" but with no chain id — defensive edge case.
+        state = WalletState(
+            connected=True,
+            mode="local",
+            address="0x" + "a" * 40,
+            chain_id=None,
+        )
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=state,
+        ):
+            out = await balance_cmd.handle_balance("")
+        assert "No chain specified" in out
+
+    async def test_uses_wallet_chain_when_no_arg(self, monkeypatch, connected_state):
+        captured = {}
+
+        def fake_defi_balance(args, **kw):
+            captured["args"] = args
+            return json.dumps(
+                {
+                    "content": [{"type": "text", "text": "0.5 ETH on Base"}],
+                    "details": {
+                        "address": args["address"],
+                        "chain": "base",
+                        "chain_id": 8453,
+                        "native_balance_wei": "500000000000000000",
+                        "native_balance": "0.5 ETH",
+                    },
+                }
+            )
+
+        monkeypatch.setattr("clawmes.tools.defi_balance.defi_balance", fake_defi_balance)
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=connected_state,
+        ):
+            out = await balance_cmd.handle_balance("")
+        assert "Native balance" in out
+        assert "0.5 ETH" in out
+        assert captured["args"]["chain"] == "8453"
+
+    async def test_uses_explicit_chain_arg(self, monkeypatch, connected_state):
+        captured = {}
+
+        def fake_defi_balance(args, **kw):
+            captured["args"] = args
+            return json.dumps(
+                {
+                    "content": [{"type": "text", "text": "0.0 ETH"}],
+                    "details": {
+                        "address": args["address"],
+                        "chain": "ethereum",
+                        "native_balance": "0.0 ETH",
+                    },
+                }
+            )
+
+        monkeypatch.setattr("clawmes.tools.defi_balance.defi_balance", fake_defi_balance)
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=connected_state,
+        ):
+            out = await balance_cmd.handle_balance("ethereum")
+        assert captured["args"]["chain"] == "ethereum"
+        assert "Native balance" in out
+
+    async def test_propagates_tool_error(self, monkeypatch, connected_state):
+        def fake_defi_balance(args, **kw):
+            return json.dumps(
+                {
+                    "content": [{"type": "text", "text": "RPC error: timeout"}],
+                    "isError": True,
+                    "details": {"error_code": "rpc_error"},
+                }
+            )
+
+        monkeypatch.setattr("clawmes.tools.defi_balance.defi_balance", fake_defi_balance)
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=connected_state,
+        ):
+            out = await balance_cmd.handle_balance("")
+        assert "RPC error" in out
+
+    async def test_falls_back_when_native_balance_missing(self, monkeypatch, connected_state):
+        # If the tool envelope changes shape and 'native_balance' is
+        # missing, the command should fall back to the wei value.
+        def fake_defi_balance(args, **kw):
+            return json.dumps(
+                {
+                    "content": [{"type": "text", "text": "?"}],
+                    "details": {
+                        "chain": "base",
+                        "native_balance_wei": "1000000000000000000",
+                    },
+                }
+            )
+
+        monkeypatch.setattr("clawmes.tools.defi_balance.defi_balance", fake_defi_balance)
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=connected_state,
+        ):
+            out = await balance_cmd.handle_balance("")
+        assert "1000000000000000000" in out
+
+
+# --- /portfolio --------------------------------------------------------
+
+
+class TestHandlePortfolio:
+    async def test_no_wallet(self, disconnected_state):
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=disconnected_state,
+        ):
+            out = await balance_cmd.handle_portfolio("")
+        assert "No wallet connected" in out
+
+    async def test_no_chain_when_disconnected_chain(self):
+        state = WalletState(
+            connected=True,
+            mode="local",
+            address="0x" + "a" * 40,
+            chain_id=None,
+        )
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=state,
+        ):
+            out = await balance_cmd.handle_portfolio("")
+        assert "No chain specified" in out
+
+    async def test_uses_tool_content_directly(self, monkeypatch, connected_state):
+        def fake_defi_balance(args, **kw):
+            return json.dumps(
+                {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": ("Balances for 0x… on Base:\n  ETH      0.5\n  USDC     100.0"),
+                        }
+                    ],
+                    "details": {
+                        "address": args["address"],
+                        "balances": [
+                            {"symbol": "ETH", "human": "0.5"},
+                            {"symbol": "USDC", "human": "100.0"},
+                        ],
+                    },
+                }
+            )
+
+        monkeypatch.setattr("clawmes.tools.defi_balance.defi_balance", fake_defi_balance)
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=connected_state,
+        ):
+            out = await balance_cmd.handle_portfolio("")
+        assert "Balances for 0x…" in out
+        assert "ETH" in out
+        assert "USDC" in out
+
+    async def test_propagates_tool_error(self, monkeypatch, connected_state):
+        def fake_defi_balance(args, **kw):
+            return json.dumps(
+                {
+                    "content": [{"type": "text", "text": "no RPC endpoint"}],
+                    "isError": True,
+                    "details": {"error_code": "rpc_unconfigured"},
+                }
+            )
+
+        monkeypatch.setattr("clawmes.tools.defi_balance.defi_balance", fake_defi_balance)
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=connected_state,
+        ):
+            out = await balance_cmd.handle_portfolio("")
+        assert "no RPC endpoint" in out
+
+    async def test_falls_back_when_content_missing(self, monkeypatch, connected_state):
+        # Defensive — defi_balance shouldn't return a payload without
+        # content, but if it ever does, we surface the details dict
+        # rather than crashing.
+        def fake_defi_balance(args, **kw):
+            return json.dumps(
+                {
+                    "content": [],
+                    "details": {"address": args["address"], "balances": []},
+                }
+            )
+
+        monkeypatch.setattr("clawmes.tools.defi_balance.defi_balance", fake_defi_balance)
+        with patch(
+            "clawmes.commands.balance.get_wallet_state",
+            return_value=connected_state,
+        ):
+            out = await balance_cmd.handle_portfolio("")
+        assert "Portfolio for" in out
+
+
+# --- registration ------------------------------------------------------
+
+
+class TestRegister:
+    def test_registers_two_commands(self):
+        captured = []
+
+        class FakeCtx:
+            def register_command(self, **kw):
+                captured.append(kw["name"])
+
+        balance_cmd.register(FakeCtx())
+        assert set(captured) == {"balance", "portfolio"}

--- a/tests/commands/test_evolve.py
+++ b/tests/commands/test_evolve.py
@@ -1,0 +1,77 @@
+"""Tests for /evolve, /stable, /evolution slash commands."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.commands import evolve as evolve_cmd
+from clawmes.services import evolution_mode as evo_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.setattr(evo_mod, "_instance", None)
+
+
+class TestHandleEvolve:
+    async def test_enables_evolution_mode(self):
+        assert evo_mod.get_evolution_mode_service().is_evolving() is False
+        out = await evolve_cmd.handle_evolve("")
+        assert "ENABLED" in out
+        assert evo_mod.get_evolution_mode_service().is_evolving() is True
+
+    async def test_idempotent_when_already_enabled(self):
+        evo_mod.get_evolution_mode_service().set_evolving(True)
+        out = await evolve_cmd.handle_evolve("")
+        assert "ENABLED" in out
+        assert evo_mod.get_evolution_mode_service().is_evolving() is True
+
+    async def test_unexpected_failure_path(self, monkeypatch):
+        # Force set_evolving to return False even when asked to enable
+        # (defensive coverage for the "should never reach here" branch).
+        monkeypatch.setattr(
+            evo_mod.EvolutionModeService,
+            "set_evolving",
+            lambda self, enabled: False,
+        )
+        out = await evolve_cmd.handle_evolve("")
+        assert "toggle failed" in out
+
+
+class TestHandleStable:
+    async def test_disables_evolution_mode(self):
+        evo_mod.get_evolution_mode_service().set_evolving(True)
+        out = await evolve_cmd.handle_stable("")
+        assert "DISABLED" in out
+        assert evo_mod.get_evolution_mode_service().is_evolving() is False
+
+    async def test_idempotent_when_already_disabled(self):
+        out = await evolve_cmd.handle_stable("")
+        assert "DISABLED" in out
+        assert evo_mod.get_evolution_mode_service().is_evolving() is False
+
+
+class TestHandleEvolution:
+    async def test_reports_disabled(self):
+        out = await evolve_cmd.handle_evolution("")
+        assert "DISABLED" in out
+        assert "/evolve" in out
+
+    async def test_reports_enabled(self):
+        evo_mod.get_evolution_mode_service().set_evolving(True)
+        out = await evolve_cmd.handle_evolution("")
+        assert "ENABLED" in out
+        assert "agent_memory" in out
+        assert "skill_evolve" in out
+
+
+class TestRegister:
+    def test_registers_three_commands(self):
+        captured = []
+
+        class FakeCtx:
+            def register_command(self, **kw):
+                captured.append(kw["name"])
+
+        evolve_cmd.register(FakeCtx())
+        assert set(captured) == {"evolve", "stable", "evolution"}

--- a/tests/services/test_evolution_mode.py
+++ b/tests/services/test_evolution_mode.py
@@ -1,0 +1,181 @@
+"""Tests for clawmes.services.evolution_mode."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawmes.services import evolution_mode as evo_mod
+from clawmes.services.evolution_mode import (
+    EvolutionModeService,
+    get_evolution_mode_service,
+    is_evolving,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.setattr(evo_mod, "_instance", None)
+
+
+class TestLifecycle:
+    def test_start_is_noop(self):
+        EvolutionModeService().start()
+
+    def test_stop_resets_to_safe_default(self):
+        svc = EvolutionModeService()
+        svc.set_evolving(True)
+        svc.stop()
+        assert svc.is_evolving() is False
+
+    def test_default_is_disabled(self):
+        assert EvolutionModeService().is_evolving() is False
+
+    def test_health_reports_status(self):
+        svc = EvolutionModeService()
+        assert svc.health()["status"] == "stable"
+        svc.set_evolving(True)
+        assert svc.health()["status"] == "evolving"
+
+
+class TestSetEvolving:
+    def test_enable(self):
+        svc = EvolutionModeService()
+        assert svc.set_evolving(True) is True
+        assert svc.is_evolving() is True
+
+    def test_disable(self):
+        svc = EvolutionModeService()
+        svc.set_evolving(True)
+        assert svc.set_evolving(False) is False
+        assert svc.is_evolving() is False
+
+    def test_coerces_truthy_values(self):
+        svc = EvolutionModeService()
+        assert svc.set_evolving(1) is True  # type: ignore[arg-type]
+        assert svc.set_evolving(0) is False  # type: ignore[arg-type]
+
+    def test_idempotent_enable(self):
+        svc = EvolutionModeService()
+        svc.set_evolving(True)
+        # Setting twice in the same state shouldn't crash or change state.
+        assert svc.set_evolving(True) is True
+
+
+class TestSingleton:
+    def test_returns_same_instance(self):
+        a = get_evolution_mode_service()
+        b = get_evolution_mode_service()
+        assert a is b
+
+    def test_module_level_helper(self):
+        assert is_evolving() is False
+        get_evolution_mode_service().set_evolving(True)
+        assert is_evolving() is True
+
+
+# --- gating behavior on agent_memory + skill_evolve ---------------------
+
+
+class TestAgentMemoryGate:
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch, tmp_path):
+        # Isolate filesystem + ensure evolution is OFF.
+        from clawmes.policy import storage as policy_storage
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        policy_storage.save_policies([])
+        # Default evolution state is off, so explicit set_evolving(False)
+        # isn't strictly necessary, but be explicit.
+        get_evolution_mode_service().set_evolving(False)
+
+    def test_add_blocked_when_disabled(self):
+        from clawmes.tools.agent_memory import agent_memory
+
+        out = json.loads(agent_memory({"action": "add", "key": "k", "content": "v"}))
+        assert out["isError"] is True
+        assert out["details"]["error_code"] == "evolution_gate"
+
+    def test_replace_blocked_when_disabled(self):
+        from clawmes.tools.agent_memory import agent_memory
+
+        out = json.loads(agent_memory({"action": "replace", "key": "k", "content": "v"}))
+        assert out["details"]["error_code"] == "evolution_gate"
+
+    def test_remove_blocked_when_disabled(self):
+        from clawmes.tools.agent_memory import agent_memory
+
+        out = json.loads(agent_memory({"action": "remove", "key": "k"}))
+        assert out["details"]["error_code"] == "evolution_gate"
+
+    def test_query_allowed_when_disabled(self):
+        # Read action — must work even with evolution disabled.
+        from clawmes.tools.agent_memory import agent_memory
+
+        out = json.loads(agent_memory({"action": "query", "query": "x"}))
+        # Either succeeds (provider returned data) or returns not_available
+        # because no Hermes memory provider is loaded — both are fine, the
+        # important thing is the action wasn't gated.
+        if out.get("isError"):
+            assert out["details"]["error_code"] != "evolution_gate"
+
+    def test_add_allowed_when_enabled(self, monkeypatch):
+        from clawmes.tools import agent_memory as am_mod
+
+        # Stub Hermes' memory provider so we can verify the call reaches it.
+        fake_provider = type(
+            "FakeProvider",
+            (),
+            {"add": lambda self, k, v: {"ok": True, "key": k, "value": v}},
+        )()
+        monkeypatch.setattr(am_mod, "_resolve_provider", lambda: fake_provider)
+
+        get_evolution_mode_service().set_evolving(True)
+        out = json.loads(am_mod.agent_memory({"action": "add", "key": "k", "content": "v"}))
+        assert "isError" not in out
+        assert out["details"]["result"]["ok"] is True
+
+
+class TestSkillEvolveGate:
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch, tmp_path):
+        from clawmes.policy import storage as policy_storage
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        policy_storage.save_policies([])
+        get_evolution_mode_service().set_evolving(False)
+
+    def test_propose_blocked_when_disabled(self):
+        from clawmes.tools.skill_evolve import skill_evolve
+
+        out = json.loads(skill_evolve({"action": "propose", "skill": "s1", "change": "add x"}))
+        assert out["isError"] is True
+        assert out["details"]["error_code"] == "evolution_gate"
+
+    def test_update_blocked_when_disabled(self):
+        from clawmes.tools.skill_evolve import skill_evolve
+
+        out = json.loads(skill_evolve({"action": "update", "proposal_id": "p1"}))
+        assert out["details"]["error_code"] == "evolution_gate"
+
+    def test_revert_blocked_when_disabled(self):
+        from clawmes.tools.skill_evolve import skill_evolve
+
+        out = json.loads(skill_evolve({"action": "revert", "proposal_id": "p1"}))
+        assert out["details"]["error_code"] == "evolution_gate"
+
+    def test_list_allowed_when_disabled(self):
+        from clawmes.tools.skill_evolve import skill_evolve
+
+        out = json.loads(skill_evolve({"action": "list"}))
+        assert "isError" not in out
+        assert "proposals" in out["details"]
+
+    def test_propose_allowed_when_enabled(self):
+        from clawmes.tools.skill_evolve import skill_evolve
+
+        get_evolution_mode_service().set_evolving(True)
+        out = json.loads(skill_evolve({"action": "propose", "skill": "s1", "change": "add x"}))
+        assert "isError" not in out
+        assert out["details"]["skill"] == "s1"

--- a/tests/tools/test_memory_privacy_herd.py
+++ b/tests/tools/test_memory_privacy_herd.py
@@ -12,11 +12,18 @@ import pytest
 @pytest.fixture(autouse=True)
 def _isolate(monkeypatch, tmp_path):
     from clawmes.policy import storage as policy_storage
+    from clawmes.services import evolution_mode as evo_mod
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     for k in ("HERD_ACCESS_TOKEN", "LOBSTER_API_KEY"):
         monkeypatch.delenv(k, raising=False)
     policy_storage.save_policies([])
+    # The agent_memory and skill_evolve write actions are now gated by
+    # evolution_mode (default off). Enable it for the existing tests
+    # so write-action assertions continue to work; gating behavior is
+    # tested separately in test_evolution_mode tests.
+    monkeypatch.setattr(evo_mod, "_instance", None)
+    evo_mod.get_evolution_mode_service().set_evolving(True)
 
 
 def _stub(monkeypatch, module_path: str, attr: str, response):


### PR DESCRIPTION
## Summary

Three additions, all closing audit gaps from the OpenClawnch parity work. **PR 4 of an ongoing series** (#3 policy_manage, #4 onboarding, #5 wallet-recovery still open).

## Surface delta

| | Before | After |
|---|---|---|
| Tools | 45 | 45 |
| Commands | 28 | **33** |
| Services | 15 | **16** |
| Hooks | 11 | 11 |
| New env vars | — | — |
| New external deps | — | — |

## What's in this PR

### 1. Evolution-mode gate (real safety improvement — audit rank #9)

Before this PR, `agent_memory` and `skill_evolve` registered unconditionally — the LLM could write to its own persistent memory and self-modify skills with zero user consent. A prompt-injected agent could silently rewrite memory or skills and the change persists across sessions. That's a real safety hole, flagged explicitly in the OC parity audit.

This PR adds the gate:

- New `EvolutionModeService` (`clawmes/services/evolution_mode.py`) — single boolean, default **OFF**, in-memory only (resets on restart by design so an attacker who flips the bit can't keep it set).
- New `/evolve` (enable), `/stable` (disable, the default), `/evolution` (status) commands.
- Gates installed inside `agent_memory` and `skill_evolve` tool handlers:
  - `agent_memory`: `add` / `replace` / `remove` gated. `query` always allowed.
  - `skill_evolve`: `propose` / `update` / `revert` gated. `list` always allowed.
- Equivalent to OpenClawnch's `wrapWithEvoGate` (`extensions/crypto/index.ts:402-419`). We implement inside the handler rather than as a decorator wrapper to keep the existing `@write_tool` pipeline untouched.

Existing test suite for these tools (`tests/tools/test_memory_privacy_herd.py`) gets a one-line autouse fixture update to enable evolution mode — existing assertions pass unchanged. Gating behavior is covered separately in `tests/services/test_evolution_mode.py`.

### 2. /balance + /portfolio (surface deltas)

Pure wrappers over `defi_balance` 's `native` and `summary` actions:

- `/balance [chain]` — native-token balance for the connected wallet.
- `/portfolio [chain]` — native + curated common-token list (USDC, WETH, USDT, DAI on Base).

Both pick up the wallet address + chain from `wallet_service` so the user doesn't have to retype. The `/portfolio` command surfaces `defi_balance` 's already-formatted summary string directly — no re-rendering needed.

## Verification

- \`pytest tests/services/test_evolution_mode.py tests/commands/test_evolve.py tests/commands/test_balance.py --cov\` → **40 tests pass, 100% coverage** on new modules
- \`pytest --cov=clawmes\` → **2103 passing**, 8 skipped, 100% coverage gate satisfied
- \`ruff check clawmes tests\` → clean
- \`ruff format --check clawmes tests\` → clean (246 files)
- \`test_plugin_manifest.py\` → passes (no tool / hook changes)
- Existing \`agent_memory\` + \`skill_evolve\` tests in \`test_memory_privacy_herd.py\` → still pass with the autouse fixture update

## Notes for reviewers

- The gate raises `evolution_gate` error code (not `policy_block`) so callers can distinguish it from the existing policy-gate path.
- `/stable` is the safe default. The README + module docstring spell out why state resets on restart (defense against an attacker who gets the LLM to flip the bit silently).
- I left `query` and `list` always-allowed even when evolution is off — these are read actions, no mutation. Same posture as the policy engine's read paths.
- Will need a trivial rebase against PR 5 (#5) if that merges first since both touch CHANGELOG and README counts.