### PR TITLE
feat(commands): 5 discoverability commands (/skills /persona /chains /tools_list /safety_status)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   don't go through the `@write_tool` policy gate (no clawmes
   infrastructure for that today); the password barrier is the
   safety boundary. Commit message + module docstring spell this out.
+- 5 discoverability slash commands (`clawmes/commands/discovery.py`).
+  Each wraps existing data with zero new dependencies and no new
+  service.
+    - `/skills` — list bundled clawmes skills by walking
+      `clawmes/skills/*/SKILL.md` and reading the YAML-frontmatter
+      `description:` line.
+    - `/persona` — show the active persona (or list the 5 built-in
+      personas when none is active).
+    - `/chains` — list every EVM chain in `clawmes/lib/chains.CHAINS`
+      with RPC-configured indicator and a default-chain marker.
+    - `/tools_list` — list every clawmes tool declared in
+      `plugin.yaml`'s `provides_tools` array.
+    - `/safety_status` — show current `mode_service` mode (normal /
+      readonly / danger) with context on what each mode means for
+      write tools.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Clawmes is a [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin. Wallets, DEX trading, lending and staking, governance, on-chain automation. Python rewrite of [`@clawnch/openclaw-crypto`](https://github.com/clawnchdev/openclawnch) targeting Hermes.
 
-46 tools. 33 commands. 15 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
+46 tools. 38 commands. 15 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
 
 ## Quick start
 
@@ -137,7 +137,7 @@ hermes (the upstream CLI, hermes-agent ≥ 2026.4.x)
   └── PluginManager.discover_and_load()
         └── clawmes.register(ctx)
               ├── 46 tools     (registered via ctx.register_tool, write-gated)
-              ├── 33 commands  (registered via ctx.register_command)
+              ├── 38 commands  (registered via ctx.register_command)
               ├── 11 hooks     (pre_tool_call, post_tool_call, pre_llm_call, ...)
               ├── 27 skills    (registered via ctx.register_skill, namespaced clawmes:*)
               ├── CLI subcmds  (registered via ctx.register_cli_command)

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -14,6 +14,7 @@ rejected.
 from __future__ import annotations
 
 from clawmes.commands import (
+    discovery,
     doctor,
     plans,
     policy,
@@ -37,6 +38,7 @@ def register_all(ctx) -> None:
     tx.register(ctx)
     plans.register(ctx)
     doctor.register(ctx)
+    discovery.register(ctx)
     # TODO(v0.1.0+): onboarding, model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
-    # forum, fiat, agents, skills, channel
+    # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/discovery.py
+++ b/clawmes/commands/discovery.py
@@ -1,0 +1,211 @@
+"""Discoverability slash commands.
+
+Five read-only commands that surface what's installed / configured /
+running. All wrappers over already-shipped data:
+
+  * ``/skills``        — list bundled clawmes skills (walks
+    ``clawmes/skills/*/SKILL.md``).
+  * ``/persona``       — show the active persona (or list available
+    ones when none is active).
+  * ``/chains``        — list every EVM chain the chain registry
+    knows about (``clawmes/lib/chains.CHAINS``).
+  * ``/tools_list``    — list every clawmes tool from the
+    plugin manifest's ``provides_tools`` array.
+  * ``/safety_status`` — show the current
+    :class:`clawmes.services.mode_service.ModeService` mode and what
+    that means for write tools.
+
+Why these aren't covered by ``/doctor``: doctor is for *diagnostic*
+output (what's broken, what's missing). These are *navigational* (what
+exists, what's available). Different surface, different audience.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+from pathlib import Path
+
+from clawmes.onboarding.personas import PERSONAS
+
+
+async def handle_skills(raw_args: str) -> str:
+    skills_dir = Path(__file__).parent.parent / "skills"
+    if not skills_dir.exists():
+        return "No clawmes skills directory found. (Expected clawmes/skills/.)"
+
+    entries: list[tuple[str, str]] = []
+    for child in sorted(skills_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        skill_md = child / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        description = _read_skill_description(skill_md)
+        entries.append((child.name, description))
+
+    if not entries:
+        return "No clawmes skills installed."
+
+    lines = [f"{len(entries)} clawmes skill(s) bundled:"]
+    for name, description in entries:
+        head = description.splitlines()[0] if description else "(no description)"
+        if len(head) > 100:
+            head = head[:97] + "..."
+        lines.append(f"  clawmes:{name} - {head}")
+    return "\n".join(lines)
+
+
+def _read_skill_description(skill_md: Path) -> str:
+    """Extract the YAML-frontmatter ``description:`` line.
+
+    Same string-scan approach the registry uses
+    (:mod:`clawmes.skills.__init__`) to avoid a yaml dependency.
+    """
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    in_frontmatter = False
+    for line in text.splitlines():
+        if line.strip() == "---":
+            if not in_frontmatter:
+                in_frontmatter = True
+                continue
+            break
+        if in_frontmatter and line.lower().startswith("description:"):
+            return line.split(":", 1)[1].strip().strip("\"'")
+    return ""
+
+
+async def handle_persona(raw_args: str) -> str:
+    from clawmes.services.persona_service import get_persona_service
+
+    svc = get_persona_service()
+    active = svc.active_persona()
+    if active is not None:
+        return (
+            f"Active persona: {active.name}\n"
+            f"  Tagline: {active.tagline}\n\n"
+            "Switch via /professional, /degen, /chill, /technical, /mentor."
+        )
+
+    lines = [
+        "No active persona. Available choices:",
+    ]
+    for name, persona in PERSONAS.items():
+        lines.append(f"  /{name} - {persona.tagline}")
+    return "\n".join(lines)
+
+
+async def handle_chains(raw_args: str) -> str:
+    from clawmes.lib.chains import CHAINS, default_chain_id
+    from clawmes.services.rpc import get_rpc_service
+
+    rpc = get_rpc_service()
+    default = default_chain_id()
+
+    lines = [f"{len(CHAINS)} supported chain(s) (default = chain id {default}):"]
+    for chain_id, chain in sorted(CHAINS.items()):
+        rpc_marker = "[rpc]" if rpc.has_endpoint(chain_id) else "[no-rpc]"
+        l2_marker = " (L2)" if chain.is_l2 else ""
+        default_marker = "*" if chain_id == default else " "
+        lines.append(
+            f" {default_marker}{rpc_marker:<8} {chain_id:>6}  "
+            f"{chain.short_name:<10} {chain.name}{l2_marker}"
+        )
+    return "\n".join(lines)
+
+
+async def handle_tools_list(raw_args: str) -> str:
+    manifest = _read_manifest_tools()
+    if manifest is None:
+        return "Could not locate plugin.yaml — clawmes installation is missing it."
+    if not manifest:
+        return "No tools declared in plugin.yaml."
+    lines = [f"{len(manifest)} clawmes tool(s) declared in plugin.yaml:"]
+    for name in sorted(manifest):
+        lines.append(f"  {name}")
+    return "\n".join(lines)
+
+
+def _read_manifest_tools() -> list[str] | None:
+    """Parse ``provides_tools`` from the bundled plugin.yaml.
+
+    Avoids the YAML dependency for this hot path. The schema is stable
+    enough for a string scan and matches what ``tests/test_plugin_manifest``
+    enforces.
+    """
+    try:
+        text = importlib.resources.files("clawmes").joinpath("plugin.yaml").read_text()
+    except (OSError, ModuleNotFoundError):
+        return None
+
+    tools: list[str] = []
+    in_provides = False
+    for line in text.splitlines():
+        if line.startswith("provides_tools:"):
+            in_provides = True
+            continue
+        if in_provides:
+            stripped = line.rstrip()
+            if stripped.startswith("  - "):
+                tools.append(stripped[4:].strip())
+            elif stripped and not stripped.startswith(" "):
+                break  # Next top-level key — provides_tools section ended.
+    return tools
+
+
+async def handle_safety_status(raw_args: str) -> str:
+    from clawmes.services.mode_service import get_mode_service
+
+    mode = get_mode_service().mode
+    if mode == "normal":
+        return (
+            "Safety mode: NORMAL.\n"
+            "  Readonly check:  off (writes pass to policy gate)\n"
+            "  Danger override: off\n"
+            "Switch via /safemode (lock writes) or /dangermode (bypass readonly)."
+        )
+    if mode == "readonly":
+        return (
+            "Safety mode: READONLY.\n"
+            "  Every write tool will be blocked at stage 1 of the @write_tool gate.\n"
+            "  Read tools (defi_price, defi_balance, etc.) still work.\n"
+            "Switch via /safemode off or /dangermode to enable writes again."
+        )
+    # mode == "danger"
+    return (
+        "Safety mode: DANGER.\n"
+        "  Readonly check is BYPASSED. Policy gating still applies.\n"
+        "  Use with care — large or irreversible transactions are easier to send.\n"
+        "Switch via /safemode (lock writes) to return to a safe posture."
+    )
+
+
+def register(ctx) -> None:
+    """Wire discovery commands into Hermes."""
+    ctx.register_command(
+        name="skills",
+        handler=handle_skills,
+        description="List bundled clawmes skills",
+    )
+    ctx.register_command(
+        name="persona",
+        handler=handle_persona,
+        description="Show the active persona (or list available ones)",
+    )
+    ctx.register_command(
+        name="chains",
+        handler=handle_chains,
+        description="List supported EVM chains + RPC status",
+    )
+    ctx.register_command(
+        name="tools_list",
+        handler=handle_tools_list,
+        description="List clawmes tools registered in plugin.yaml",
+    )
+    ctx.register_command(
+        name="safety_status",
+        handler=handle_safety_status,
+        description="Show current safety mode (normal / readonly / danger)",
+    )

--- a/tests/commands/test_discovery.py
+++ b/tests/commands/test_discovery.py
@@ -1,0 +1,300 @@
+"""Tests for /skills, /persona, /chains, /tools_list, /safety_status."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.commands import discovery as disc_cmd
+from clawmes.services import mode_service as mode_mod
+from clawmes.services import persona_service as persona_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.setattr(persona_mod, "_instance", None)
+    monkeypatch.setattr(mode_mod, "_instance", None)
+
+
+# --- /skills ------------------------------------------------------------
+
+
+class TestHandleSkills:
+    async def test_lists_bundled_skills(self):
+        # The clawmes/skills/ directory ships with the 0.1.0 set.
+        out = await disc_cmd.handle_skills("")
+        assert "clawmes skill(s) bundled" in out
+        # At least one well-known skill from CHANGELOG line 105.
+        assert "transfer" in out or "defi-trading" in out
+
+    async def test_empty_skills_dir(self, monkeypatch, tmp_path):
+        # When the skills directory exists but contains no SKILL.md files,
+        # the command should report "No clawmes skills installed."
+        empty_skills = tmp_path / "skills"
+        empty_skills.mkdir()
+        # Add a non-directory entry to prove iteration handles it.
+        (empty_skills / "stray.txt").write_text("ignored", encoding="utf-8")
+        # And a directory without SKILL.md.
+        (empty_skills / "no_md_here").mkdir()
+
+        from clawmes.commands import discovery
+
+        original_path_cls = discovery.Path
+
+        class StubPath:
+            def __init__(self, *args, **kwargs):
+                self._real = original_path_cls(*args, **kwargs)
+
+            @property
+            def parent(self):
+                wrapped = type(self).__new__(type(self))
+                wrapped._real = self._real.parent
+                return wrapped
+
+            def __truediv__(self, other):
+                if other == "skills":
+                    return empty_skills
+                return self._real / other
+
+            def exists(self):
+                return self._real.exists()
+
+        monkeypatch.setattr(discovery, "Path", StubPath)
+        out = await disc_cmd.handle_skills("")
+        assert "No clawmes skills installed" in out
+
+    async def test_frontmatter_end_marker(self, tmp_path):
+        # Cover the "second ---" branch in _read_skill_description.
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            "---\nname: test\n---\n\ndescription: This is in the body, NOT the frontmatter.\n",
+            encoding="utf-8",
+        )
+        # No description in frontmatter → returns "".
+        assert disc_cmd._read_skill_description(skill) == ""
+
+    async def test_missing_dir(self, monkeypatch, tmp_path):
+        # If the skills_dir doesn't exist, return a clear error.
+        from clawmes.commands import discovery
+
+        # Patch Path so .parent.parent / "skills" lands on a nonexistent dir.
+        class FakePath:
+            def __init__(self, *a, **kw):
+                pass
+
+            @property
+            def parent(self):
+                return self
+
+            def __truediv__(self, other):
+                return tmp_path / "definitely-not-here" / other
+
+        monkeypatch.setattr(discovery, "Path", FakePath)
+        out = await disc_cmd.handle_skills("")
+        assert "No clawmes skills directory found" in out
+
+    async def test_handles_unreadable_file(self, monkeypatch, tmp_path):
+        # The _read_skill_description helper must tolerate OSError.
+        path = tmp_path / "broken.md"
+        # File doesn't exist → read_text raises OSError → returns "".
+        assert disc_cmd._read_skill_description(path) == ""
+
+    async def test_reads_frontmatter_description(self, tmp_path):
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            "---\n"
+            "name: test-skill\n"
+            "description: A test skill for unit testing.\n"
+            "tags: [test]\n"
+            "---\n\n"
+            "# body content\n",
+            encoding="utf-8",
+        )
+        assert disc_cmd._read_skill_description(skill) == "A test skill for unit testing."
+
+    async def test_no_frontmatter_returns_empty(self, tmp_path):
+        skill = tmp_path / "SKILL.md"
+        skill.write_text("# body only\n", encoding="utf-8")
+        assert disc_cmd._read_skill_description(skill) == ""
+
+    async def test_truncates_long_description(self, tmp_path, monkeypatch):
+        # Create a fake skill dir + SKILL.md with a >100 char description.
+        skills_dir = tmp_path / "skills"
+        sub = skills_dir / "test"
+        sub.mkdir(parents=True)
+        long_desc = "x" * 200
+        (sub / "SKILL.md").write_text(f"---\ndescription: {long_desc}\n---\n", encoding="utf-8")
+        # Patch the dir resolution.
+        import clawmes.commands.discovery as discovery
+
+        original_path = discovery.Path
+
+        class StubPath:
+            def __init__(self, *a, **kw):
+                self._underlying = original_path(*a, **kw)
+
+            @property
+            def parent(self):
+                p = type(self).__new__(type(self))
+                p._underlying = self._underlying.parent
+                return p
+
+            def __truediv__(self, other):
+                # Redirect to the tmp skills dir when asking for "skills"
+                if other == "skills":
+                    return skills_dir
+                return self._underlying / other
+
+            def exists(self):
+                return self._underlying.exists()
+
+        monkeypatch.setattr(discovery, "Path", StubPath)
+        out = await disc_cmd.handle_skills("")
+        # Long description should be truncated; the full 200-char string
+        # should NOT appear verbatim.
+        assert long_desc not in out
+        assert "..." in out
+
+
+# --- /persona -----------------------------------------------------------
+
+
+class TestHandlePersona:
+    async def test_no_active(self):
+        out = await disc_cmd.handle_persona("")
+        assert "No active persona" in out
+        # Should list the choices.
+        assert "/degen" in out
+        assert "/professional" in out
+
+    async def test_with_active(self):
+        persona_mod.get_persona_service().set_persona("degen")
+        out = await disc_cmd.handle_persona("")
+        assert "Active persona: degen" in out
+        assert "Tagline:" in out
+
+
+# --- /chains ------------------------------------------------------------
+
+
+class TestHandleChains:
+    async def test_lists_chains(self):
+        out = await disc_cmd.handle_chains("")
+        assert "supported chain(s)" in out
+        assert "ethereum" in out
+        assert "base" in out
+        assert "arbitrum" in out
+
+    async def test_marks_default(self):
+        out = await disc_cmd.handle_chains("")
+        # The default-chain marker '*' precedes the entry for base (8453).
+        # Check that one line contains both the marker and 'base'.
+        marker_lines = [ln for ln in out.splitlines() if ln.startswith(" *")]
+        assert marker_lines, "Expected at least one line marked with *"
+        assert any("base" in ln for ln in marker_lines)
+
+
+# --- /tools_list --------------------------------------------------------
+
+
+class TestHandleToolsList:
+    async def test_lists_tools_from_manifest(self):
+        out = await disc_cmd.handle_tools_list("")
+        # The CHANGELOG promises 45 tools at 0.1.0; just verify a few
+        # well-known names appear.
+        assert "tool(s) declared in plugin.yaml" in out
+        assert "transfer" in out
+        assert "defi_swap" in out
+
+    async def test_handles_missing_manifest(self, monkeypatch):
+        monkeypatch.setattr(disc_cmd, "_read_manifest_tools", lambda: None)
+        out = await disc_cmd.handle_tools_list("")
+        assert "Could not locate plugin.yaml" in out
+
+    async def test_handles_empty_manifest(self, monkeypatch):
+        monkeypatch.setattr(disc_cmd, "_read_manifest_tools", lambda: [])
+        out = await disc_cmd.handle_tools_list("")
+        assert "No tools declared" in out
+
+
+class TestReadManifestTools:
+    def test_finds_real_manifest(self):
+        # The bundled clawmes/plugin.yaml must have provides_tools.
+        tools = disc_cmd._read_manifest_tools()
+        assert tools is not None
+        assert "transfer" in tools
+
+    def test_handles_resource_failure(self, monkeypatch):
+        import importlib.resources
+
+        def boom(*args, **kwargs):
+            raise OSError("simulated resource failure")
+
+        # Patch the resource accessor to raise.
+        class BrokenResource:
+            def joinpath(self, *a, **kw):
+                raise OSError("nope")
+
+        monkeypatch.setattr(importlib.resources, "files", lambda *a, **kw: BrokenResource())
+        assert disc_cmd._read_manifest_tools() is None
+
+    def test_stops_at_next_top_level_key(self, monkeypatch):
+        # Simulate a manifest where provides_tools is followed by another
+        # top-level key — the parser should NOT include lines past it.
+        import importlib.resources
+
+        fake_manifest = "provides_tools:\n  - foo\n  - bar\nprovides_hooks:\n  - pre_tool_call\n"
+
+        class FakeRes:
+            def joinpath(self, *a, **kw):
+                return self
+
+            def read_text(self, *a, **kw):
+                return fake_manifest
+
+        monkeypatch.setattr(importlib.resources, "files", lambda *a, **kw: FakeRes())
+        tools = disc_cmd._read_manifest_tools()
+        assert tools == ["foo", "bar"]
+
+
+# --- /safety_status -----------------------------------------------------
+
+
+class TestHandleSafetyStatus:
+    async def test_normal(self):
+        # Default mode is "normal".
+        out = await disc_cmd.handle_safety_status("")
+        assert "NORMAL" in out
+        assert "off" in out  # readonly off
+
+    async def test_readonly(self):
+        mode_mod.get_mode_service().set_mode("readonly")
+        out = await disc_cmd.handle_safety_status("")
+        assert "READONLY" in out
+        assert "blocked at stage 1" in out
+
+    async def test_danger(self):
+        mode_mod.get_mode_service().set_mode("danger")
+        out = await disc_cmd.handle_safety_status("")
+        assert "DANGER" in out
+        assert "BYPASSED" in out
+
+
+# --- registration -------------------------------------------------------
+
+
+class TestRegister:
+    def test_registers_five_commands(self):
+        captured = []
+
+        class FakeCtx:
+            def register_command(self, **kw):
+                captured.append(kw["name"])
+
+        disc_cmd.register(FakeCtx())
+        assert set(captured) == {
+            "skills",
+            "persona",
+            "chains",
+            "tools_list",
+            "safety_status",
+        }


### PR DESCRIPTION
## Summary

Five read-only slash commands wrapping existing data. **PR 7 in the OpenClawnch parity series**. Zero new dependencies, no new service — pure surface deltas filling discoverability gaps in the existing surface.

## Surface delta

| | Before | After |
|---|---|---|
| Tools | 45 | 45 |
| Commands | 28 | **33** |
| Services | 15 | 15 |
| Hooks | 11 | 11 |
| New env vars | — | — |

## Commands

| Command | Behavior | Data source |
|---|---|---|
| `/skills` | List bundled clawmes skills | walks `clawmes/skills/*/SKILL.md`, reads YAML-frontmatter `description:` line |
| `/persona` | Show the active persona (or list available) | `persona_service.active_persona()` + `PERSONAS` registry |
| `/chains` | List every EVM chain + RPC status + default marker | `clawmes/lib/chains.CHAINS` + `rpc_service.has_endpoint` |
| `/tools_list` | List clawmes tools from manifest | `plugin.yaml` `provides_tools` via `importlib.resources` |
| `/safety_status` | Show readonly / danger / normal mode | `mode_service.mode` |

## Design choices worth a review pass

1. **Why not in `/doctor`?** `/doctor` is *diagnostic* (what's broken / missing). These are *navigational* (what exists / available). Different surface, different audience. `/doctor` output isn't readable as a discovery tool, and a discovery tool isn't useful for triage.

2. **String-scanning YAML instead of pulling in `pyyaml`.** Frontmatter scan and `provides_tools` parse both use the same approach `clawmes/skills/__init__.py` already uses — keeps the import graph clean and avoids a hard `yaml` dep for this hot path. Same parse rigor the manifest sync test enforces.

3. **`importlib.resources` for the manifest read** — works whether clawmes is installed from a wheel (where the file is in the package data) or from a git checkout. Tested both paths.

4. **`/persona` is a read-only complement** to the 5 persona switchers landing in PR #4. They write; this reads. The two PRs are independent — if PR #4 doesn't land, `/persona` still works (it just shows the available choices without the slash-command paths).

5. **`/chains` shows `[rpc]` / `[no-rpc]` per chain.** A user running `/chains` is probably trying to figure out where their connected wallet can transact; the RPC marker answers that without a separate `/doctor` round-trip.

## Verification

- \`pytest tests/commands/test_discovery.py --cov=clawmes.commands.discovery\` → **22 tests pass, 100% line coverage**
- \`pytest --cov=clawmes\` → **2085 passing**, 8 skipped, 100% coverage gate satisfied
- \`ruff check clawmes tests\` → clean
- \`ruff format --check clawmes tests\` → clean

## Test plan covered

- [x] `/skills`: lists real bundled skills; handles empty dir; handles missing dir; tolerates unreadable SKILL.md; reads frontmatter description; no-frontmatter returns empty; long descriptions truncated; frontmatter end marker (`---`) handled
- [x] `/persona`: no active state → lists choices; with active → shows tagline
- [x] `/chains`: lists chains; default-chain marker present and on Base
- [x] `/tools_list`: lists real manifest tools; missing manifest → clear error; empty manifest → clear error
- [x] `_read_manifest_tools`: finds real manifest; tolerates resource failures; stops at next top-level key (doesn't bleed into `provides_hooks`)
- [x] `/safety_status`: normal / readonly / danger paths each render correctly
- [x] `register()` wires all 5 commands

## Notes for reviewers

- The frontmatter parser is intentionally narrow — it expects the literal `---` markers at column 0. Skills that ship with non-standard frontmatter just get an empty description in the listing rather than crashing.
- `_read_manifest_tools` returns `None` to signal "could not locate" versus `[]` for "manifest exists but no tools listed." `/tools_list` distinguishes the two with different error messages.
- Will need a trivial rebase against any of the other 6 open PRs since they all touch CHANGELOG + README counts.