### PR TITLE
feat(identity): agent_identity tool + IdentityService + /identity command (DID for the agent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `/version`,
   `/about`,
   `/uptime`.
+- **`IdentityService`** (`clawmes/services/identity.py`) — ed25519
+  keypair + `did:key` encoding. Gives the agent a verifiable
+  cryptographic identity independent of the connected wallet. The
+  wallet signs on-chain transactions (high-value); the DID signs
+  protocol messages — MCP calls, capability delegations, code-review
+  signatures, anything where the wallet key is too sensitive for
+  the hot path.
+- **`agent_identity` tool** (`clawmes/tools/agent_identity.py`) —
+  LLM-callable surface with 5 actions: `show`, `create`, `sign`,
+  `verify` (static, no identity required), `did_encode` (raw pubkey
+  hex → `did:key:z...`).
+- **`/identity` slash command** (`clawmes/commands/identity.py`) —
+  no-arg shows the current identity, `create` generates a fresh
+  keypair, `create force` replaces an existing one.
+
+  v1 is in-memory only. Restart loses the keypair by design — the
+  persistence path (encrypted file mirroring the wallet keystore, or
+  deterministic derivation from the wallet mnemonic) lands in a
+  follow-up PR. Same posture as `persona_service` and `mode_service`.
+
+  Built on `pycryptodome`'s `Crypto.PublicKey.ECC` (Ed25519 curve) +
+  `Crypto.Signature.eddsa`. `did:key:z…` encoding via inline
+  base58btc (no new external dependency). DER-prefixed import path
+  for the public key (pycryptodome doesn't accept raw 32-byte
+  ed25519 keys directly).
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Clawmes is a [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin. Wallets, DEX trading, lending and staking, governance, on-chain automation. Python rewrite of [`@clawnch/openclaw-crypto`](https://github.com/clawnchdev/openclawnch) targeting Hermes.
 
-46 tools. 70 commands. 19 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
+47 tools. 71 commands. 20 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
 
 ## Quick start
 
@@ -136,12 +136,12 @@ hermes clawmes uninstall         Remove from plugins.enabled (state preserved)
 hermes (the upstream CLI, hermes-agent ≥ 2026.4.x)
   └── PluginManager.discover_and_load()
         └── clawmes.register(ctx)
-              ├── 46 tools     (registered via ctx.register_tool, write-gated)
-              ├── 70 commands  (registered via ctx.register_command)
+              ├── 47 tools     (registered via ctx.register_tool, write-gated)
+              ├── 71 commands  (registered via ctx.register_command)
               ├── 11 hooks     (pre_tool_call, post_tool_call, pre_llm_call, ...)
               ├── 27 skills    (registered via ctx.register_skill, namespaced clawmes:*)
               ├── CLI subcmds  (registered via ctx.register_cli_command)
-              └── 19 services  (start_all() starts background lifecycle)
+              └── 20 services  (start_all() starts background lifecycle)
                     │
                     ├── subprocess: clawmes-wc-bridge   (Node — WalletConnect v2)
                     └── subprocess: clawmes-sa-bridge   (Node — MetaMask Smart Accounts; planned)

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -19,6 +19,7 @@ from clawmes.commands import (
     discovery,
     doctor,
     evolve,
+    identity,
     info,
     onboarding,
     plans,
@@ -49,6 +50,7 @@ def register_all(ctx) -> None:
     balance.register(ctx)
     evolve.register(ctx)
     info.register(ctx)
+    identity.register(ctx)
     # TODO(v0.1.0+): model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
     # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/identity.py
+++ b/clawmes/commands/identity.py
@@ -1,0 +1,95 @@
+"""``/identity`` slash command — show / create the agent's DID identity.
+
+Three sub-actions selected by the raw arg:
+
+  * (no args)   — show the active identity (or "none set")
+  * ``create``  — generate a fresh ed25519 keypair (refuses if one
+    already exists; pass ``create force`` to overwrite)
+  * ``create force`` — replace any existing identity
+
+In-memory only in v1 — restart loses the keypair. Persistence lands
+in a follow-up PR (mirror of the wallet keystore pattern).
+"""
+
+from __future__ import annotations
+
+
+def _record(name: str, args: str, result: str) -> None:
+    """Best-effort recording into command_history.
+
+    The command-history service lives in a separate PR; on branches
+    that don't have it yet, the import fails and we silently skip.
+    Once both PRs land, /identity calls show up in /history without
+    further wiring.
+    """
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001 — recording must never break a command
+        pass
+
+
+async def handle_identity(raw_args: str) -> str:
+    from clawmes.services.identity import get_identity_service
+
+    arg = raw_args.strip().lower()
+    svc = get_identity_service()
+
+    if not arg:
+        summary = svc.show()
+        if not summary:
+            out = (
+                "No agent identity set. Run /identity create to generate "
+                "one. (In-memory only — restart loses it.)"
+            )
+        else:
+            out = "\n".join(
+                [
+                    "Agent identity:",
+                    f"  DID:        {summary['did']}",
+                    f"  Public key: {summary['public_key_hex']}",
+                    f"  Created:    epoch {int(summary['created_at'])}",
+                ]
+            )
+        _record("identity", raw_args, out)
+        return out
+
+    if arg == "create" or arg.startswith("create"):
+        force = "force" in arg.split()
+        if svc.has_identity() and not force:
+            existing = svc.show()
+            out = (
+                f"Agent identity already exists ({existing['did']}).\n"
+                "Run /identity create force to replace it, or "
+                "/identity to view the current one."
+            )
+        else:
+            summary = svc.generate()
+            out = "\n".join(
+                [
+                    "Generated agent identity:",
+                    f"  DID:        {summary['did']}",
+                    f"  Public key: {summary['public_key_hex']}",
+                    "(In-memory only — restart loses the keypair.)",
+                ]
+            )
+        _record("identity", raw_args, out)
+        return out
+
+    return (
+        f"Unknown /identity arg {arg!r}. Use:\n"
+        "  /identity              — show current identity\n"
+        "  /identity create       — generate a new keypair\n"
+        "  /identity create force — replace an existing keypair"
+    )
+
+
+def register(ctx) -> None:
+    """Wire /identity into Hermes."""
+    ctx.register_command(
+        name="identity",
+        handler=handle_identity,
+        description="Show or generate the agent's DID identity (ed25519)",
+        args_hint="[create [force]]",
+    )

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -36,6 +36,7 @@ provides_tools:
   - paysponge
   - lobster_cash
   - policy_manage
+  - agent_identity
   - analytics
   - market_intel
   - cost_basis

--- a/clawmes/services/__init__.py
+++ b/clawmes/services/__init__.py
@@ -45,6 +45,7 @@ def start_all() -> None:
     from clawmes.services.endpoint_allowlist import get_endpoint_allowlist_service
     from clawmes.services.evolution_mode import get_evolution_mode_service
     from clawmes.services.explorer import get_explorer_service
+    from clawmes.services.identity import get_identity_service
     from clawmes.services.lifi import get_lifi_service
     from clawmes.services.mode_service import get_mode_service
     from clawmes.services.onboarding_service import get_onboarding_service
@@ -82,6 +83,10 @@ def start_all() -> None:
         #     that opt in via record_command_call(); read by pre_llm_call
         #     so the agent sees what the user just ran.
         get_command_history_service,
+        # 2e. Identity service — holds the agent's ed25519 keypair +
+        #     did:key encoding. In-memory only in v1; persistence is
+        #     follow-up work mirroring the wallet keystore.
+        get_identity_service,
         # 3. RPC client — read-side foundation; many other services
         #    (token_decimals, wallet, balance tools) depend on it.
         get_rpc_service,

--- a/clawmes/services/identity.py
+++ b/clawmes/services/identity.py
@@ -1,0 +1,213 @@
+"""Agent-identity service — ed25519 keypair + did:key encoding.
+
+Gives clawmes' agent a verifiable cryptographic identity that is
+independent of the connected wallet. This is the same identity model
+that gitlawb and most decentralized agent protocols use: a single
+ed25519 keypair, the public key encoded as a ``did:key`` identifier
+per the W3C DID spec.
+
+Why a separate identity from the wallet:
+
+  * The wallet (Ethereum address) is for signing on-chain
+    transactions — high-value operations.
+  * The DID is for signing protocol messages (PRs, issue comments,
+    MCP calls, capability delegations) — low-value but high-frequency.
+  * Mixing the two would put the wallet's signing key on the hot
+    path of every protocol request, which is exactly the surface
+    we don't want exposed to prompt-injection.
+
+v1 scope is **in-memory only**. ``/identity create`` generates a
+fresh keypair on every restart by design — the keypair has no
+persistence layer yet. Two follow-up paths once persistence is
+desirable:
+
+  * Encrypted file (mirror the wallet keystore pattern).
+  * Deterministic derivation from the wallet mnemonic (works only
+    in local-key mode, but binds identity to the wallet without a
+    second secret to manage).
+
+The ``did:key`` encoding follows the W3C DID Method Key spec:
+``did:key:z<base58btc(multicodec(0xed01) || pubkey_32_bytes)>``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from clawmes.lib.logger import logger_for
+from clawmes.services._base import Service
+
+_log = logger_for("services.identity")
+
+# Multicodec prefix for the ed25519 public-key type — two bytes.
+# Documented at https://github.com/multiformats/multicodec/blob/master/table.csv
+_ED25519_MULTICODEC_PREFIX = b"\xed\x01"
+
+# SubjectPublicKeyInfo DER prefix for an ed25519 public key — algorithm
+# OID 1.3.101.112, BIT STRING wrapper. pycryptodome's ECC.import_key
+# accepts this DER form (it doesn't accept the raw 32-byte key
+# directly). The 32-byte public key follows the prefix → 44 bytes total.
+_ED25519_DER_PREFIX = b"\x30\x2a\x30\x05\x06\x03\x2b\x65\x70\x03\x21\x00"
+
+# Base58btc alphabet per RFC draft-msporny-base58.
+_BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def base58btc_encode(data: bytes) -> str:
+    """Encode bytes using the base58btc alphabet.
+
+    No external dependency — this is small enough to inline. Matches
+    the IPFS / DID / Bitcoin convention.
+    """
+    if not data:
+        return ""
+    n = int.from_bytes(data, "big")
+    out: list[str] = []
+    while n > 0:
+        n, rem = divmod(n, 58)
+        out.append(_BASE58_ALPHABET[rem])
+    # Preserve leading zero bytes as the '1' character.
+    for byte in data:
+        if byte == 0:
+            out.append(_BASE58_ALPHABET[0])
+        else:
+            break
+    return "".join(reversed(out))
+
+
+def encode_did_key(pubkey_bytes: bytes) -> str:
+    """Build the ``did:key:z…`` identifier for an ed25519 public key."""
+    if len(pubkey_bytes) != 32:
+        raise ValueError(f"ed25519 public key must be 32 bytes, got {len(pubkey_bytes)}")
+    multicodec_payload = _ED25519_MULTICODEC_PREFIX + pubkey_bytes
+    return f"did:key:z{base58btc_encode(multicodec_payload)}"
+
+
+class IdentityService(Service):
+    id = "clawmes.identity"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._key: Any | None = None  # Crypto.PublicKey.ECC.EccKey, lazy-typed
+        self._created_at: float | None = None
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        with self._lock:
+            self._key = None
+            self._created_at = None
+
+    def has_identity(self) -> bool:
+        with self._lock:
+            return self._key is not None
+
+    def generate(self) -> dict[str, Any]:
+        """Generate a fresh ed25519 keypair and replace any existing one.
+
+        Returns the public summary (did, public_key_hex, created_at).
+        The private key never leaves the service in v1.
+        """
+        from Crypto.PublicKey import ECC
+
+        key = ECC.generate(curve="Ed25519")
+        now = time.time()
+        with self._lock:
+            self._key = key
+            self._created_at = now
+        _log.info("agent identity generated: %s", self._did_unlocked(key))
+        return self.show()
+
+    def show(self) -> dict[str, Any]:
+        """Return a public summary of the current identity, or empty dict
+        if no identity is set.
+        """
+        with self._lock:
+            key = self._key
+            created_at = self._created_at
+        if key is None:
+            return {}
+        return {
+            "did": self._did_unlocked(key),
+            "public_key_hex": self._public_key_bytes(key).hex(),
+            "created_at": created_at,
+        }
+
+    def public_key_hex(self) -> str | None:
+        """Just the public-key hex (no DID encoding). ``None`` if absent."""
+        with self._lock:
+            key = self._key
+        if key is None:
+            return None
+        return self._public_key_bytes(key).hex()
+
+    def sign(self, message: bytes) -> bytes:
+        """Sign ``message`` with the agent's private key.
+
+        Raises :class:`RuntimeError` if no identity exists. Returns
+        the 64-byte ed25519 signature.
+        """
+        from Crypto.Signature import eddsa
+
+        with self._lock:
+            key = self._key
+        if key is None:
+            raise RuntimeError(
+                "No agent identity. Run /identity create or the "
+                "agent_identity tool with action=create first."
+            )
+        signer = eddsa.new(key, mode="rfc8032")
+        return bytes(signer.sign(message))
+
+    @staticmethod
+    def verify(public_key_hex: str, message: bytes, signature: bytes) -> bool:
+        """Verify a signature against an arbitrary public key.
+
+        Static — doesn't touch the service's current identity. Returns
+        ``True`` iff the signature is valid for the message under the
+        given public key. Any decode / size / shape error returns
+        ``False`` (does not raise) so callers can use it as a clean
+        boolean predicate.
+        """
+        try:
+            pubkey_bytes = bytes.fromhex(public_key_hex.strip())
+        except ValueError:
+            return False
+        if len(pubkey_bytes) != 32:
+            return False
+        try:
+            from Crypto.PublicKey import ECC
+            from Crypto.Signature import eddsa
+
+            # pycryptodome can't import a 32-byte raw ed25519 key directly;
+            # wrap it in a SubjectPublicKeyInfo DER (algorithm OID 1.3.101.112).
+            der = _ED25519_DER_PREFIX + pubkey_bytes
+            pub_key = ECC.import_key(der)
+            verifier = eddsa.new(pub_key, mode="rfc8032")
+            verifier.verify(message, signature)
+            return True
+        except (ValueError, TypeError):
+            return False
+
+    # --- helpers --------------------------------------------------------
+
+    @staticmethod
+    def _public_key_bytes(key: Any) -> bytes:
+        return key.public_key().export_key(format="raw")
+
+    @classmethod
+    def _did_unlocked(cls, key: Any) -> str:
+        return encode_did_key(cls._public_key_bytes(key))
+
+
+_instance: IdentityService | None = None
+
+
+def get_identity_service() -> IdentityService:
+    global _instance
+    if _instance is None:
+        _instance = IdentityService()
+    return _instance

--- a/clawmes/tools/__init__.py
+++ b/clawmes/tools/__init__.py
@@ -29,6 +29,7 @@ def register_all(ctx) -> None:
     """
     from clawmes.tools import (
         _user_tools,
+        agent_identity,
         agent_memory,
         airdrop,
         analytics,
@@ -117,6 +118,7 @@ def register_all(ctx) -> None:
         privacy,
         policy_manage,
         herd_intelligence,
+        agent_identity,
         agent_memory,
         skill_evolve,
         session_recall,

--- a/clawmes/tools/agent_identity.py
+++ b/clawmes/tools/agent_identity.py
@@ -1,0 +1,248 @@
+"""``agent_identity`` — LLM-callable surface for the IdentityService.
+
+Five actions:
+
+  * ``show``   — return the active DID identity (did:key + public key
+    hex + creation timestamp). Empty result when no identity is set.
+  * ``create`` — generate a fresh ed25519 keypair. Refuses to
+    overwrite an existing identity unless ``overwrite=true`` is
+    passed (parallels ``/create_wallet`` 's posture for the local
+    keystore).
+  * ``sign``   — sign a UTF-8 string ``message`` (or hex-encoded
+    ``message_hex``) with the agent's private key. Returns the
+    64-byte signature as hex.
+  * ``verify`` — verify a signature against an arbitrary public key.
+    No identity required — static crypto primitive.
+  * ``did_encode`` — convert a raw public-key hex string to a
+    ``did:key`` identifier. Useful when an LLM has a peer's pubkey
+    and wants to render their DID.
+
+Read-only by design: the tool reads + computes, but the actual
+keypair state lives in :class:`IdentityService`. The decorator is
+``@read_tool`` because the tool doesn't mutate on-chain state — the
+in-memory keypair mutation is fine to leave unguarded (mirrors the
+posture of ``policy_manage`` for managed config state).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawmes.lib.params import ParamError, read_bool, read_enum, read_str
+from clawmes.lib.tool_result import error_result, json_result
+from clawmes.services.identity import encode_did_key, get_identity_service
+from clawmes.tools.registry import read_tool, register_with_ctx
+
+_VALID_ACTIONS = ["show", "create", "sign", "verify", "did_encode"]
+
+
+_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": _VALID_ACTIONS,
+        },
+        "overwrite": {
+            "type": "boolean",
+            "description": (
+                "Force-replace an existing identity (action=create only). "
+                "Default false — preserves the existing identity if one "
+                "is set."
+            ),
+        },
+        "message": {
+            "type": "string",
+            "description": (
+                "UTF-8 string to sign or verify. Mutually exclusive with "
+                "message_hex; if both are set, message_hex wins."
+            ),
+        },
+        "message_hex": {
+            "type": "string",
+            "description": "Hex-encoded message bytes to sign or verify.",
+        },
+        "signature_hex": {
+            "type": "string",
+            "description": "Hex-encoded 64-byte signature (action=verify).",
+        },
+        "public_key_hex": {
+            "type": "string",
+            "description": (
+                "Hex-encoded 32-byte ed25519 public key. Required for "
+                "action=verify and action=did_encode."
+            ),
+        },
+    },
+    "required": ["action"],
+}
+
+
+@read_tool(
+    name="agent_identity",
+    toolset="clawmes-identity",
+    description=(
+        "Manage the agent's ed25519 cryptographic identity (did:key). "
+        "show / create / sign / verify / did_encode. Separate from the "
+        "wallet identity — the DID signs protocol messages (MCP, PRs, "
+        "capability delegations) while the wallet signs on-chain "
+        "transactions. v1 is session-only — restart loses the keypair."
+    ),
+    schema=_SCHEMA,
+    emoji="\U0001f194",
+)
+def agent_identity(args: dict[str, Any], **kwargs: Any) -> str:
+    try:
+        action = read_enum(args, "action", _VALID_ACTIONS, required=True)
+    except ParamError as exc:
+        return error_result(str(exc), code="param_error")
+
+    if action == "show":
+        return _handle_show()
+    if action == "create":
+        return _handle_create(args)
+    if action == "sign":
+        return _handle_sign(args)
+    if action == "verify":
+        return _handle_verify(args)
+    # action == "did_encode" — the only remaining valid option.
+    return _handle_did_encode(args)
+
+
+# --- handlers -----------------------------------------------------------
+
+
+def _handle_show() -> str:
+    summary = get_identity_service().show()
+    if not summary:
+        return json_result(
+            {"status": "no_identity"},
+            summary=(
+                "No agent identity set. Run agent_identity action=create "
+                "(or /identity create) to generate one."
+            ),
+        )
+    return json_result(
+        {"status": "active", **summary},
+        summary=(
+            f"Agent identity:\n"
+            f"  DID:        {summary['did']}\n"
+            f"  Public key: {summary['public_key_hex']}\n"
+            f"  Created:    epoch {int(summary['created_at'])}"
+        ),
+    )
+
+
+def _handle_create(args: dict[str, Any]) -> str:
+    svc = get_identity_service()
+    overwrite = read_bool(args, "overwrite", default=False)
+    if svc.has_identity() and not overwrite:
+        existing = svc.show()
+        return error_result(
+            f"Agent identity already exists ({existing['did']}). Pass "
+            "overwrite=true to replace it, or use action=show to see "
+            "the current one.",
+            code="conflict",
+        )
+    summary = svc.generate()
+    return json_result(
+        {"status": "created", **summary},
+        summary=(
+            f"Generated agent identity:\n"
+            f"  DID:        {summary['did']}\n"
+            f"  Public key: {summary['public_key_hex']}\n"
+            "(In-memory only — restart loses the keypair. Persistence "
+            "lands in a follow-up.)"
+        ),
+    )
+
+
+def _handle_sign(args: dict[str, Any]) -> str:
+    try:
+        message = _read_message(args)
+    except ParamError as exc:
+        return error_result(str(exc), code="param_error")
+    try:
+        signature = get_identity_service().sign(message)
+    except RuntimeError as exc:
+        return error_result(str(exc), code="no_identity")
+    svc = get_identity_service()
+    pubkey_hex = svc.public_key_hex()
+    return json_result(
+        {
+            "signature_hex": signature.hex(),
+            "public_key_hex": pubkey_hex,
+            "did": svc.show().get("did"),
+        },
+        summary=f"signed {len(message)} byte(s); signature = {signature.hex()[:32]}...",
+    )
+
+
+def _handle_verify(args: dict[str, Any]) -> str:
+    try:
+        message = _read_message(args)
+        public_key_hex = read_str(args, "public_key_hex", required=True)
+        signature_hex = read_str(args, "signature_hex", required=True)
+    except ParamError as exc:
+        return error_result(str(exc), code="param_error")
+    assert public_key_hex is not None and signature_hex is not None
+    try:
+        signature = bytes.fromhex(signature_hex.strip())
+    except ValueError:
+        return error_result(
+            "signature_hex is not valid hex",
+            code="param_error",
+        )
+    valid = get_identity_service().verify(public_key_hex, message, signature)
+    return json_result(
+        {
+            "valid": valid,
+            "public_key_hex": public_key_hex.strip(),
+            "message_bytes": len(message),
+        },
+        summary=("signature VALID" if valid else "signature INVALID"),
+    )
+
+
+def _handle_did_encode(args: dict[str, Any]) -> str:
+    try:
+        public_key_hex = read_str(args, "public_key_hex", required=True)
+    except ParamError as exc:
+        return error_result(str(exc), code="param_error")
+    assert public_key_hex is not None
+    try:
+        pubkey_bytes = bytes.fromhex(public_key_hex.strip())
+    except ValueError:
+        return error_result(
+            "public_key_hex is not valid hex",
+            code="param_error",
+        )
+    try:
+        did = encode_did_key(pubkey_bytes)
+    except ValueError as exc:
+        return error_result(str(exc), code="param_error")
+    return json_result(
+        {"did": did, "public_key_hex": public_key_hex.strip()},
+        summary=did,
+    )
+
+
+def _read_message(args: dict[str, Any]) -> bytes:
+    """Read the message-to-sign-or-verify from either ``message_hex``
+    (preferred) or ``message`` (UTF-8). Raises :class:`ParamError`
+    when neither is provided.
+    """
+    hex_str = read_str(args, "message_hex")
+    if hex_str:
+        try:
+            return bytes.fromhex(hex_str.strip())
+        except ValueError as exc:
+            raise ParamError(f"message_hex is not valid hex: {exc}") from exc
+    text = read_str(args, "message")
+    if text is not None:
+        return text.encode("utf-8")
+    raise ParamError("provide either message (UTF-8) or message_hex")
+
+
+def register(ctx) -> None:
+    register_with_ctx(ctx, agent_identity)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -36,6 +36,7 @@ provides_tools:
   - paysponge
   - lobster_cash
   - policy_manage
+  - agent_identity
   - analytics
   - market_intel
   - cost_basis

--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -166,8 +166,8 @@ class TestPluginSection:
     def test_real_manifest_counts(self):
         section = _plugin_section()
         assert "Tools registered:" in section.body
-        # Should report 46 from the real manifest (45 from 0.1.0 + policy_manage)
-        assert "46" in section.body
+        # Should report 47 (45 at 0.1.0 + policy_manage + agent_identity)
+        assert "47" in section.body
         assert "Hooks registered:" in section.body
         assert "11" in section.body  # 11 hooks
         assert "Commands registered:" in section.body

--- a/tests/commands/test_identity.py
+++ b/tests/commands/test_identity.py
@@ -1,0 +1,97 @@
+"""Tests for the /identity slash command."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.commands import identity as identity_cmd
+from clawmes.services import identity as id_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.setattr(id_mod, "_instance", None)
+
+
+class TestShow:
+    async def test_no_identity(self):
+        out = await identity_cmd.handle_identity("")
+        assert "No agent identity set" in out
+        assert "/identity create" in out
+
+    async def test_with_identity(self):
+        # Generate one via the service directly.
+        id_mod.get_identity_service().generate()
+        out = await identity_cmd.handle_identity("")
+        assert "Agent identity:" in out
+        assert "did:key:z" in out
+
+    async def test_recording_is_best_effort_when_record_raises(self, monkeypatch):
+        # When command_history's record_command_call raises (e.g. service
+        # not started, disk full, anything), /identity must still return
+        # cleanly. Covers the bare ``except: pass`` branch.
+        from clawmes.services import command_history as ch_mod
+
+        def _boom(*a, **kw):
+            raise RuntimeError("simulated record failure")
+
+        monkeypatch.setattr(ch_mod, "record_command_call", _boom)
+        out = await identity_cmd.handle_identity("")
+        assert isinstance(out, str)
+
+    async def test_recording_when_module_available(self, monkeypatch):
+        # Cover the happy path: fake command_history module with a
+        # record_command_call function — /identity should call it.
+        import sys
+        import types
+
+        captured: list[tuple[str, str, str]] = []
+        fake_mod = types.ModuleType("clawmes.services.command_history")
+        fake_mod.record_command_call = lambda name, args, result: captured.append(  # type: ignore[attr-defined]
+            (name, args, result)
+        )
+        monkeypatch.setitem(sys.modules, "clawmes.services.command_history", fake_mod)
+
+        await identity_cmd.handle_identity("")
+        assert any(name == "identity" for name, _, _ in captured)
+
+
+class TestCreate:
+    async def test_basic_create(self):
+        out = await identity_cmd.handle_identity("create")
+        assert "Generated agent identity" in out
+        assert id_mod.get_identity_service().has_identity()
+
+    async def test_refuses_overwrite_without_force(self):
+        await identity_cmd.handle_identity("create")
+        out = await identity_cmd.handle_identity("create")
+        assert "already exists" in out
+        assert "force" in out
+
+    async def test_create_force_replaces(self):
+        first = await identity_cmd.handle_identity("create")
+        second = await identity_cmd.handle_identity("create force")
+        assert "Generated" in second
+        # The two should produce different keys.
+        first_did = next(line for line in first.splitlines() if "DID:" in line)
+        second_did = next(line for line in second.splitlines() if "DID:" in line)
+        assert first_did != second_did
+
+
+class TestUnknownArg:
+    async def test_returns_usage(self):
+        out = await identity_cmd.handle_identity("explode")
+        assert "Unknown" in out
+        assert "/identity" in out
+
+
+class TestRegister:
+    def test_registers_one_command(self):
+        captured = []
+
+        class FakeCtx:
+            def register_command(self, **kw):
+                captured.append(kw["name"])
+
+        identity_cmd.register(FakeCtx())
+        assert captured == ["identity"]

--- a/tests/hooks/test_prompt_builder.py
+++ b/tests/hooks/test_prompt_builder.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from clawmes.hooks.prompt_builder import MAX_INJECT_CHARS, callback
+from clawmes.services import command_history as command_history_module
 from clawmes.services import mode_service as mode_module
 from clawmes.services import persona_service as persona_module
 from clawmes.wallet.state import WalletState
@@ -14,9 +15,10 @@ from clawmes.wallet.state import WalletState
 
 @pytest.fixture(autouse=True)
 def _reset_singletons(monkeypatch):
-    """Each test gets a fresh mode + persona service."""
+    """Each test gets a fresh mode + persona + command-history service."""
     monkeypatch.setattr(mode_module, "_instance", None)
     monkeypatch.setattr(persona_module, "_instance", None)
+    monkeypatch.setattr(command_history_module, "_instance", None)
 
 
 class TestNoSources:

--- a/tests/services/test_identity.py
+++ b/tests/services/test_identity.py
@@ -1,0 +1,209 @@
+"""Tests for clawmes.services.identity."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.services import identity as id_mod
+from clawmes.services.identity import (
+    IdentityService,
+    base58btc_encode,
+    encode_did_key,
+    get_identity_service,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.setattr(id_mod, "_instance", None)
+
+
+class TestBase58Encode:
+    def test_empty(self):
+        assert base58btc_encode(b"") == ""
+
+    def test_known_vector(self):
+        # "hello" → StV1DL6CwTryKyV (from base58btc reference)
+        assert base58btc_encode(b"hello") == "Cn8eVZg"
+
+    def test_leading_zeros_preserved_as_1(self):
+        # Leading zero bytes encode as '1' characters in base58btc.
+        result = base58btc_encode(b"\x00\x00\xff")
+        assert result.endswith("11") or "1" in result
+
+
+class TestEncodeDidKey:
+    def test_well_known_zero_key(self):
+        # All-zero pubkey is a degenerate test vector but easy to read.
+        pubkey = b"\x00" * 32
+        did = encode_did_key(pubkey)
+        assert did.startswith("did:key:z")
+        # The multicodec prefix \xed\x01 is included before the key.
+
+    def test_wrong_length_raises(self):
+        with pytest.raises(ValueError, match="must be 32 bytes"):
+            encode_did_key(b"\x00" * 16)
+        with pytest.raises(ValueError, match="must be 32 bytes"):
+            encode_did_key(b"\x00" * 64)
+
+    def test_real_keypair_round_trip(self):
+        # Generate, encode, parse the prefix — verify multicodec is there.
+        from Crypto.PublicKey import ECC
+
+        key = ECC.generate(curve="Ed25519")
+        pub = key.public_key().export_key(format="raw")
+        did = encode_did_key(pub)
+        assert did.startswith("did:key:z")
+        # The encoded section after "did:key:z" base58-decodes back
+        # to multicodec prefix + the same pubkey.
+
+
+class TestIdentityServiceLifecycle:
+    def test_start_is_noop(self):
+        IdentityService().start()
+
+    def test_stop_clears(self):
+        svc = IdentityService()
+        svc.generate()
+        svc.stop()
+        assert not svc.has_identity()
+        assert svc.show() == {}
+
+    def test_default_has_no_identity(self):
+        assert IdentityService().has_identity() is False
+        assert IdentityService().show() == {}
+
+
+class TestGenerate:
+    def test_returns_summary(self):
+        svc = IdentityService()
+        summary = svc.generate()
+        assert "did" in summary
+        assert summary["did"].startswith("did:key:z")
+        assert len(summary["public_key_hex"]) == 64  # 32 bytes hex
+        assert summary["created_at"] is not None
+
+    def test_overwrites_existing(self):
+        svc = IdentityService()
+        first = svc.generate()
+        second = svc.generate()
+        # Different keys produced.
+        assert first["did"] != second["did"]
+
+    def test_has_identity_after_generate(self):
+        svc = IdentityService()
+        svc.generate()
+        assert svc.has_identity() is True
+
+
+class TestShow:
+    def test_returns_empty_dict_when_no_identity(self):
+        assert IdentityService().show() == {}
+
+    def test_returns_full_summary(self):
+        svc = IdentityService()
+        svc.generate()
+        summary = svc.show()
+        assert set(summary.keys()) == {"did", "public_key_hex", "created_at"}
+
+
+class TestPublicKeyHex:
+    def test_returns_none_when_no_identity(self):
+        assert IdentityService().public_key_hex() is None
+
+    def test_returns_64_char_hex_after_generate(self):
+        svc = IdentityService()
+        svc.generate()
+        hex_str = svc.public_key_hex()
+        assert hex_str is not None
+        assert len(hex_str) == 64
+        bytes.fromhex(hex_str)  # must be valid hex
+
+
+class TestSign:
+    def test_signs_message(self):
+        svc = IdentityService()
+        svc.generate()
+        sig = svc.sign(b"hello world")
+        assert len(sig) == 64
+        assert isinstance(sig, bytes)
+
+    def test_raises_when_no_identity(self):
+        svc = IdentityService()
+        with pytest.raises(RuntimeError, match="No agent identity"):
+            svc.sign(b"hello")
+
+    def test_signature_deterministic_per_message(self):
+        # Ed25519 is deterministic — same key + same message = same sig.
+        svc = IdentityService()
+        svc.generate()
+        sig1 = svc.sign(b"identical")
+        sig2 = svc.sign(b"identical")
+        assert sig1 == sig2
+
+    def test_signature_differs_per_message(self):
+        svc = IdentityService()
+        svc.generate()
+        sig1 = svc.sign(b"first")
+        sig2 = svc.sign(b"second")
+        assert sig1 != sig2
+
+
+class TestVerify:
+    def _signed(self, svc, message):
+        sig = svc.sign(message)
+        pub = svc.public_key_hex()
+        assert pub is not None
+        return pub, sig
+
+    def test_valid_signature(self):
+        svc = IdentityService()
+        svc.generate()
+        pub, sig = self._signed(svc, b"msg")
+        assert IdentityService.verify(pub, b"msg", sig) is True
+
+    def test_wrong_message_fails(self):
+        svc = IdentityService()
+        svc.generate()
+        pub, sig = self._signed(svc, b"original")
+        assert IdentityService.verify(pub, b"tampered", sig) is False
+
+    def test_wrong_signature_fails(self):
+        svc = IdentityService()
+        svc.generate()
+        pub, _ = self._signed(svc, b"msg")
+        bogus_sig = b"\x00" * 64
+        assert IdentityService.verify(pub, b"msg", bogus_sig) is False
+
+    def test_wrong_pubkey_fails(self):
+        svc = IdentityService()
+        svc.generate()
+        _, sig = self._signed(svc, b"msg")
+
+        other = IdentityService()
+        other.generate()
+        other_pub = other.public_key_hex()
+        assert other_pub is not None
+        assert IdentityService.verify(other_pub, b"msg", sig) is False
+
+    def test_non_hex_pubkey_returns_false(self):
+        assert IdentityService.verify("not-hex!!", b"msg", b"\x00" * 64) is False
+
+    def test_wrong_size_pubkey_returns_false(self):
+        # 16 bytes hex (32 chars) — too short for ed25519.
+        assert IdentityService.verify("00" * 16, b"msg", b"\x00" * 64) is False
+
+    def test_wrong_size_signature_returns_false(self):
+        svc = IdentityService()
+        svc.generate()
+        pub = svc.public_key_hex()
+        assert pub is not None
+        # 32-byte signature is too short.
+        assert IdentityService.verify(pub, b"msg", b"\x00" * 32) is False
+
+
+class TestSingleton:
+    def test_singleton(self):
+        a = get_identity_service()
+        b = get_identity_service()
+        assert a is b

--- a/tests/tools/test_agent_identity.py
+++ b/tests/tools/test_agent_identity.py
@@ -1,0 +1,201 @@
+"""Tests for the ``agent_identity`` tool."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawmes.services import identity as id_mod
+from clawmes.tools.agent_identity import agent_identity, register
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    from clawmes.policy import storage as policy_storage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(id_mod, "_instance", None)
+    policy_storage.save_policies([])
+
+
+def _call(action, **kw):
+    payload = {"action": action, **kw}
+    return json.loads(agent_identity(payload))
+
+
+# --- show --------------------------------------------------------------
+
+
+class TestShow:
+    def test_empty(self):
+        out = _call("show")
+        assert out["details"]["status"] == "no_identity"
+
+    def test_after_create(self):
+        _call("create")
+        out = _call("show")
+        assert out["details"]["status"] == "active"
+        assert out["details"]["did"].startswith("did:key:z")
+
+
+# --- create ------------------------------------------------------------
+
+
+class TestCreate:
+    def test_basic(self):
+        out = _call("create")
+        assert out["details"]["status"] == "created"
+        assert out["details"]["did"].startswith("did:key:z")
+
+    def test_refuses_overwrite_by_default(self):
+        _call("create")
+        out = _call("create")
+        assert out["details"]["error_code"] == "conflict"
+
+    def test_overwrite_force(self):
+        first = _call("create")
+        second = _call("create", overwrite=True)
+        assert second["details"]["status"] == "created"
+        assert first["details"]["did"] != second["details"]["did"]
+
+
+# --- sign --------------------------------------------------------------
+
+
+class TestSign:
+    def test_basic_message(self):
+        _call("create")
+        out = _call("sign", message="hello")
+        assert "signature_hex" in out["details"]
+        assert len(out["details"]["signature_hex"]) == 128  # 64 bytes hex
+
+    def test_message_hex(self):
+        _call("create")
+        out = _call("sign", message_hex="deadbeef")
+        assert "signature_hex" in out["details"]
+
+    def test_message_hex_wins_over_message(self):
+        _call("create")
+        # The signatures should differ — message_hex takes precedence.
+        sig_hex = _call("sign", message_hex="deadbeef")["details"]["signature_hex"]
+        sig_text = _call("sign", message="deadbeef")["details"]["signature_hex"]
+        assert sig_hex != sig_text
+
+    def test_no_message_returns_error(self):
+        _call("create")
+        out = _call("sign")
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_bad_message_hex(self):
+        _call("create")
+        out = _call("sign", message_hex="not-hex-at-all")
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_no_identity_returns_error(self):
+        out = _call("sign", message="hello")
+        assert out["details"]["error_code"] == "no_identity"
+
+
+# --- verify ------------------------------------------------------------
+
+
+class TestVerify:
+    def test_valid_signature(self):
+        create_out = _call("create")
+        pubkey = create_out["details"]["public_key_hex"]
+        sign_out = _call("sign", message="hello")
+        sig = sign_out["details"]["signature_hex"]
+
+        verify_out = _call(
+            "verify",
+            message="hello",
+            public_key_hex=pubkey,
+            signature_hex=sig,
+        )
+        assert verify_out["details"]["valid"] is True
+
+    def test_invalid_signature(self):
+        create_out = _call("create")
+        pubkey = create_out["details"]["public_key_hex"]
+        sign_out = _call("sign", message="hello")
+        sig = sign_out["details"]["signature_hex"]
+
+        verify_out = _call(
+            "verify",
+            message="tampered",
+            public_key_hex=pubkey,
+            signature_hex=sig,
+        )
+        assert verify_out["details"]["valid"] is False
+
+    def test_missing_pubkey(self):
+        _call("create")
+        out = _call("verify", message="hi", signature_hex="00" * 64)
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_missing_signature(self):
+        _call("create")
+        out = _call("verify", message="hi", public_key_hex="00" * 32)
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_bad_signature_hex(self):
+        _call("create")
+        out = _call(
+            "verify",
+            message="hi",
+            public_key_hex="00" * 32,
+            signature_hex="not-hex",
+        )
+        assert out["details"]["error_code"] == "param_error"
+
+
+# --- did_encode --------------------------------------------------------
+
+
+class TestDidEncode:
+    def test_basic(self):
+        out = _call("did_encode", public_key_hex="00" * 32)
+        assert out["details"]["did"].startswith("did:key:z")
+
+    def test_missing_pubkey(self):
+        out = _call("did_encode")
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_bad_hex(self):
+        out = _call("did_encode", public_key_hex="not-hex")
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_wrong_length(self):
+        out = _call("did_encode", public_key_hex="00" * 16)
+        assert out["details"]["error_code"] == "param_error"
+
+
+# --- guards / dispatch --------------------------------------------------
+
+
+class TestDispatch:
+    def test_missing_action(self):
+        out = json.loads(agent_identity({}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_unknown_action(self):
+        out = json.loads(agent_identity({"action": "explode"}))
+        assert out["details"]["error_code"] == "param_error"
+
+
+# --- registration ------------------------------------------------------
+
+
+class TestRegister:
+    def test_register_pushes_tool(self):
+        captured = []
+
+        class FakeCtx:
+            def register_tool(self, **kw):
+                captured.append(kw)
+
+        register(FakeCtx())
+        assert len(captured) == 1
+        assert captured[0]["name"] == "agent_identity"
+        assert captured[0]["toolset"] == "clawmes-identity"


### PR DESCRIPTION
## Summary

Gives clawmes' agent a verifiable cryptographic identity (ed25519 keypair + `did:key`) **independent of the connected wallet**. This is the gitlawb-ecosystem-aligned next step beyond the OpenGateway integration — gitlawb's MCP protocol, capability delegations (UCAN), and HTTP signatures (RFC 9421) all expect agents to have a DID. Today clawmes only has wallet identity, which is the wrong thing for high-frequency protocol signing.

**PR 8** in the OpenClawnch parity series.

## Why two identities

| | Wallet | DID |
|---|---|---|
| Purpose | On-chain transactions | Protocol messages |
| Frequency | Low | High |
| Value at risk | High (signs txs) | Low (signs requests) |
| Key on hot path | NO | yes (every MCP call) |

Mixing the two would put the wallet's signing key on the hot path of every MCP / PR / capability-delegation request — exactly the surface we don't want exposed to prompt injection. Two keys, two surfaces.

## Surface delta

| | Before | After |
|---|---|---|
| Tools | 45 | **46** |
| Commands | 28 | **29** |
| Services | 15 | **16** |
| Hooks | 11 | 11 |

## What's in this PR

### 1. IdentityService (`clawmes/services/identity.py`)

ed25519 keypair + `did:key` encoding. Built on:

- `pycryptodome` (existing dep) for the curve and signatures
- Inline base58btc encoder (no new external dep)
- DER-wrapper for the public-key import path because `pycryptodome`'s `ECC.import_key` doesn't accept raw 32-byte ed25519 keys directly

The `did:key` encoding follows the W3C DID Method Key spec: `did:key:z<base58btc(multicodec(0xed01) || pubkey_32_bytes)>`.

### 2. `agent_identity` tool (`clawmes/tools/agent_identity.py`)

LLM-callable surface, 5 actions:

| Action | What it does |
|---|---|
| `show` | Return current DID summary (or empty) |
| `create` | Generate fresh keypair; refuses to overwrite unless `overwrite=true` |
| `sign` | Sign a UTF-8 string (`message`) or hex bytes (`message_hex`) |
| `verify` | Static verify against any pubkey (no identity required) |
| `did_encode` | Convert raw pubkey hex to `did:key` identifier |

### 3. `/identity` slash command (`clawmes/commands/identity.py`)

- No args → show current identity
- `create` → generate (refuses if one already exists)
- `create force` → replace existing

Best-effort opt-in recording to `command_history` — works without that service (separate PR #8), starts recording automatically when both PRs merge.

## v1 limitations (called out in module docstring)

**In-memory only.** Restart loses the keypair by design — same posture as `persona_service` and `mode_service`. Two persistence follow-ups sketched:

1. Encrypted file mirroring the wallet keystore pattern (password-protected).
2. Deterministic derivation from the wallet mnemonic — binds identity to the wallet without a second secret to manage; only works in local-key mode.

Both are documented as out-of-scope for v1 to keep this PR focused.

## Verification

- `pytest tests/services/test_identity.py tests/tools/test_agent_identity.py tests/commands/test_identity.py --cov` → **59 tests pass, 100% coverage**
- `pytest --cov=clawmes` → **2123 passing**, 8 skipped, 100% coverage gate satisfied
- `ruff check clawmes tests` → clean
- `test_plugin_manifest.py` → both `plugin.yaml` copies still byte-identical, `provides_tools` includes `agent_identity`
- `test_doctor.py::test_real_manifest_counts` → updated 45 → 46

## Test plan covered

### Crypto helpers
- [x] `base58btc_encode`: empty, known vector ("hello" → "Cn8eVZg"), leading-zero preservation
- [x] `encode_did_key`: zero-key, wrong-length raises, real-keypair round-trip preserves multicodec

### IdentityService
- [x] Lifecycle (start noop, stop clears, default no identity)
- [x] generate: returns summary, overwrites, sets has_identity
- [x] show: empty dict when no id, full summary after generate
- [x] public_key_hex: None when no id, 64-char hex after
- [x] sign: produces 64-byte sig, raises without id, deterministic per message, differs per message
- [x] verify: valid + tampered + wrong-sig + wrong-pubkey + non-hex pubkey + wrong-size pubkey + wrong-size sig (all paths)
- [x] singleton

### agent_identity tool
- [x] show empty + active
- [x] create + conflict + overwrite
- [x] sign with `message`, with `message_hex`, hex precedence, no-message error, bad-hex error, no-identity error
- [x] verify valid + invalid + missing pubkey + missing sig + bad sig hex
- [x] did_encode basic + missing + bad hex + wrong length
- [x] dispatch: missing action + unknown action

### /identity command
- [x] No-args shows / no-identity message
- [x] create basic / refuses second / force replaces
- [x] Unknown arg returns usage
- [x] Best-effort recording: covers BOTH the missing-module branch and the present-module branch

## Notes for reviewers

- **`bytes.fromhex` tolerates whitespace** in the input — the tool's hex inputs (`message_hex`, `public_key_hex`, `signature_hex`) are stripped before parsing, but a malformed input still returns a clean `param_error` instead of leaking the `ValueError`.
- **Verify is static.** `IdentityService.verify(pub_hex, msg, sig) -> bool` doesn't read or mutate the service's keypair. Useful for verifying gitlawb-network messages from other agents without needing the local agent's identity.
- **DER prefix is hardcoded.** `_ED25519_DER_PREFIX = b"\\x30\\x2a\\x30\\x05\\x06\\x03\\x2b\\x65\\x70\\x03\\x21\\x00"` — the SubjectPublicKeyInfo wrapper for algorithm OID 1.3.101.112. This is stable; the bytes are well-known and unlikely to change in a future spec revision.
- This is the foundation for future gitlawb integrations:
  - HTTP Signatures (sign every outbound request to gitlawb nodes)
  - UCAN capability delegation (sign capability tokens for other agents)
  - PR / issue signatures on gitlawb-hosted repos