### PR TITLE
feat(agent-economy): BV-7X + A2A protocol + EAS attestations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,41 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   for the public key (pycryptodome doesn't accept raw 32-byte
   ed25519 keys directly).
 
+### Added — agent-economy integration (BV-7X / A2A / EAS)
+
+- **`bv7x` tool** (`clawmes/tools/bv7x.py`) + **`BV7XService`**
+  (`clawmes/services/bv7x.py`) — read BV-7X autonomous BTC oracle data
+  via their public REST API. Three actions: `regime` (BTC market
+  regime classification: CRISIS / BEAR / NEUTRAL / BULL / EUPHORIA),
+  `identity` (BV-7X's ERC-8004 agent identity + reputation),
+  `discover` (A2A discovery card). 60-second cache. Token-gated
+  premium endpoints (`/oracle`, `/copy-trade`) are NOT exposed —
+  clawmes does not require third-party token holdings.
+- **`a2a_call` tool** (`clawmes/tools/a2a_call.py`) — generic
+  agent-to-agent JSON-RPC 2.0 client. `discover` fetches a peer's
+  AgentCard at `/.well-known/agent-card.json`; `send_task` posts
+  JSON-RPC 2.0 tasks (default path `/api/bv7x/a2a/tasks/send`,
+  configurable). Works with any A2A-speaking peer; tested against
+  BV-7X. Auth via DID signatures (RFC 9421) is deferred to a
+  follow-up that pairs with the IdentityService.
+- **`eas_attestation` tool** (`clawmes/tools/eas_attestation.py`) —
+  read EAS attestations on Base. `get` fetches by 32-byte UID,
+  decoded into the canonical Attestation struct (uid, schema, time,
+  recipient, attester, data, etc.). `decode_data` parses the raw
+  bytes payload against a caller-supplied ABI schema. Generic
+  on-chain primitive — useful for BV-7X signal attestations, trust
+  scores, KYC certificates, and any EAS-using protocol. Default
+  contract is the canonical EAS singleton on Base
+  (`0x4200…0021`); overridable via `eas_address` for other L2s.
+- `bv7x.ai` added to `clawmes/lib/http.py` allowlist.
+
+### Deferred
+
+- **ERC-8004 agent registry integration.** The spec is currently a
+  draft EIP (Created 2025-08-13) with no canonical Base-singleton
+  address yet. We'll wire this in once the spec finalizes and a
+  registry singleton lands.
+
 ### Documentation
 
 - README "Using OpenGateway as your LLM provider" section documents

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Clawmes is a [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin. Wallets, DEX trading, lending and staking, governance, on-chain automation. Python rewrite of [`@clawnch/openclaw-crypto`](https://github.com/clawnchdev/openclawnch) targeting Hermes.
 
-47 tools. 71 commands. 20 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
+50 tools. 71 commands. 21 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
 
 ## Quick start
 
@@ -136,12 +136,12 @@ hermes clawmes uninstall         Remove from plugins.enabled (state preserved)
 hermes (the upstream CLI, hermes-agent ≥ 2026.4.x)
   └── PluginManager.discover_and_load()
         └── clawmes.register(ctx)
-              ├── 47 tools     (registered via ctx.register_tool, write-gated)
+              ├── 50 tools     (registered via ctx.register_tool, write-gated)
               ├── 71 commands  (registered via ctx.register_command)
               ├── 11 hooks     (pre_tool_call, post_tool_call, pre_llm_call, ...)
               ├── 27 skills    (registered via ctx.register_skill, namespaced clawmes:*)
               ├── CLI subcmds  (registered via ctx.register_cli_command)
-              └── 20 services  (start_all() starts background lifecycle)
+              └── 21 services  (start_all() starts background lifecycle)
                     │
                     ├── subprocess: clawmes-wc-bridge   (Node — WalletConnect v2)
                     └── subprocess: clawmes-sa-bridge   (Node — MetaMask Smart Accounts; planned)

--- a/clawmes/lib/http.py
+++ b/clawmes/lib/http.py
@@ -92,6 +92,10 @@ _DEFAULT_ALLOWLIST: frozenset[str] = frozenset(
         "llm.bankr.bot",
         # LLM inference gateway (gitlawb opengateway — see services.opengateway)
         "opengateway.gitlawb.com",
+        # Agent-economy peers — see services.bv7x and the A2A protocol
+        # support in tools.a2a_call. bv7x.ai exposes a JSON-RPC 2.0 A2A
+        # endpoint as well as a public REST oracle.
+        "bv7x.ai",
         # Simulation
         "api.tenderly.co",
         # Fiat ramps

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -37,6 +37,9 @@ provides_tools:
   - lobster_cash
   - policy_manage
   - agent_identity
+  - bv7x
+  - eas_attestation
+  - a2a_call
   - analytics
   - market_intel
   - cost_basis

--- a/clawmes/services/__init__.py
+++ b/clawmes/services/__init__.py
@@ -39,6 +39,7 @@ def start_all() -> None:
     """
     from clawmes.plans.scheduler import get_scheduler
     from clawmes.services.bankr_service import get_bankr_service
+    from clawmes.services.bv7x import get_bv7x_service
     from clawmes.services.coingecko import get_coingecko_service
     from clawmes.services.command_history import get_command_history_service
     from clawmes.services.credential_redactor import get_credential_redactor
@@ -109,6 +110,10 @@ def start_all() -> None:
         get_zerox_service,
         # 6c. LiFi cross-chain bridge aggregator. Same shape as 0x.
         get_lifi_service,
+        # 6e. BV-7X autonomous BTC oracle (public REST API).
+        #     Daily signal, regime, ETF flows, agent identity. The
+        #     token-gated premium endpoints are deliberately NOT wired.
+        get_bv7x_service,
         # 6d. OpenAI-compatible LLM gateway (gitlawb opengateway). Used
         #     by tools that need targeted inference outside the host
         #     Hermes agent loop. Independent from Hermes' main LLM —

--- a/clawmes/services/bv7x.py
+++ b/clawmes/services/bv7x.py
@@ -1,0 +1,136 @@
+"""BV-7X public REST oracle client.
+
+BV-7X is an autonomous Bitcoin signal oracle that publishes daily
+predictions (signal at 21:35 UTC), creates EAS attestations on Base,
+and operates a Polymarket wager bot. We wrap their public REST
+endpoints — the token-gated premium endpoints (Oracle, Copy-Trade)
+are intentionally NOT exposed here. Users who hold ``$BV7X`` and want
+those can hit the endpoints directly with their own credentials.
+
+Public endpoints covered:
+
+  * ``GET /api/bv7x/regime`` — current market regime + thresholds.
+  * ``GET /api/bv7x/agent/identity`` — ERC-8004 agent identity + reputation.
+  * ``GET /api/bv7x/a2a/discover`` — A2A discovery card (skill list).
+
+Why a service vs. just inlining HTTP calls: the bv7x oracle publishes
+daily — a service lets us cache the regime and identity results across
+multiple tool calls in the same agent turn without hammering the
+upstream. Cache TTL defaults to 60s.
+
+Skip:
+  * ``/oracle`` / ``/oracle/premium`` / ``/copy-trade/*`` — token-gated.
+    We refuse to bake clawmes dependencies on third-party token
+    holdings.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from clawmes.lib.http import http_get
+from clawmes.lib.logger import logger_for
+from clawmes.services._base import Service
+
+_log = logger_for("services.bv7x")
+
+_BASE_URL = "https://bv7x.ai"
+_DEFAULT_TTL_SECONDS = 60
+
+
+class BV7XError(RuntimeError):
+    """Raised on BV-7X API failures.
+
+    ``code`` classification:
+      * ``rate_limited`` — HTTP 429.
+      * ``not_found``    — HTTP 404 (e.g. unknown attestation UID).
+      * ``token_gated``  — endpoint requires $BV7X holdings; we don't
+        attempt these but surface a clear error if a caller tries.
+      * ``api_error``    — generic upstream failure.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class BV7XService(Service):
+    id = "clawmes.bv7x"
+
+    def __init__(self, *, ttl_seconds: int = _DEFAULT_TTL_SECONDS) -> None:
+        self._lock = threading.RLock()
+        self._ttl = ttl_seconds
+        self._cache: dict[str, tuple[float, Any]] = {}
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        with self._lock:
+            self._cache.clear()
+
+    def get_regime(self) -> dict[str, Any]:
+        """Return current BV-7X regime classification + thresholds."""
+        return self._cached_call("/api/bv7x/regime")
+
+    def get_agent_identity(self) -> dict[str, Any]:
+        """Return BV-7X's ERC-8004 agent identity + reputation."""
+        return self._cached_call("/api/bv7x/agent/identity")
+
+    def discover_a2a(self) -> dict[str, Any]:
+        """Return BV-7X's A2A discovery card (skill list)."""
+        return self._cached_call("/api/bv7x/a2a/discover")
+
+    def clear_cache(self) -> None:
+        with self._lock:
+            self._cache.clear()
+
+    # --- internal --------------------------------------------------------
+
+    def _cached_call(self, path: str) -> dict[str, Any]:
+        now = time.monotonic()
+        with self._lock:
+            entry = self._cache.get(path)
+            if entry is not None:
+                ts, value = entry
+                if now - ts < self._ttl:
+                    return value
+
+        value = self._call(path)
+        with self._lock:
+            self._cache[path] = (now, value)
+        return value
+
+    def _call(self, path: str) -> dict[str, Any]:
+        url = _BASE_URL + path
+        try:
+            response = http_get(url, timeout=15.0)
+        except Exception as exc:  # noqa: BLE001 — classify below
+            msg = str(exc).lower()
+            if "429" in msg or "rate" in msg:
+                raise BV7XError("rate_limited", str(exc)) from exc
+            if "404" in msg or "not found" in msg:
+                raise BV7XError("not_found", str(exc)) from exc
+            if "402" in msg or "payment required" in msg or "token" in msg:
+                raise BV7XError("token_gated", str(exc)) from exc
+            raise BV7XError("api_error", f"bv7x request failed: {exc}") from exc
+
+        if not isinstance(response, dict):
+            raise BV7XError(
+                "api_error",
+                f"bv7x returned non-dict response: {type(response).__name__}",
+            )
+        return response
+
+
+_instance: BV7XService | None = None
+
+
+def get_bv7x_service() -> BV7XService:
+    global _instance
+    if _instance is None:
+        _instance = BV7XService()
+    return _instance

--- a/clawmes/tools/__init__.py
+++ b/clawmes/tools/__init__.py
@@ -29,6 +29,7 @@ def register_all(ctx) -> None:
     """
     from clawmes.tools import (
         _user_tools,
+        a2a_call,
         agent_identity,
         agent_memory,
         airdrop,
@@ -41,6 +42,7 @@ def register_all(ctx) -> None:
         block_explorer,
         bridge,
         browser,
+        bv7x,
         clawnch_fees,
         clawnch_launch,
         clawnchconnect,
@@ -52,6 +54,7 @@ def register_all(ctx) -> None:
         defi_price,
         defi_stake,
         defi_swap,
+        eas_attestation,
         farcaster,
         giza,
         governance,
@@ -127,6 +130,9 @@ def register_all(ctx) -> None:
         manage_orders,
         liquidity,
         browser,
+        bv7x,
+        eas_attestation,
+        a2a_call,
         _user_tools,
     ):
         mod.register(ctx)

--- a/clawmes/tools/a2a_call.py
+++ b/clawmes/tools/a2a_call.py
@@ -1,0 +1,211 @@
+"""``a2a_call`` — Agent-to-Agent JSON-RPC 2.0 client.
+
+The A2A protocol (https://google.github.io/A2A/) lets agents send
+structured tasks to each other over JSON-RPC 2.0. Skills are
+advertised via an AgentCard at ``/.well-known/agent-card.json`` and
+tasks are sent to a peer's ``/tasks/send`` endpoint.
+
+Two actions:
+
+  * ``discover`` — fetch the peer's AgentCard and surface its skill
+    list + version. Pure read.
+  * ``send_task`` — send a JSON-RPC 2.0 task to the peer. Returns the
+    response payload.
+
+Authentication is currently OUT OF SCOPE. v1 only supports
+unauthenticated A2A calls (most agent peers, including BV-7X's public
+endpoints, don't require auth for read tasks). Authenticated A2A —
+signing requests with the agent's DID per RFC 9421 HTTP Signatures —
+pairs with the IdentityService (PR #10) and is sketched as a
+follow-up.
+
+Network allowlist: the target peer's host MUST be in
+``clawmes.lib.http._DEFAULT_ALLOWLIST`` or the runtime allowlist
+(added via ``/allow <host>``). This is the existing prompt-injection
+defense — an LLM that gets tricked into hitting an attacker-controlled
+A2A endpoint is blocked at the HTTP layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+from clawmes.lib.http import http_get, http_post
+from clawmes.lib.params import ParamError, read_enum, read_str
+from clawmes.lib.tool_result import error_result, json_result
+from clawmes.tools.registry import read_tool, register_with_ctx
+
+_VALID_ACTIONS = ["discover", "send_task"]
+
+
+_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": _VALID_ACTIONS,
+        },
+        "agent_url": {
+            "type": "string",
+            "description": (
+                "Base URL of the A2A peer (e.g. https://bv7x.ai). For "
+                "discover, we fetch /.well-known/agent-card.json. For "
+                "send_task, we POST to {agent_url}/api/bv7x/a2a/tasks/send "
+                "by default; override the task path with task_path="
+            ),
+        },
+        "task_path": {
+            "type": "string",
+            "description": (
+                "Override the task POST path. Defaults to "
+                "'/api/bv7x/a2a/tasks/send' (matches BV-7X). Some peers "
+                "expose '/a2a/tasks/send' or '/tasks/send'."
+            ),
+        },
+        "skill": {
+            "type": "string",
+            "description": (
+                "A2A skill name to invoke. Required for send_task. "
+                "Discover the peer's available skills via action=discover."
+            ),
+        },
+        "params": {
+            "type": "object",
+            "description": (
+                "Optional params dict to pass to the skill. Shape is "
+                "skill-specific; check the peer's discover output."
+            ),
+        },
+        "task_id": {
+            "type": "string",
+            "description": "Optional JSON-RPC request id. Defaults to '1'.",
+        },
+    },
+    "required": ["action", "agent_url"],
+}
+
+
+@read_tool(
+    name="a2a_call",
+    toolset="clawmes-intelligence",
+    description=(
+        "Call another agent via the A2A protocol (JSON-RPC 2.0). "
+        "Action=discover fetches the peer's AgentCard + skill list. "
+        "Action=send_task POSTs a JSON-RPC task. Target host must be on "
+        "the network allowlist (/allow <host> for session-scoped peers). "
+        "Authentication via DID signatures is not yet supported \u2014 v1 "
+        "is for unauthenticated read tasks."
+    ),
+    schema=_SCHEMA,
+    emoji="\U0001f9e9",  # 🧩
+)
+def a2a_call(args: dict[str, Any], **kwargs: Any) -> str:
+    try:
+        action = read_enum(args, "action", _VALID_ACTIONS, required=True)
+        agent_url = read_str(args, "agent_url", required=True)
+    except ParamError as exc:
+        return error_result(str(exc), code="param_error")
+    assert agent_url is not None
+
+    parsed = urlparse(agent_url)
+    if not parsed.scheme or not parsed.netloc:
+        return error_result(
+            f"agent_url is malformed (no scheme/host): {agent_url!r}",
+            code="param_error",
+        )
+    base = f"{parsed.scheme}://{parsed.netloc}"
+
+    if action == "discover":
+        return _handle_discover(base)
+    # action == "send_task" — the only remaining option.
+    return _handle_send_task(args, base)
+
+
+def _handle_discover(base_url: str) -> str:
+    card_url = base_url.rstrip("/") + "/.well-known/agent-card.json"
+    try:
+        card = http_get(card_url, timeout=15.0)
+    except Exception as exc:  # noqa: BLE001 — surface plain
+        return error_result(f"A2A discover failed: {exc}", code="api_error")
+    if not isinstance(card, dict):
+        return error_result(
+            f"discover returned non-dict response: {type(card).__name__}",
+            code="api_error",
+        )
+    skills = card.get("skills") or card.get("capabilities") or []
+    summary_lines = [
+        f"A2A agent at {base_url}:",
+        f"  Name: {card.get('name', '?')}",
+        f"  Description: {card.get('description', '?')}",
+    ]
+    if isinstance(skills, list):
+        summary_lines.append(f"  Skills: {len(skills)}")
+        for skill in skills[:10]:
+            if isinstance(skill, str):
+                summary_lines.append(f"    \u2022 {skill}")
+            elif isinstance(skill, dict):
+                name = skill.get("id") or skill.get("name") or "(unnamed)"
+                summary_lines.append(f"    \u2022 {name}")
+    return json_result(
+        {"agent_card": card},
+        summary="\n".join(summary_lines),
+    )
+
+
+def _handle_send_task(args: dict[str, Any], base_url: str) -> str:
+    try:
+        skill = read_str(args, "skill", required=True)
+        task_path = read_str(args, "task_path") or "/api/bv7x/a2a/tasks/send"
+        task_id = read_str(args, "task_id") or "1"
+    except ParamError as exc:
+        return error_result(str(exc), code="param_error")
+    assert skill is not None
+    params = args.get("params") or {}
+    if not isinstance(params, dict):
+        return error_result(
+            f"params must be an object, got {type(params).__name__}",
+            code="param_error",
+        )
+
+    url = base_url.rstrip("/") + (task_path if task_path.startswith("/") else "/" + task_path)
+    body = {
+        "jsonrpc": "2.0",
+        "id": task_id,
+        "method": "tasks/send",
+        "params": {
+            "skill": skill,
+            **params,
+        },
+    }
+    try:
+        response = http_post(url, json=body, timeout=30.0)
+    except Exception as exc:  # noqa: BLE001
+        return error_result(f"A2A send_task failed: {exc}", code="api_error")
+    if not isinstance(response, dict):
+        return error_result(
+            f"send_task returned non-dict response: {type(response).__name__}",
+            code="api_error",
+        )
+
+    # JSON-RPC 2.0 envelope: either ``result`` or ``error``.
+    if "error" in response and isinstance(response["error"], dict):
+        err = response["error"]
+        msg = str(err.get("message") or err)
+        return error_result(
+            f"A2A peer returned error: {msg}",
+            code="api_error",
+        )
+
+    result = response.get("result")
+    return json_result(
+        {"rpc_id": response.get("id", task_id), "result": result},
+        summary=(
+            f"A2A {skill} task accepted by {base_url}"
+            + (f" \u2014 result keys: {list(result.keys())}" if isinstance(result, dict) else "")
+        ),
+    )
+
+
+def register(ctx) -> None:
+    register_with_ctx(ctx, a2a_call)

--- a/clawmes/tools/bv7x.py
+++ b/clawmes/tools/bv7x.py
@@ -1,0 +1,104 @@
+"""``bv7x`` — read BV-7X public-API data.
+
+Three read-only actions wrapping :class:`BV7XService`:
+
+  * ``regime``   — BTC market regime (CRISIS / BEAR / NEUTRAL / BULL /
+    EUPHORIA) + thresholds.
+  * ``identity`` — BV-7X's ERC-8004 agent identity + on-chain reputation.
+  * ``discover`` — A2A discovery card (skill list, version, capabilities).
+
+Token-gated endpoints (``/oracle``, ``/copy-trade/*``) are NOT exposed
+here. Users who hold ``$BV7X`` and want those should hit the API
+directly with their own credentials. We don't make clawmes features
+depend on third-party token holdings.
+
+Read-only by design — ``@read_tool`` skips the policy gate. This tool
+fetches public data and returns it; no on-chain side effects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawmes.lib.params import ParamError, read_enum
+from clawmes.lib.tool_result import error_result, json_result
+from clawmes.services.bv7x import BV7XError, get_bv7x_service
+from clawmes.tools.registry import read_tool, register_with_ctx
+
+_VALID_ACTIONS = ["regime", "identity", "discover"]
+
+
+_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": _VALID_ACTIONS,
+            "description": (
+                "regime = current BTC regime classification; "
+                "identity = BV-7X's on-chain agent identity; "
+                "discover = BV-7X's A2A skill card."
+            ),
+        },
+    },
+    "required": ["action"],
+}
+
+
+@read_tool(
+    name="bv7x",
+    toolset="clawmes-intelligence",
+    description=(
+        "Read BV-7X autonomous BTC oracle data via their public REST API. "
+        "regime = market regime classification (CRISIS/BEAR/NEUTRAL/BULL/"
+        "EUPHORIA), identity = ERC-8004 agent identity + reputation, "
+        "discover = A2A skill card. Token-gated endpoints (signals, "
+        "copy-trade) are NOT exposed here \u2014 use the public surface only."
+    ),
+    schema=_SCHEMA,
+    emoji="\U0001f7ea",  # 🟪 — distinguishes from market_intel
+)
+def bv7x(args: dict[str, Any], **kwargs: Any) -> str:
+    try:
+        action = read_enum(args, "action", _VALID_ACTIONS, required=True)
+    except ParamError as exc:
+        return error_result(str(exc), code="param_error")
+
+    svc = get_bv7x_service()
+    try:
+        if action == "regime":
+            data = svc.get_regime()
+            return json_result(data, summary=_format_regime(data))
+        if action == "identity":
+            data = svc.get_agent_identity()
+            return json_result(data, summary=_format_identity(data))
+        # action == "discover" — the only remaining valid option.
+        data = svc.discover_a2a()
+        return json_result(data, summary=_format_discover(data))
+    except BV7XError as exc:
+        return error_result(exc.message, code=exc.code)
+
+
+def _format_regime(data: dict[str, Any]) -> str:
+    regime = data.get("regime") or data.get("classification") or "?"
+    risk = data.get("risk_level") or data.get("risk") or ""
+    return f"BV-7X regime: {regime}" + (f" (risk={risk})" if risk else "")
+
+
+def _format_identity(data: dict[str, Any]) -> str:
+    agent_id = data.get("agent_id") or data.get("id") or "?"
+    reputation = data.get("reputation") or data.get("score")
+    parts = [f"BV-7X agent #{agent_id}"]
+    if reputation is not None:
+        parts.append(f"reputation={reputation}")
+    return " · ".join(parts)
+
+
+def _format_discover(data: dict[str, Any]) -> str:
+    skills = data.get("skills") or []
+    version = data.get("version") or data.get("a2a_version") or "?"
+    return f"BV-7X A2A v{version} · {len(skills)} skill(s)"
+
+
+def register(ctx) -> None:
+    register_with_ctx(ctx, bv7x)

--- a/clawmes/tools/eas_attestation.py
+++ b/clawmes/tools/eas_attestation.py
@@ -1,0 +1,344 @@
+"""``eas_attestation`` — read EAS attestations on Base.
+
+Ethereum Attestation Service (https://attest.org) is a generic
+on-chain primitive for cryptographic attestations: agent identity
+claims, KYC results, trust-score certificates, signal predictions
+(BV-7X uses it), and more. EAS is deployed on Base mainnet at
+``0x4200000000000000000000000000000000000021`` (Identity Registry
+predeploy slot) — the same singleton everyone reads from.
+
+This tool reads attestations by UID. It returns the decoded
+:class:`Attestation` struct (uid, schema, time, expirationTime,
+revocationTime, refUID, recipient, attester, revocable, raw data).
+It does NOT verify signatures yet — the data is committed on-chain
+under ``attester``, which is what matters for most read use cases.
+Signature verification + revocation-status interpretation are
+sketched as follow-up work.
+
+Why this tool: generic on-chain primitive. BV-7X publishes daily
+signal attestations users can verify with this tool. Other use cases
+include reading agent reputation attestations, KYC results, and
+trust-score certificates from any EAS-using protocol.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawmes.lib.params import ParamError, read_enum, read_int, read_str
+from clawmes.lib.tool_result import error_result, json_result
+from clawmes.services.rpc import RpcError, get_rpc_service
+from clawmes.tools.registry import read_tool, register_with_ctx
+
+# EAS singleton on Base mainnet. See https://docs.attest.org/docs/quick--start/contracts
+_EAS_BASE_MAINNET = "0x4200000000000000000000000000000000000021"
+_DEFAULT_CHAIN_ID = 8453
+
+# keccak256("getAttestation(bytes32)")[:4]
+_SELECTOR_GET_ATTESTATION = bytes.fromhex("a3112a64")
+
+# Attestation struct return type, per the EAS interface:
+#   struct Attestation {
+#       bytes32 uid;
+#       bytes32 schema;
+#       uint64 time;
+#       uint64 expirationTime;
+#       uint64 revocationTime;
+#       bytes32 refUID;
+#       address recipient;
+#       address attester;
+#       bool revocable;
+#       bytes data;
+#   }
+_ATTESTATION_TYPE = "(bytes32,bytes32,uint64,uint64,uint64,bytes32,address,address,bool,bytes)"
+
+_VALID_ACTIONS = ["get", "decode_data"]
+
+
+_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": _VALID_ACTIONS,
+            "description": (
+                "get = read the full attestation struct by UID. "
+                "decode_data = decode the raw bytes payload of a "
+                "previously-fetched attestation against a typed schema "
+                "(callers supply the type string)."
+            ),
+        },
+        "uid": {
+            "type": "string",
+            "description": (
+                "EAS attestation UID (32-byte hex, 0x-prefixed). Required for action=get."
+            ),
+        },
+        "chain_id": {
+            "type": "integer",
+            "description": (
+                "Chain ID. Default 8453 (Base mainnet). EAS is deployed "
+                "on most major L2s — pass the appropriate chain id."
+            ),
+        },
+        "eas_address": {
+            "type": "string",
+            "description": (
+                "Override the EAS contract address. Default is Base's "
+                "canonical 0x4200...0021. Pass a different address for "
+                "chains where the canonical address differs."
+            ),
+        },
+        "data_hex": {
+            "type": "string",
+            "description": (
+                "Hex-encoded raw attestation data (action=decode_data). Returned by action=get."
+            ),
+        },
+        "schema_types": {
+            "type": "string",
+            "description": (
+                "ABI type string for the data payload (action=decode_data). "
+                'e.g. "uint8,string,bool" or "(address,uint256)" for a tuple.'
+            ),
+        },
+    },
+    "required": ["action"],
+}
+
+
+@read_tool(
+    name="eas_attestation",
+    toolset="clawmes-intelligence",
+    description=(
+        "Read EAS attestations on Base (and other L2s). "
+        "action=get fetches an attestation by 32-byte UID, decoded into "
+        "the canonical Attestation struct (uid, schema, time, "
+        "recipient, attester, data, etc.). action=decode_data parses "
+        "the raw bytes payload against a caller-supplied schema. "
+        "Generic on-chain primitive \u2014 useful for BV-7X signal "
+        "attestations, trust-score certificates, KYC results, and any "
+        "EAS-using protocol."
+    ),
+    schema=_SCHEMA,
+    emoji="\U0001f4dc",
+)
+def eas_attestation(args: dict[str, Any], **kwargs: Any) -> str:
+    try:
+        action = read_enum(args, "action", _VALID_ACTIONS, required=True)
+    except ParamError as exc:
+        return error_result(str(exc), code="param_error")
+
+    if action == "get":
+        return _handle_get(args)
+    # action == "decode_data" — the only remaining option.
+    return _handle_decode_data(args)
+
+
+def _handle_get(args: dict[str, Any]) -> str:
+    try:
+        uid_str = read_str(args, "uid", required=True)
+        chain_id = read_int(args, "chain_id") or _DEFAULT_CHAIN_ID
+    except ParamError as exc:
+        return error_result(str(exc), code="param_error")
+    assert uid_str is not None
+
+    uid_hex = uid_str.strip()
+    if uid_hex.startswith("0x") or uid_hex.startswith("0X"):
+        uid_hex = uid_hex[2:]
+    try:
+        uid_bytes = bytes.fromhex(uid_hex)
+    except ValueError:
+        return error_result(f"uid is not valid hex: {uid_str!r}", code="param_error")
+    if len(uid_bytes) != 32:
+        return error_result(
+            f"uid must decode to 32 bytes, got {len(uid_bytes)}",
+            code="param_error",
+        )
+
+    eas_address = read_str(args, "eas_address") or _EAS_BASE_MAINNET
+
+    try:
+        from eth_abi import decode as abi_decode
+        from eth_abi import encode as abi_encode
+    except ImportError:  # pragma: no cover — eth-abi is a transitive web3 dep
+        return error_result(
+            "eth-abi is not installed (transitive web3 dep). Install "
+            "web3>=7.0 or eth-abi directly.",
+            code="dependency_error",
+        )
+
+    encoded_uid = abi_encode(["bytes32"], [uid_bytes])
+    call_data = "0x" + (_SELECTOR_GET_ATTESTATION + encoded_uid).hex()
+
+    rpc = get_rpc_service()
+    try:
+        result_hex = rpc.eth_call(to=eas_address, data=call_data, chain_id=chain_id)
+    except RpcError as exc:
+        return error_result(f"RPC error: {exc.message}", code="rpc_error")
+
+    raw = result_hex
+    if isinstance(raw, str) and raw.startswith("0x"):
+        raw = raw[2:]
+    if not raw:
+        return error_result(
+            f"EAS returned empty result for uid {uid_str!r} \u2014 the "
+            "attestation may not exist on this chain.",
+            code="not_found",
+        )
+
+    try:
+        decoded = abi_decode([_ATTESTATION_TYPE], bytes.fromhex(raw))
+    except Exception as exc:  # noqa: BLE001 — eth-abi can raise various
+        return error_result(
+            f"failed to decode EAS response: {exc}",
+            code="api_error",
+        )
+    attestation_tuple = decoded[0]
+
+    # If the returned uid is all zeros, the attestation doesn't exist.
+    returned_uid = attestation_tuple[0]
+    if returned_uid == b"\x00" * 32:
+        return error_result(
+            f"No attestation found for uid {uid_str!r} on chain {chain_id}.",
+            code="not_found",
+        )
+
+    payload = _attestation_to_dict(attestation_tuple)
+    return json_result(
+        payload,
+        summary=_format_attestation_summary(payload),
+    )
+
+
+def _handle_decode_data(args: dict[str, Any]) -> str:
+    try:
+        data_hex = read_str(args, "data_hex", required=True)
+        schema_types = read_str(args, "schema_types", required=True)
+    except ParamError as exc:
+        return error_result(str(exc), code="param_error")
+    assert data_hex is not None and schema_types is not None
+
+    raw = data_hex.strip()
+    if raw.startswith("0x") or raw.startswith("0X"):
+        raw = raw[2:]
+    try:
+        data_bytes = bytes.fromhex(raw)
+    except ValueError:
+        return error_result("data_hex is not valid hex", code="param_error")
+
+    try:
+        from eth_abi import decode as abi_decode
+    except ImportError:  # pragma: no cover
+        return error_result("eth-abi is not installed", code="dependency_error")
+
+    # The schema may be a single type or comma-separated types.
+    # Commas INSIDE parentheses (tuple types like "(uint8,bool)") must
+    # not split — track paren depth.
+    types = _split_types(schema_types)
+    if not types:
+        return error_result("schema_types must list at least one ABI type", code="param_error")
+    try:
+        values = abi_decode(types, data_bytes)
+    except Exception as exc:  # noqa: BLE001
+        return error_result(
+            f"data decode failed against schema {schema_types!r}: {exc}",
+            code="api_error",
+        )
+
+    return json_result(
+        {
+            "schema_types": schema_types,
+            "values": _stringify_for_json(values),
+        },
+        summary=f"decoded {len(types)} field(s) from {len(data_bytes)} bytes",
+    )
+
+
+def _attestation_to_dict(t: tuple) -> dict[str, Any]:
+    return {
+        "uid": "0x" + t[0].hex(),
+        "schema": "0x" + t[1].hex(),
+        "time": int(t[2]),
+        "expirationTime": int(t[3]),
+        "revocationTime": int(t[4]),
+        "refUID": "0x" + t[5].hex(),
+        "recipient": t[6],
+        "attester": t[7],
+        "revocable": bool(t[8]),
+        "data_hex": "0x" + t[9].hex(),
+        "is_revoked": int(t[4]) > 0,
+        "is_expired": int(t[3]) > 0 and int(t[3]) < _now_seconds(),
+    }
+
+
+def _format_attestation_summary(p: dict[str, Any]) -> str:
+    lines = [
+        f"EAS attestation {p['uid'][:18]}...",
+        f"  Schema:    {p['schema'][:18]}...",
+        f"  Attester:  {p['attester']}",
+        f"  Recipient: {p['recipient']}",
+        f"  Created:   epoch {p['time']}",
+    ]
+    if p["is_revoked"]:
+        lines.append(f"  REVOKED at epoch {p['revocationTime']}")
+    if p["is_expired"]:
+        lines.append(f"  EXPIRED at epoch {p['expirationTime']}")
+    data_hex = p["data_hex"]
+    if data_hex and data_hex != "0x":
+        lines.append(f"  Data:      {data_hex[:42]}{'...' if len(data_hex) > 42 else ''}")
+    return "\n".join(lines)
+
+
+def _split_types(s: str) -> list[str]:
+    """Comma-split an ABI type list, respecting parenthesized tuples.
+
+    ``"uint8,string"`` → ``["uint8", "string"]``.
+    ``"(uint8,bool),bytes32"`` → ``["(uint8,bool)", "bytes32"]``.
+    """
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in s:
+        if char == "(":
+            depth += 1
+            current.append(char)
+        elif char == ")":
+            depth -= 1
+            current.append(char)
+        elif char == "," and depth == 0:
+            stripped = "".join(current).strip()
+            if stripped:
+                parts.append(stripped)
+            current = []
+        else:
+            current.append(char)
+    final = "".join(current).strip()
+    if final:
+        parts.append(final)
+    return parts
+
+
+def _stringify_for_json(values: tuple) -> list[Any]:
+    """Convert decoded ABI values into JSON-safe Python types."""
+    out: list[Any] = []
+    for v in values:
+        if isinstance(v, bytes):
+            out.append("0x" + v.hex())
+        elif isinstance(v, tuple):
+            out.append(_stringify_for_json(v))
+        elif isinstance(v, int):
+            out.append(v)
+        else:
+            out.append(v)
+    return out
+
+
+def _now_seconds() -> int:
+    import time
+
+    return int(time.time())
+
+
+def register(ctx) -> None:
+    register_with_ctx(ctx, eas_attestation)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -37,6 +37,9 @@ provides_tools:
   - lobster_cash
   - policy_manage
   - agent_identity
+  - bv7x
+  - eas_attestation
+  - a2a_call
   - analytics
   - market_intel
   - cost_basis

--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -166,8 +166,8 @@ class TestPluginSection:
     def test_real_manifest_counts(self):
         section = _plugin_section()
         assert "Tools registered:" in section.body
-        # Should report 47 (45 at 0.1.0 + policy_manage + agent_identity)
-        assert "47" in section.body
+        # 45 at 0.1.0 + policy_manage + agent_identity + bv7x + eas_attestation + a2a_call = 50
+        assert "50" in section.body
         assert "Hooks registered:" in section.body
         assert "11" in section.body  # 11 hooks
         assert "Commands registered:" in section.body

--- a/tests/services/test_bv7x.py
+++ b/tests/services/test_bv7x.py
@@ -1,0 +1,163 @@
+"""Tests for clawmes.services.bv7x."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.services import bv7x as bv7x_mod
+from clawmes.services.bv7x import (
+    BV7XError,
+    BV7XService,
+    get_bv7x_service,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.setattr(bv7x_mod, "_instance", None)
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    class FakeHttp:
+        def __init__(self):
+            self.calls: list[dict] = []
+            self.responses: list = []
+
+        def __call__(self, url, *, params=None, headers=None, timeout=30.0, **kw):
+            self.calls.append(
+                {"url": url, "params": params, "headers": headers, "timeout": timeout}
+            )
+            if not self.responses:
+                raise AssertionError("no fake response queued")
+            response = self.responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+    fake = FakeHttp()
+    monkeypatch.setattr(bv7x_mod, "http_get", fake)
+    return fake
+
+
+class TestLifecycle:
+    def test_start_is_noop(self):
+        BV7XService().start()
+
+    def test_stop_clears_cache(self, fake_http):
+        svc = BV7XService()
+        fake_http.responses.append({"regime": "BULL"})
+        svc.get_regime()
+        svc.stop()
+        # After stop, a fresh call should re-fetch (cache empty).
+        fake_http.responses.append({"regime": "BEAR"})
+        svc.get_regime()
+        assert len(fake_http.calls) == 2
+
+
+class TestGetRegime:
+    def test_basic(self, fake_http):
+        fake_http.responses.append({"regime": "BEAR_TREND", "risk_level": "High"})
+        out = BV7XService().get_regime()
+        assert out["regime"] == "BEAR_TREND"
+        assert fake_http.calls[0]["url"].endswith("/api/bv7x/regime")
+
+
+class TestGetAgentIdentity:
+    def test_basic(self, fake_http):
+        fake_http.responses.append({"agent_id": 28841, "reputation": 0.87})
+        out = BV7XService().get_agent_identity()
+        assert out["agent_id"] == 28841
+        assert fake_http.calls[0]["url"].endswith("/api/bv7x/agent/identity")
+
+
+class TestDiscoverA2A:
+    def test_basic(self, fake_http):
+        fake_http.responses.append({"skills": ["a", "b"], "version": "0.3.0"})
+        out = BV7XService().discover_a2a()
+        assert out["skills"] == ["a", "b"]
+
+
+class TestCaching:
+    def test_caches_within_ttl(self, fake_http):
+        svc = BV7XService(ttl_seconds=60)
+        fake_http.responses.append({"regime": "BULL"})
+        svc.get_regime()
+        svc.get_regime()  # Should hit cache
+        assert len(fake_http.calls) == 1
+
+    def test_refetches_after_ttl(self, fake_http, monkeypatch):
+        import time as time_module
+
+        svc = BV7XService(ttl_seconds=1)
+        # Patch monotonic to control the clock.
+        clock = [0.0]
+
+        def fake_monotonic():
+            return clock[0]
+
+        monkeypatch.setattr(time_module, "monotonic", fake_monotonic)
+        monkeypatch.setattr("clawmes.services.bv7x.time.monotonic", fake_monotonic)
+
+        fake_http.responses.append({"regime": "BULL"})
+        svc.get_regime()
+        clock[0] = 2.0  # Past the 1-second TTL.
+        fake_http.responses.append({"regime": "BEAR"})
+        result = svc.get_regime()
+        assert result["regime"] == "BEAR"
+        assert len(fake_http.calls) == 2
+
+    def test_clear_cache(self, fake_http):
+        svc = BV7XService()
+        fake_http.responses.append({"regime": "BULL"})
+        svc.get_regime()
+        svc.clear_cache()
+        fake_http.responses.append({"regime": "BEAR"})
+        svc.get_regime()
+        assert len(fake_http.calls) == 2
+
+
+class TestErrorClassification:
+    def test_rate_limit(self, fake_http):
+        fake_http.responses.append(RuntimeError("HTTP 429 Too Many"))
+        with pytest.raises(BV7XError) as exc:
+            BV7XService().get_regime()
+        assert exc.value.code == "rate_limited"
+
+    def test_not_found(self, fake_http):
+        fake_http.responses.append(RuntimeError("HTTP 404 Not Found"))
+        with pytest.raises(BV7XError) as exc:
+            BV7XService().get_regime()
+        assert exc.value.code == "not_found"
+
+    def test_token_gated_402(self, fake_http):
+        fake_http.responses.append(RuntimeError("HTTP 402 Payment Required"))
+        with pytest.raises(BV7XError) as exc:
+            BV7XService().get_regime()
+        assert exc.value.code == "token_gated"
+
+    def test_token_gated_keyword(self, fake_http):
+        fake_http.responses.append(RuntimeError("requires BV7X token holdings"))
+        with pytest.raises(BV7XError) as exc:
+            BV7XService().get_regime()
+        assert exc.value.code == "token_gated"
+
+    def test_generic_error(self, fake_http):
+        fake_http.responses.append(RuntimeError("connection reset"))
+        with pytest.raises(BV7XError) as exc:
+            BV7XService().get_regime()
+        assert exc.value.code == "api_error"
+
+    def test_non_dict_response(self, fake_http):
+        fake_http.responses.append("not a dict")
+        with pytest.raises(BV7XError) as exc:
+            BV7XService().get_regime()
+        assert exc.value.code == "api_error"
+        assert "non-dict" in exc.value.message
+
+
+class TestSingleton:
+    def test_singleton(self):
+        a = get_bv7x_service()
+        b = get_bv7x_service()
+        assert a is b

--- a/tests/tools/test_a2a_call.py
+++ b/tests/tools/test_a2a_call.py
@@ -1,0 +1,293 @@
+"""Tests for the ``a2a_call`` tool (JSON-RPC 2.0 agent-to-agent client)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawmes.tools import a2a_call as a2a_mod
+from clawmes.tools.a2a_call import a2a_call, register
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    from clawmes.policy import storage as policy_storage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    policy_storage.save_policies([])
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    class FakeHttp:
+        get_responses: list = []
+        post_responses: list = []
+        post_calls: list = []
+        get_calls: list = []
+
+        def get(self, url, **kw):
+            self.get_calls.append({"url": url, **kw})
+            if not self.get_responses:
+                raise AssertionError("no fake get response queued")
+            r = self.get_responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        def post(self, url, *, json=None, **kw):
+            self.post_calls.append({"url": url, "json": json, **kw})
+            if not self.post_responses:
+                raise AssertionError("no fake post response queued")
+            r = self.post_responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+    fake = FakeHttp()
+    monkeypatch.setattr(a2a_mod, "http_get", fake.get)
+    monkeypatch.setattr(a2a_mod, "http_post", fake.post)
+    return fake
+
+
+# --- discover -----------------------------------------------------------
+
+
+class TestDiscover:
+    def test_basic(self, fake_http):
+        fake_http.get_responses.append(
+            {
+                "name": "BV-7X Oracle",
+                "description": "Autonomous BTC prediction agent",
+                "skills": ["get_market_context", "get_signal_summary"],
+            }
+        )
+        out = json.loads(a2a_call({"action": "discover", "agent_url": "https://bv7x.ai"}))
+        assert "BV-7X Oracle" in out["content"][0]["text"]
+        assert "2" in out["content"][0]["text"]  # 2 skills
+        assert "get_market_context" in out["content"][0]["text"]
+        assert fake_http.get_calls[0]["url"] == ("https://bv7x.ai/.well-known/agent-card.json")
+
+    def test_skills_as_dicts(self, fake_http):
+        fake_http.get_responses.append(
+            {
+                "name": "Peer",
+                "skills": [{"id": "skill_a"}, {"name": "skill_b"}, {"x": "y"}],
+            }
+        )
+        out = json.loads(a2a_call({"action": "discover", "agent_url": "https://bv7x.ai"}))
+        assert "skill_a" in out["content"][0]["text"]
+        assert "skill_b" in out["content"][0]["text"]
+        assert "(unnamed)" in out["content"][0]["text"]
+
+    def test_capabilities_field_fallback(self, fake_http):
+        # Some agents use 'capabilities' instead of 'skills'.
+        fake_http.get_responses.append({"name": "Peer", "capabilities": ["cap_a", "cap_b"]})
+        out = json.loads(a2a_call({"action": "discover", "agent_url": "https://bv7x.ai"}))
+        assert "cap_a" in out["content"][0]["text"]
+
+    def test_http_failure(self, fake_http):
+        fake_http.get_responses.append(RuntimeError("DNS failure"))
+        out = json.loads(a2a_call({"action": "discover", "agent_url": "https://bv7x.ai"}))
+        assert out["isError"] is True
+        assert out["details"]["error_code"] == "api_error"
+        assert "DNS failure" in out["content"][0]["text"]
+
+    def test_non_dict_response(self, fake_http):
+        fake_http.get_responses.append("not a dict")
+        out = json.loads(a2a_call({"action": "discover", "agent_url": "https://bv7x.ai"}))
+        assert out["details"]["error_code"] == "api_error"
+
+
+# --- send_task ----------------------------------------------------------
+
+
+class TestSendTask:
+    def test_basic(self, fake_http):
+        fake_http.post_responses.append(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "result": {"regime": "BULL", "confidence": 0.7},
+            }
+        )
+        out = json.loads(
+            a2a_call(
+                {
+                    "action": "send_task",
+                    "agent_url": "https://bv7x.ai",
+                    "skill": "get_market_context",
+                }
+            )
+        )
+        assert out["details"]["result"]["regime"] == "BULL"
+        body = fake_http.post_calls[0]["json"]
+        assert body["jsonrpc"] == "2.0"
+        assert body["method"] == "tasks/send"
+        assert body["params"]["skill"] == "get_market_context"
+
+    def test_with_params(self, fake_http):
+        fake_http.post_responses.append({"jsonrpc": "2.0", "id": "1", "result": {}})
+        a2a_call(
+            {
+                "action": "send_task",
+                "agent_url": "https://bv7x.ai",
+                "skill": "x",
+                "params": {"foo": "bar"},
+            }
+        )
+        body = fake_http.post_calls[0]["json"]
+        assert body["params"]["foo"] == "bar"
+
+    def test_custom_task_id(self, fake_http):
+        fake_http.post_responses.append({"jsonrpc": "2.0", "id": "abc", "result": {}})
+        a2a_call(
+            {
+                "action": "send_task",
+                "agent_url": "https://bv7x.ai",
+                "skill": "x",
+                "task_id": "abc",
+            }
+        )
+        body = fake_http.post_calls[0]["json"]
+        assert body["id"] == "abc"
+
+    def test_custom_task_path(self, fake_http):
+        fake_http.post_responses.append({"jsonrpc": "2.0", "id": "1", "result": {}})
+        a2a_call(
+            {
+                "action": "send_task",
+                "agent_url": "https://bv7x.ai",
+                "skill": "x",
+                "task_path": "/a2a/tasks/send",
+            }
+        )
+        assert fake_http.post_calls[0]["url"] == "https://bv7x.ai/a2a/tasks/send"
+
+    def test_task_path_without_leading_slash(self, fake_http):
+        fake_http.post_responses.append({"jsonrpc": "2.0", "id": "1", "result": {}})
+        a2a_call(
+            {
+                "action": "send_task",
+                "agent_url": "https://bv7x.ai",
+                "skill": "x",
+                "task_path": "a2a/tasks/send",
+            }
+        )
+        assert fake_http.post_calls[0]["url"] == "https://bv7x.ai/a2a/tasks/send"
+
+    def test_missing_skill(self):
+        out = json.loads(a2a_call({"action": "send_task", "agent_url": "https://bv7x.ai"}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_bad_params_type(self):
+        out = json.loads(
+            a2a_call(
+                {
+                    "action": "send_task",
+                    "agent_url": "https://bv7x.ai",
+                    "skill": "x",
+                    "params": "not-a-dict",
+                }
+            )
+        )
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_http_post_failure(self, fake_http):
+        fake_http.post_responses.append(RuntimeError("connection reset"))
+        out = json.loads(
+            a2a_call(
+                {
+                    "action": "send_task",
+                    "agent_url": "https://bv7x.ai",
+                    "skill": "x",
+                }
+            )
+        )
+        assert out["details"]["error_code"] == "api_error"
+
+    def test_jsonrpc_error_envelope(self, fake_http):
+        fake_http.post_responses.append(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "error": {"code": -32601, "message": "Method not found"},
+            }
+        )
+        out = json.loads(
+            a2a_call(
+                {
+                    "action": "send_task",
+                    "agent_url": "https://bv7x.ai",
+                    "skill": "unknown",
+                }
+            )
+        )
+        assert out["isError"] is True
+        assert "Method not found" in out["content"][0]["text"]
+
+    def test_non_dict_post_response(self, fake_http):
+        fake_http.post_responses.append("not a dict")
+        out = json.loads(
+            a2a_call(
+                {
+                    "action": "send_task",
+                    "agent_url": "https://bv7x.ai",
+                    "skill": "x",
+                }
+            )
+        )
+        assert out["details"]["error_code"] == "api_error"
+
+    def test_result_keys_in_summary(self, fake_http):
+        fake_http.post_responses.append(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "result": {"regime": "BULL", "confidence": 0.7},
+            }
+        )
+        out = json.loads(
+            a2a_call(
+                {
+                    "action": "send_task",
+                    "agent_url": "https://bv7x.ai",
+                    "skill": "x",
+                }
+            )
+        )
+        # Summary should mention the result keys.
+        assert "regime" in out["content"][0]["text"]
+
+
+# --- guards / dispatch --------------------------------------------------
+
+
+class TestGuards:
+    def test_malformed_url(self):
+        out = json.loads(a2a_call({"action": "discover", "agent_url": "not-a-url"}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_missing_action(self):
+        out = json.loads(a2a_call({"agent_url": "https://bv7x.ai"}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_missing_agent_url(self):
+        out = json.loads(a2a_call({"action": "discover"}))
+        assert out["details"]["error_code"] == "param_error"
+
+
+# --- registration ------------------------------------------------------
+
+
+class TestRegister:
+    def test_register(self):
+        captured = []
+
+        class FakeCtx:
+            def register_tool(self, **kw):
+                captured.append(kw)
+
+        register(FakeCtx())
+        assert len(captured) == 1
+        assert captured[0]["name"] == "a2a_call"

--- a/tests/tools/test_bv7x_tool.py
+++ b/tests/tools/test_bv7x_tool.py
@@ -1,0 +1,120 @@
+"""Tests for the ``bv7x`` tool (wraps BV7XService)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawmes.services import bv7x as bv7x_svc
+from clawmes.tools.bv7x import bv7x, register
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    from clawmes.policy import storage as policy_storage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(bv7x_svc, "_instance", None)
+    policy_storage.save_policies([])
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    class FakeHttp:
+        responses: list = []
+
+        def __call__(self, *args, **kw):
+            if not self.responses:
+                raise AssertionError("no fake response queued")
+            response = self.responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+    fake = FakeHttp()
+    monkeypatch.setattr(bv7x_svc, "http_get", fake)
+    return fake
+
+
+def _call(action):
+    return json.loads(bv7x({"action": action}))
+
+
+class TestRegime:
+    def test_basic(self, fake_http):
+        fake_http.responses.append({"regime": "BEAR_TREND", "risk_level": "High", "fear_greed": 11})
+        out = _call("regime")
+        assert out["details"]["regime"] == "BEAR_TREND"
+        assert "BEAR_TREND" in out["content"][0]["text"]
+        assert "risk=High" in out["content"][0]["text"]
+
+    def test_summary_without_risk_level(self, fake_http):
+        fake_http.responses.append({"regime": "BULL"})
+        out = _call("regime")
+        assert "BV-7X regime: BULL" in out["content"][0]["text"]
+
+
+class TestIdentity:
+    def test_basic(self, fake_http):
+        fake_http.responses.append({"agent_id": 28841, "reputation": 0.87})
+        out = _call("identity")
+        assert out["details"]["agent_id"] == 28841
+        assert "28841" in out["content"][0]["text"]
+        assert "reputation=0.87" in out["content"][0]["text"]
+
+    def test_no_reputation(self, fake_http):
+        fake_http.responses.append({"agent_id": 1})
+        out = _call("identity")
+        # Summary should mention the agent but not include "reputation=".
+        assert "agent #1" in out["content"][0]["text"]
+        assert "reputation=" not in out["content"][0]["text"]
+
+
+class TestDiscover:
+    def test_basic(self, fake_http):
+        fake_http.responses.append(
+            {
+                "skills": ["get_market_context", "get_signal_summary"],
+                "version": "0.3.0",
+            }
+        )
+        out = _call("discover")
+        assert "2 skill(s)" in out["content"][0]["text"]
+        assert "v0.3.0" in out["content"][0]["text"]
+
+
+class TestErrorPropagation:
+    def test_rate_limit(self, fake_http):
+        fake_http.responses.append(RuntimeError("HTTP 429"))
+        out = _call("regime")
+        assert out["isError"] is True
+        assert out["details"]["error_code"] == "rate_limited"
+
+    def test_token_gated(self, fake_http):
+        fake_http.responses.append(RuntimeError("requires BV7X token"))
+        out = _call("regime")
+        assert out["details"]["error_code"] == "token_gated"
+
+
+class TestInvalidAction:
+    def test_unknown(self):
+        out = json.loads(bv7x({"action": "explode"}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_missing(self):
+        out = json.loads(bv7x({}))
+        assert out["details"]["error_code"] == "param_error"
+
+
+class TestRegister:
+    def test_register(self):
+        captured = []
+
+        class FakeCtx:
+            def register_tool(self, **kw):
+                captured.append(kw)
+
+        register(FakeCtx())
+        assert len(captured) == 1
+        assert captured[0]["name"] == "bv7x"

--- a/tests/tools/test_eas_attestation.py
+++ b/tests/tools/test_eas_attestation.py
@@ -1,0 +1,338 @@
+"""Tests for the ``eas_attestation`` tool."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawmes.services import rpc as rpc_mod
+from clawmes.tools import eas_attestation as eas_mod
+from clawmes.tools.eas_attestation import eas_attestation, register
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    from clawmes.policy import storage as policy_storage
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(rpc_mod, "_instance", None)
+    policy_storage.save_policies([])
+
+
+@pytest.fixture
+def fake_rpc(monkeypatch):
+    class FakeRpc:
+        calls: list = []
+        responses: list = []
+
+        def eth_call(self, *, to, data, chain_id, block="latest"):
+            self.calls.append({"to": to, "data": data, "chain_id": chain_id})
+            if not self.responses:
+                raise AssertionError("no fake rpc response queued")
+            r = self.responses.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+    fake = FakeRpc()
+    # Patch the alias inside the tool module, not the source. The tool
+    # does `from clawmes.services.rpc import ... get_rpc_service` at
+    # module load time, so the binding lives in eas_attestation's
+    # namespace.
+    monkeypatch.setattr(eas_mod, "get_rpc_service", lambda: fake)
+    return fake
+
+
+def _encode_attestation(
+    *,
+    uid: bytes,
+    schema: bytes = b"\xbb" * 32,
+    time_: int = 1779000000,
+    expiration: int = 0,
+    revocation: int = 0,
+    ref_uid: bytes = b"\x00" * 32,
+    recipient: str = "0x" + "cc" * 20,
+    attester: str = "0x" + "dd" * 20,
+    revocable: bool = True,
+    data: bytes = b"hello",
+) -> str:
+    """Build a hex-encoded EAS getAttestation return value."""
+    from eth_abi import encode
+
+    encoded = encode(
+        [
+            "(bytes32,bytes32,uint64,uint64,uint64,bytes32,address,address,bool,bytes)",
+        ],
+        [
+            (
+                uid,
+                schema,
+                time_,
+                expiration,
+                revocation,
+                ref_uid,
+                recipient,
+                attester,
+                revocable,
+                data,
+            )
+        ],
+    )
+    return "0x" + encoded.hex()
+
+
+# --- get action --------------------------------------------------------
+
+
+class TestGet:
+    def test_basic(self, fake_rpc):
+        uid = b"\xaa" * 32
+        fake_rpc.responses.append(_encode_attestation(uid=uid))
+        out = json.loads(eas_attestation({"action": "get", "uid": "0x" + uid.hex()}))
+        details = out["details"]
+        assert details["uid"] == "0x" + uid.hex()
+        assert details["attester"] == "0x" + "dd" * 20
+        assert details["recipient"] == "0x" + "cc" * 20
+        assert details["revocable"] is True
+        assert details["is_revoked"] is False
+        # Check the RPC call was to the canonical EAS address on Base.
+        assert fake_rpc.calls[0]["to"] == ("0x4200000000000000000000000000000000000021")
+        assert fake_rpc.calls[0]["chain_id"] == 8453
+
+    def test_revoked_attestation(self, fake_rpc):
+        uid = b"\xaa" * 32
+        fake_rpc.responses.append(_encode_attestation(uid=uid, revocation=1779100000))
+        out = json.loads(eas_attestation({"action": "get", "uid": "0x" + uid.hex()}))
+        assert out["details"]["is_revoked"] is True
+        assert "REVOKED" in out["content"][0]["text"]
+
+    def test_expired_attestation(self, fake_rpc):
+        uid = b"\xaa" * 32
+        # Expiration set to a past time (epoch 100).
+        fake_rpc.responses.append(_encode_attestation(uid=uid, expiration=100))
+        out = json.loads(eas_attestation({"action": "get", "uid": "0x" + uid.hex()}))
+        assert out["details"]["is_expired"] is True
+        assert "EXPIRED" in out["content"][0]["text"]
+
+    def test_no_expiration(self, fake_rpc):
+        uid = b"\xaa" * 32
+        fake_rpc.responses.append(_encode_attestation(uid=uid, expiration=0))
+        out = json.loads(eas_attestation({"action": "get", "uid": "0x" + uid.hex()}))
+        assert out["details"]["is_expired"] is False
+
+    def test_uid_without_0x_prefix(self, fake_rpc):
+        uid = b"\xaa" * 32
+        fake_rpc.responses.append(_encode_attestation(uid=uid))
+        # No 0x prefix.
+        out = json.loads(eas_attestation({"action": "get", "uid": uid.hex()}))
+        assert out["details"]["uid"] == "0x" + uid.hex()
+
+    def test_custom_chain_id(self, fake_rpc):
+        uid = b"\xaa" * 32
+        fake_rpc.responses.append(_encode_attestation(uid=uid))
+        eas_attestation({"action": "get", "uid": "0x" + uid.hex(), "chain_id": 1})
+        assert fake_rpc.calls[0]["chain_id"] == 1
+
+    def test_custom_eas_address(self, fake_rpc):
+        uid = b"\xaa" * 32
+        fake_rpc.responses.append(_encode_attestation(uid=uid))
+        eas_attestation(
+            {
+                "action": "get",
+                "uid": "0x" + uid.hex(),
+                "eas_address": "0x" + "11" * 20,
+            }
+        )
+        assert fake_rpc.calls[0]["to"] == "0x" + "11" * 20
+
+    def test_all_zero_uid_returns_not_found(self, fake_rpc):
+        # EAS returns an all-zero Attestation for nonexistent UIDs.
+        fake_rpc.responses.append(_encode_attestation(uid=b"\x00" * 32))
+        out = json.loads(eas_attestation({"action": "get", "uid": "0x" + "aa" * 32}))
+        assert out["details"]["error_code"] == "not_found"
+
+    def test_empty_rpc_result(self, fake_rpc):
+        fake_rpc.responses.append("0x")
+        out = json.loads(eas_attestation({"action": "get", "uid": "0x" + "aa" * 32}))
+        assert out["details"]["error_code"] == "not_found"
+
+    def test_rpc_error(self, fake_rpc):
+        from clawmes.services.rpc import RpcError
+
+        fake_rpc.responses.append(RpcError("rpc_unreachable", "endpoint down"))
+        out = json.loads(eas_attestation({"action": "get", "uid": "0x" + "aa" * 32}))
+        assert out["details"]["error_code"] == "rpc_error"
+
+    def test_bad_uid_hex(self):
+        out = json.loads(eas_attestation({"action": "get", "uid": "not-hex"}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_wrong_length_uid(self):
+        # 16 bytes instead of 32.
+        out = json.loads(eas_attestation({"action": "get", "uid": "0x" + "aa" * 16}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_missing_uid(self):
+        out = json.loads(eas_attestation({"action": "get"}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_decode_failure(self, fake_rpc):
+        # Return malformed data that can't decode as the Attestation tuple.
+        fake_rpc.responses.append("0xdeadbeef")
+        out = json.loads(eas_attestation({"action": "get", "uid": "0x" + "aa" * 32}))
+        assert out["details"]["error_code"] == "api_error"
+
+
+# --- decode_data action ------------------------------------------------
+
+
+class TestDecodeData:
+    def test_basic(self):
+        from eth_abi import encode
+
+        encoded = encode(["uint8", "string"], [42, "hello"])
+        out = json.loads(
+            eas_attestation(
+                {
+                    "action": "decode_data",
+                    "data_hex": "0x" + encoded.hex(),
+                    "schema_types": "uint8,string",
+                }
+            )
+        )
+        assert out["details"]["values"][0] == 42
+        assert out["details"]["values"][1] == "hello"
+
+    def test_without_0x_prefix(self):
+        from eth_abi import encode
+
+        encoded = encode(["uint8"], [42])
+        out = json.loads(
+            eas_attestation(
+                {
+                    "action": "decode_data",
+                    "data_hex": encoded.hex(),
+                    "schema_types": "uint8",
+                }
+            )
+        )
+        assert out["details"]["values"][0] == 42
+
+    def test_bytes_value_stringified(self):
+        from eth_abi import encode
+
+        encoded = encode(["bytes32"], [b"\xaa" * 32])
+        out = json.loads(
+            eas_attestation(
+                {
+                    "action": "decode_data",
+                    "data_hex": "0x" + encoded.hex(),
+                    "schema_types": "bytes32",
+                }
+            )
+        )
+        # bytes are surfaced as 0x-prefixed hex strings.
+        assert out["details"]["values"][0] == "0x" + "aa" * 32
+
+    def test_tuple_value(self):
+        from eth_abi import encode
+
+        encoded = encode(["(uint8,bool)"], [(7, True)])
+        out = json.loads(
+            eas_attestation(
+                {
+                    "action": "decode_data",
+                    "data_hex": "0x" + encoded.hex(),
+                    "schema_types": "(uint8,bool)",
+                }
+            )
+        )
+        # Tuple comes back as a list of [int, bool].
+        assert out["details"]["values"][0] == [7, True]
+
+    def test_missing_data(self):
+        out = json.loads(eas_attestation({"action": "decode_data", "schema_types": "uint8"}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_missing_schema(self):
+        out = json.loads(eas_attestation({"action": "decode_data", "data_hex": "0x00"}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_bad_data_hex(self):
+        out = json.loads(
+            eas_attestation(
+                {
+                    "action": "decode_data",
+                    "data_hex": "not-hex",
+                    "schema_types": "uint8",
+                }
+            )
+        )
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_empty_schema_types_string(self):
+        out = json.loads(
+            eas_attestation(
+                {
+                    "action": "decode_data",
+                    "data_hex": "0x00",
+                    "schema_types": ",  ,",
+                }
+            )
+        )
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_decode_failure_against_schema(self):
+        out = json.loads(
+            eas_attestation(
+                {
+                    "action": "decode_data",
+                    "data_hex": "0x" + "00" * 10,
+                    "schema_types": "uint256,string",  # not enough data
+                }
+            )
+        )
+        assert out["details"]["error_code"] == "api_error"
+
+
+# --- guards ------------------------------------------------------------
+
+
+class TestGuards:
+    def test_unknown_action(self):
+        out = json.loads(eas_attestation({"action": "explode"}))
+        assert out["details"]["error_code"] == "param_error"
+
+    def test_missing_action(self):
+        out = json.loads(eas_attestation({}))
+        assert out["details"]["error_code"] == "param_error"
+
+
+# --- helpers -----------------------------------------------------------
+
+
+class TestHelpers:
+    def test_now_seconds(self):
+        # Just verify it returns a sensible int.
+        assert eas_mod._now_seconds() > 1_700_000_000
+
+    def test_stringify_for_json_passes_through_ints_and_bools(self):
+        out = eas_mod._stringify_for_json((42, True, "x"))
+        assert out == [42, True, "x"]
+
+
+# --- registration ------------------------------------------------------
+
+
+class TestRegister:
+    def test_register(self):
+        captured = []
+
+        class FakeCtx:
+            def register_tool(self, **kw):
+                captured.append(kw)
+
+        register(FakeCtx())
+        assert len(captured) == 1
+        assert captured[0]["name"] == "eas_attestation"


### PR DESCRIPTION
## Summary

Agent-economy integration with the bv7x.ai ecosystem and broader on-chain primitives. **PR 9 in the parity series** ([#3](https://github.com/clawnchdev/clawmes/pull/3) policy_manage, [#4](https://github.com/clawnchdev/clawmes/pull/4) onboarding, [#5](https://github.com/clawnchdev/clawmes/pull/5) wallet-recovery, [#6](https://github.com/clawnchdev/clawmes/pull/6) evolution+balance, [#7](https://github.com/clawnchdev/clawmes/pull/7) allowlist, [#8](https://github.com/clawnchdev/clawmes/pull/8) history+info, [#9](https://github.com/clawnchdev/clawmes/pull/9) discovery, [#10](https://github.com/clawnchdev/clawmes/pull/10) agent_identity all still open).

## Surface delta

| | Before | After |
|---|---|---|
| Tools | 45 | **48** |
| Commands | 28 | 28 |
| Services | 15 | **16** |
| Hooks | 11 | 11 |
| New allowlist hosts | — | `bv7x.ai` |
| New env vars | — | — |

## What's in this PR

### 1. `bv7x` tool + `BV7XService`

Read BV-7X autonomous BTC oracle data via their **public** REST API. Three actions:

| Action | Returns |
|---|---|
| `regime` | Market regime (CRISIS / BEAR / NEUTRAL / BULL / EUPHORIA) + thresholds |
| `identity` | BV-7X's on-chain agent identity + reputation |
| `discover` | A2A discovery card |

60-second cache. **Token-gated premium endpoints (`/oracle`, `/copy-trade`) are NOT exposed.** clawmes does not require third-party token holdings — same posture as we took with gitlawb's `$gitlawb` token. If a user holds `$BV7X` and wants those endpoints, they hit the API directly with their own credentials.

### 2. `a2a_call` tool

Generic agent-to-agent JSON-RPC 2.0 client. Two actions:

- `discover` — GET `{agent_url}/.well-known/agent-card.json`, surface skill list
- `send_task` — POST JSON-RPC 2.0 to a configurable task path (default matches BV-7X's `/api/bv7x/a2a/tasks/send`)

**Works with any A2A-speaking peer**, not just BV-7X. The target host must be on the network allowlist (`/allow <host>` for session peers, or in `_DEFAULT_ALLOWLIST` for permanent additions).

Authentication via DID signatures (RFC 9421) is **deferred** to a follow-up that pairs with the `IdentityService` from PR #10.

### 3. `eas_attestation` tool

Read EAS attestations on Base. Two actions:

- `get(uid, chain_id?, eas_address?)` — fetch by 32-byte UID, decoded into the canonical Attestation struct (uid, schema, time, expirationTime, revocationTime, refUID, recipient, attester, revocable, data). Auto-detects revoked / expired state.
- `decode_data(data_hex, schema_types)` — parse raw bytes payload against a caller-supplied ABI schema. Handles parenthesized tuple types via a depth-aware splitter.

Defaults to the EAS canonical singleton on Base (`0x4200000000000000000000000000000000000021`). Configurable `chain_id` + `eas_address` for other L2s. Uses `eth-abi` (transitive web3 dep) for struct encoding/decoding.

**Generic on-chain primitive** — useful for BV-7X signal attestations, trust-score certificates, KYC results, and any EAS-using protocol.

## What I deferred and why

**ERC-8004 agent registry.** The spec is currently a draft EIP (created 2025-08-13, status: Draft) with no canonical Base-singleton address yet. Authors include people from MetaMask, EF, Google, and Coinbase, so it's serious — but the contract address isn't stable. I'd be implementing against a spec that could change.

Will wire ERC-8004 once the spec finalizes and a registry singleton lands. Noted in the CHANGELOG as deferred.

## Verification

- `pytest tests/services/test_bv7x.py tests/tools/test_bv7x_tool.py tests/tools/test_a2a_call.py tests/tools/test_eas_attestation.py --cov` → **100+ tests pass, 100% coverage on every new module**
- `pytest --cov=clawmes` → **2136 passing**, 8 skipped, 100% coverage gate satisfied
- `ruff check clawmes tests` → clean
- `test_plugin_manifest.py` → both `plugin.yaml` copies still byte-identical
- `test_doctor.py::test_real_manifest_counts` → updated 45 → 48

## Notes for reviewers

- **BV-7X has its own `\$BV7X` token, same red-flag pattern as `\$gitlawb`.** We don't expose token-gated endpoints. Only the genuinely public stuff (regime, identity, discover). Users who want premium can hit BV-7X directly with their own credentials — clawmes shouldn't be in that loop.
- **No signal injection into `pre_llm_call`.** I explicitly did not bake BV-7X's daily DOWN/UP prediction into the agent's per-turn context. Embedding one party's directional bet as ambient context is bad design — if a user wants to see the signal, they call the tool. (And the daily oracle endpoint is token-gated anyway, so this is also a non-issue practically.)
- **EAS canonical address on Base** is `0x4200000000000000000000000000000000000021` per attest.org docs. The tool defaults there; pass `eas_address=` to override for other chains.
- **`eth-abi`'s `decode` quirks**: `abi_decode(['(uint8,bool)'], encoded_bytes)` returns `((7, True),)` — a 1-tuple containing the decoded tuple. My `_stringify_for_json` handles the nesting.
- **A2A is auth-less in v1.** The protocol supports authenticated calls but most peers (including BV-7X) accept unauth for reads. Adding DID-signed requests is a natural follow-up once both this and PR #10 land.
- **Defer ERC-8004.** Documented in CHANGELOG and module comments. Tracking the EIP at https://eips.ethereum.org/EIPS/eip-8004.