### PR TITLE
feat(launch): image + social metadata (twitter, website, telegram, farcaster, discord)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added — launch metadata (image + socials)
+
+- **`/launch image <url>`** — set the token image URL.
+- **`/launch twitter <handle|url>`** (alias `/launch x`) — set X / Twitter
+  handle or full URL. Bare handles (`clawnchbot`, `@clawnchbot`) are
+  normalized to `https://x.com/<handle>`; full URLs pass through.
+- **`/launch website <url>`** — set the project website.
+- **`/launch telegram <handle|url>`** — set Telegram handle or invite URL.
+  Bare handles normalize to `https://t.me/<handle>`.
+- **`/launch farcaster <handle|url>`** — set Farcaster handle. Bare
+  handles normalize to `https://warpcast.com/<handle>`.
+- **`/launch discord <url>`** — set Discord invite URL (no
+  normalization; full URLs only).
+- **`clawnch_launch` tool** — accepts the same set of metadata args
+  (`image`, `twitter`, `website`, `telegram`, `farcaster`, `discord`)
+  with the same normalization logic. LLM can pass them directly per
+  the updated OpenAI schema.
+- Collected metadata is serialized to `tokenParams.image` +
+  `tokenParams.metadata.socialMediaUrls` per the Clawnch API contract,
+  matching the format the launchpad's deploy endpoint already accepts
+  (server-side handling unchanged).
+- `/launch status` and `/launch` (usage) now render the `socials`
+  sub-map with one line per platform for readability.
+
 ## 0.2.0 — 2026-05-21
 
 Major release covering ten merged PRs plus the Clawnch launchpad

--- a/README.md
+++ b/README.md
@@ -160,11 +160,19 @@ Clawmes wires the Clawnch launchpad end-to-end so any user can deploy a token fr
 /launch name MyCoin
 /launch symbol MC
 /launch description The next big thing       # optional
+/launch image https://i.imgur.com/mycoin.png # optional
+/launch twitter mycoin                       # optional — also: /launch x
+/launch website mycoin.xyz                   # optional
+/launch telegram mycoinchat                  # optional
+/launch farcaster mycoin                     # optional
+/launch discord https://discord.gg/abc       # optional
 /launch confirm
 # Clawnch's deployer wallet submits the Clanker tx server-side;
 # your wallet only signs the captcha. Returns tx hash + token
 # address.
 ```
+
+Social handles get normalized (`mycoin` → `https://x.com/mycoin`); full URLs pass through unchanged. They're persisted to `tokenParams.metadata.socialMediaUrls` on the launchpad side and may render as badges on the launch detail page.
 
 Free-tier rate limit: 1 deploy per 24 hours per agent. To skip the cooldown, send `0.001 ETH` (or the current bypass amount) to the Clawnch bypass recipient on Base, then `/launch bypass <tx_hash>` and `/launch confirm`.
 

--- a/clawmes/commands/launch.py
+++ b/clawmes/commands/launch.py
@@ -6,15 +6,24 @@ single channel can have multiple deploys in progress concurrently.
 
 Steps:
 
-  1. ``/launch`` (no args) — show usage + start a new deploy slot.
-  2. ``/launch name <token name>`` — set the name.
-  3. ``/launch symbol <ticker>`` — set the symbol.
-  4. ``/launch description <text>`` — optional one-liner.
-  5. ``/launch bypass <0x...>`` — optional tx hash to skip the 24h
-     cooldown. Falls back to free path if omitted.
-  6. ``/launch confirm`` — execute the deploy.
-  7. ``/launch cancel`` — clear the slot.
-  8. ``/launch status`` — show the current draft.
+  Core:
+    ``/launch name <token name>``
+    ``/launch symbol <ticker>``
+    ``/launch description <text>``        (optional)
+
+  Metadata:
+    ``/launch image <url>``               (optional — token image)
+    ``/launch twitter <handle | url>``    (optional — X / Twitter)
+    ``/launch website <url>``             (optional)
+    ``/launch telegram <handle | url>``   (optional)
+    ``/launch farcaster <handle | url>``  (optional)
+    ``/launch discord <url>``             (optional)
+
+  Flow:
+    ``/launch bypass <tx_hash>``          (optional — skip 24h cooldown)
+    ``/launch status``                    (show draft)
+    ``/launch confirm``                   (deploy)
+    ``/launch cancel``                    (clear)
 
 Auth: requires ``CLAWNCH_API_KEY`` in env (Clawnch refuses unauth'd
 deploys). The user-facing error from the underlying call tells the
@@ -31,6 +40,55 @@ from typing import Any
 
 _log_state: dict[str, dict[str, Any]] = {}
 _state_lock = threading.RLock()
+
+
+# ── social link normalization ───────────────────────────────────────
+
+
+def _normalize_handle_or_url(value: str, base_url: str) -> str:
+    """Turn ``@handle`` / ``handle`` / full URL into a full URL.
+
+    Falls back to the raw value when nothing else fits — Clawnch's
+    socialMediaUrls is a free-form ``{platform, url}`` list, so we
+    don't strictly need URLs; this is just for ergonomics so a user
+    can type ``/launch twitter clawnchbot`` and get something sane.
+    """
+    v = value.strip()
+    if v.startswith(("http://", "https://")):
+        return v
+    handle = v.removeprefix("@").strip()
+    return f"{base_url}{handle}" if handle else v
+
+
+def _normalize_url(value: str) -> str:
+    """Pass-through normalizer for URLs (website, telegram, discord).
+
+    Strips whitespace. Adds ``https://`` if missing for bare hostnames
+    like ``example.com``. Returns the raw value if the input doesn't
+    look hostname-shaped.
+    """
+    v = value.strip()
+    if v.startswith(("http://", "https://")):
+        return v
+    if "." in v and " " not in v:
+        return f"https://{v}"
+    return v
+
+
+# Map of `/launch <platform>` arg to (clawnch platform name, normalizer).
+# Keeping the clawnch platform names stable since the launchpad UI may
+# render badges keyed on these strings (twitter, telegram, etc.).
+_SOCIAL_PLATFORMS: dict[str, tuple[str, str]] = {
+    "twitter": ("twitter", "https://x.com/"),
+    "x": ("twitter", "https://x.com/"),  # alias
+    "telegram": ("telegram", "https://t.me/"),
+    "farcaster": ("farcaster", "https://warpcast.com/"),
+    "discord": ("discord", ""),  # discord uses full invite URLs
+    "website": ("website", ""),  # plain URL
+}
+
+
+# ── per-sender state helpers ────────────────────────────────────────
 
 
 def _record(name: str, args: str, result: str) -> None:
@@ -60,6 +118,22 @@ def _clear_draft(sender_id: str) -> None:
 
 def _resolve_sender(kwargs: dict[str, Any]) -> str:
     return str(kwargs.get("sender_id") or "default")
+
+
+def _set_social(draft: dict[str, Any], platform_arg: str, value: str) -> str:
+    """Record a social link on the draft. Returns user-facing message."""
+    cfg = _SOCIAL_PLATFORMS[platform_arg]
+    platform_name, base_url = cfg
+    if base_url:
+        url = _normalize_handle_or_url(value, base_url)
+    else:
+        url = _normalize_url(value)
+    socials = draft.setdefault("socials", {})
+    socials[platform_name] = url
+    return f"{platform_name.capitalize()} set: {url}"
+
+
+# ── main handler ────────────────────────────────────────────────────
 
 
 async def handle_launch(raw_args: str, **kwargs: Any) -> str:
@@ -95,8 +169,8 @@ async def handle_launch(raw_args: str, **kwargs: Any) -> str:
             draft["symbol"] = rest.upper()
             out = (
                 f"Symbol set: {draft['symbol']}. "
-                "Next: /launch description <text> (optional) or "
-                "/launch confirm."
+                "Add metadata (/launch image, /launch twitter, /launch website…) "
+                "or /launch confirm."
             )
     elif action == "description":
         draft = _get_draft(sender_id)
@@ -104,7 +178,20 @@ async def handle_launch(raw_args: str, **kwargs: Any) -> str:
             out = "Usage: /launch description <text>"
         else:
             draft["description"] = rest
-            out = "Description set. Next: /launch confirm."
+            out = "Description set."
+    elif action == "image":
+        draft = _get_draft(sender_id)
+        if not rest:
+            out = "Usage: /launch image <url>"
+        else:
+            draft["image"] = _normalize_url(rest)
+            out = f"Image set: {draft['image']}"
+    elif action in _SOCIAL_PLATFORMS:
+        draft = _get_draft(sender_id)
+        if not rest:
+            out = f"Usage: /launch {action} <handle or url>"
+        else:
+            out = _set_social(draft, action, rest)
     elif action == "bypass":
         draft = _get_draft(sender_id)
         if not rest:
@@ -117,10 +204,16 @@ async def handle_launch(raw_args: str, **kwargs: Any) -> str:
     else:
         out = (
             f"Unknown /launch arg {action!r}. Use:\n"
-            "  /launch                       — show this help\n"
+            "  /launch                       — show this help + draft\n"
             "  /launch name <name>           — set token name\n"
             "  /launch symbol <TICKER>       — set ticker\n"
             "  /launch description <text>    — optional description\n"
+            "  /launch image <url>           — token image URL\n"
+            "  /launch twitter <handle|url>  — X / Twitter (alias: /launch x)\n"
+            "  /launch website <url>         — website\n"
+            "  /launch telegram <handle|url> — Telegram\n"
+            "  /launch farcaster <handle>    — Farcaster\n"
+            "  /launch discord <url>         — Discord\n"
             "  /launch bypass <tx_hash>      — skip 24h cooldown\n"
             "  /launch status                — show current draft\n"
             "  /launch confirm               — deploy\n"
@@ -134,11 +227,24 @@ def _render_usage(draft: dict[str, Any]) -> str:
     lines = [
         "Launch a token on Clawnch (guided flow).",
         "",
+        "Required:",
         "  /launch name <token name>",
         "  /launch symbol <TICKER>",
-        "  /launch description <text>     (optional)",
-        "  /launch bypass <tx_hash>       (optional — skip 24h cooldown)",
-        "  /launch confirm",
+        "",
+        "Optional metadata:",
+        "  /launch description <text>",
+        "  /launch image <url>",
+        "  /launch twitter <handle|url>     (or /launch x)",
+        "  /launch website <url>",
+        "  /launch telegram <handle|url>",
+        "  /launch farcaster <handle|url>",
+        "  /launch discord <url>",
+        "",
+        "Flow:",
+        "  /launch bypass <tx_hash>         (skip 24h cooldown)",
+        "  /launch status                   (show draft)",
+        "  /launch confirm                  (deploy)",
+        "  /launch cancel                   (clear draft)",
         "",
         "Requires CLAWNCH_API_KEY. Use /register_agent if you need a key.",
         "Active wallet must be connected — the deploy signs a captcha.",
@@ -146,8 +252,7 @@ def _render_usage(draft: dict[str, Any]) -> str:
     if draft:
         lines.append("")
         lines.append("Current draft:")
-        for key, value in draft.items():
-            lines.append(f"  {key}: {value}")
+        lines.extend(_format_draft_lines(draft))
     return "\n".join(lines)
 
 
@@ -155,9 +260,21 @@ def _render_status(draft: dict[str, Any]) -> str:
     if not draft:
         return "No launch draft. Start with /launch name <token name>."
     lines = ["Launch draft:"]
-    for key, value in draft.items():
-        lines.append(f"  {key}: {value}")
+    lines.extend(_format_draft_lines(draft))
     return "\n".join(lines)
+
+
+def _format_draft_lines(draft: dict[str, Any]) -> list[str]:
+    """Format draft for display. Socials get nested rendering for clarity."""
+    out: list[str] = []
+    for key, value in draft.items():
+        if key == "socials" and isinstance(value, dict):
+            out.append("  socials:")
+            for platform, url in value.items():
+                out.append(f"    {platform}: {url}")
+        else:
+            out.append(f"  {key}: {value}")
+    return out
 
 
 async def _confirm(sender_id: str) -> str:
@@ -173,6 +290,15 @@ async def _confirm(sender_id: str) -> str:
     token_params: dict[str, Any] = {"name": name, "symbol": symbol}
     if description := draft.get("description"):
         token_params["description"] = description
+    if image := draft.get("image"):
+        token_params["image"] = image
+    socials = draft.get("socials") or {}
+    if socials:
+        token_params["metadata"] = {
+            "socialMediaUrls": [
+                {"platform": platform, "url": url} for platform, url in socials.items()
+            ]
+        }
 
     bypass = draft.get("bypass_tx_hash")
 
@@ -217,5 +343,5 @@ def register(ctx) -> None:
         name="launch",
         handler=handle_launch,
         description="Deploy a token on Clawnch via guided chat flow",
-        args_hint="[name | symbol | description | bypass | status | confirm | cancel] <value>",
+        args_hint="[name | symbol | description | image | twitter | website | telegram | farcaster | discord | bypass | status | confirm | cancel] <value>",
     )

--- a/clawmes/skills/clawnch-launch/SKILL.md
+++ b/clawmes/skills/clawnch-launch/SKILL.md
@@ -81,10 +81,18 @@ the public launch detail page. Observable + intentional.
 | `/launch name <token name>` | Step 1: set name. |
 | `/launch symbol <TICKER>` | Step 2: set symbol. |
 | `/launch description <text>` | Optional one-liner. |
+| `/launch image <url>` | Token image URL. |
+| `/launch twitter <handle\|url>` | X / Twitter (alias: `/launch x`). Accepts `@handle`, `handle`, or full URL. |
+| `/launch website <url>` | Website URL. |
+| `/launch telegram <handle\|url>` | Telegram handle or invite URL. |
+| `/launch farcaster <handle\|url>` | Farcaster handle or Warpcast URL. |
+| `/launch discord <url>` | Discord invite URL. |
 | `/launch bypass <tx_hash>` | Optional: skip 24h cooldown. |
 | `/launch status` | Show current draft. |
 | `/launch confirm` | Deploy. |
 | `/launch cancel` | Clear draft. |
+
+Social handles are normalized — `/launch twitter clawnchbot` becomes `https://x.com/clawnchbot`. Full URLs pass through unchanged. The launchpad stores them as `tokenParams.metadata.socialMediaUrls` and may render them as badges on the launch detail page.
 
 ## Tool actions
 
@@ -92,8 +100,10 @@ the public launch detail page. Observable + intentional.
 
 | Action | Returns |
 |---|---|
-| `deploy` | `{txHash, tokenAddress, ...}` on success. Requires `name`, `symbol`; accepts `description`, `image`, `bypass_tx_hash`. |
+| `deploy` | `{txHash, tokenAddress, ...}` on success. Requires `name`, `symbol`; accepts `description`, `image`, `twitter`, `website`, `telegram`, `farcaster`, `discord`, `bypass_tx_hash`. |
 | `info` | Launch metadata for a deployed token. Requires `token` (address). |
+
+Each social arg is normalized the same way the slash command does — bare handles become full platform URLs, full URLs pass through. Pass `discord` and `website` as complete URLs.
 
 ### `clawnch_fees`
 

--- a/clawmes/tools/clawnch_launch.py
+++ b/clawmes/tools/clawnch_launch.py
@@ -12,6 +12,12 @@ launchpad HTTP API. Two actions:
     bypass recipient (see ``CLAWNCH_BYPASS_RECIPIENT``).
   * ``info`` — read launch metadata for an existing token.
 
+Metadata: ``image`` + per-platform social URLs (``twitter``,
+``website``, ``telegram``, ``farcaster``, ``discord``) are passed
+through to the launchpad's ``tokenParams.metadata.socialMediaUrls``.
+Each platform value is normalized (``@handle`` -> full URL when the
+platform has a stable user URL like x.com / t.me / warpcast).
+
 What used to be ``pair`` and ``seed_lp`` collapsed into ``deploy``:
 Clanker handles ERC-20 deploy + Uniswap V4 pool + initial liquidity
 seeding atomically in one call, so the multi-step ``pair`` /
@@ -34,6 +40,39 @@ from clawmes.tools.registry import register_with_ctx, write_tool
 
 _log = logger_for("tools.clawnch_launch")
 
+
+# Map of (schema arg name, clawnch platform name, base URL). Base URL
+# is empty for platforms that use full invite / handle URLs (discord,
+# website). Matches the same set the /launch command exposes.
+_SOCIAL_FIELDS: tuple[tuple[str, str, str], ...] = (
+    ("twitter", "twitter", "https://x.com/"),
+    ("website", "website", ""),
+    ("telegram", "telegram", "https://t.me/"),
+    ("farcaster", "farcaster", "https://warpcast.com/"),
+    ("discord", "discord", ""),
+)
+
+
+def _normalize_social(value: str, base_url: str) -> str:
+    """Normalize a social handle / URL. Mirrors commands.launch logic.
+
+    ``@handle`` or ``handle`` becomes ``base_url + handle`` when a
+    base URL is provided; full ``http(s)://`` URLs pass through.
+    Empty base URL = treat as a raw URL (just strip whitespace + add
+    ``https://`` for bare hostnames).
+    """
+    v = value.strip()
+    if v.startswith(("http://", "https://")):
+        return v
+    if base_url:
+        handle = v.removeprefix("@").strip()
+        return f"{base_url}{handle}" if handle else v
+    # No base URL — bare-hostname autocomplete or pass through.
+    if "." in v and " " not in v:
+        return f"https://{v}"
+    return v
+
+
 _SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -50,6 +89,28 @@ _SCHEMA: dict[str, Any] = {
         "image": {
             "type": "string",
             "description": "Image URL for token metadata (deploy, optional).",
+        },
+        "twitter": {
+            "type": "string",
+            "description": (
+                "X / Twitter handle (with or without @) or full URL (deploy, optional)."
+            ),
+        },
+        "website": {
+            "type": "string",
+            "description": "Website URL (deploy, optional).",
+        },
+        "telegram": {
+            "type": "string",
+            "description": ("Telegram handle or invite URL (deploy, optional)."),
+        },
+        "farcaster": {
+            "type": "string",
+            "description": ("Farcaster handle or full Warpcast URL (deploy, optional)."),
+        },
+        "discord": {
+            "type": "string",
+            "description": "Discord invite URL (deploy, optional).",
         },
         "bypass_tx_hash": {
             "type": "string",
@@ -79,8 +140,9 @@ _SCHEMA: dict[str, Any] = {
         "Deploy a token on Base via the Clawnch launchpad. Clawnch "
         "handles the deploy + initial liquidity atomically via the "
         "Clanker SDK; the user's wallet signs a captcha challenge to "
-        "prove identity. Requires CLAWNCH_API_KEY (register an agent "
-        "with /register_agent)."
+        "prove identity. Supports image + social metadata (twitter / "
+        "website / telegram / farcaster / discord). Requires "
+        "CLAWNCH_API_KEY (register an agent with /register_agent)."
     ),
     schema=_SCHEMA,
     emoji="\U0001f31f",
@@ -112,6 +174,14 @@ def _handle_deploy(args: dict[str, Any]) -> str:
         token_params["description"] = description
     if image := read_str(args, "image"):
         token_params["image"] = image
+
+    # Build socialMediaUrls from individual platform args.
+    socials: list[dict[str, str]] = []
+    for arg_key, platform_name, base_url in _SOCIAL_FIELDS:
+        if value := read_str(args, arg_key):
+            socials.append({"platform": platform_name, "url": _normalize_social(value, base_url)})
+    if socials:
+        token_params["metadata"] = {"socialMediaUrls": socials}
 
     bypass = read_str(args, "bypass_tx_hash") or None
 

--- a/tests/commands/test_launch.py
+++ b/tests/commands/test_launch.py
@@ -106,6 +106,124 @@ class TestDraftBuilding:
         assert "alice" not in launch_mod._log_state
 
 
+class TestImage:
+    async def test_image_requires_value(self):
+        out = await launch_mod.handle_launch("image", sender_id="alice")
+        assert "Usage" in out
+
+    async def test_image_full_url(self):
+        out = await launch_mod.handle_launch("image https://i.imgur.com/x.png", sender_id="alice")
+        assert "Image set: https://i.imgur.com/x.png" in out
+        assert launch_mod._log_state["alice"]["image"] == "https://i.imgur.com/x.png"
+
+    async def test_image_bare_hostname_gets_https(self):
+        await launch_mod.handle_launch("image example.com/x.png", sender_id="alice")
+        assert launch_mod._log_state["alice"]["image"] == "https://example.com/x.png"
+
+    async def test_image_passthrough_for_weird_input(self):
+        # Doesn't look like a URL — pass through unchanged (no autocomplete)
+        await launch_mod.handle_launch("image not a url", sender_id="alice")
+        assert launch_mod._log_state["alice"]["image"] == "not a url"
+
+
+class TestSocialPlatforms:
+    async def test_twitter_handle_normalized(self):
+        out = await launch_mod.handle_launch("twitter clawnchbot", sender_id="alice")
+        assert "Twitter set" in out
+        assert "https://x.com/clawnchbot" in out
+        socials = launch_mod._log_state["alice"]["socials"]
+        assert socials["twitter"] == "https://x.com/clawnchbot"
+
+    async def test_twitter_at_handle_normalized(self):
+        await launch_mod.handle_launch("twitter @clawnchbot", sender_id="alice")
+        assert launch_mod._log_state["alice"]["socials"]["twitter"] == "https://x.com/clawnchbot"
+
+    async def test_twitter_full_url_passthrough(self):
+        await launch_mod.handle_launch("twitter https://x.com/clawnchbot", sender_id="alice")
+        assert launch_mod._log_state["alice"]["socials"]["twitter"] == "https://x.com/clawnchbot"
+
+    async def test_x_alias_works(self):
+        # /launch x is an alias for /launch twitter; stores under "twitter"
+        await launch_mod.handle_launch("x clawnchbot", sender_id="alice")
+        assert "twitter" in launch_mod._log_state["alice"]["socials"]
+
+    async def test_telegram_handle_normalized(self):
+        await launch_mod.handle_launch("telegram clawnchalerts", sender_id="alice")
+        assert launch_mod._log_state["alice"]["socials"]["telegram"] == "https://t.me/clawnchalerts"
+
+    async def test_farcaster_handle_normalized(self):
+        await launch_mod.handle_launch("farcaster clawn", sender_id="alice")
+        assert (
+            launch_mod._log_state["alice"]["socials"]["farcaster"] == "https://warpcast.com/clawn"
+        )
+
+    async def test_discord_url_passthrough(self):
+        await launch_mod.handle_launch("discord https://discord.gg/abc", sender_id="alice")
+        assert launch_mod._log_state["alice"]["socials"]["discord"] == "https://discord.gg/abc"
+
+    async def test_discord_bare_hostname_gets_https(self):
+        await launch_mod.handle_launch("discord discord.gg/abc", sender_id="alice")
+        assert launch_mod._log_state["alice"]["socials"]["discord"] == "https://discord.gg/abc"
+
+    async def test_website_full_url(self):
+        await launch_mod.handle_launch("website https://mycoin.xyz", sender_id="alice")
+        assert launch_mod._log_state["alice"]["socials"]["website"] == "https://mycoin.xyz"
+
+    async def test_website_bare_hostname(self):
+        await launch_mod.handle_launch("website mycoin.xyz", sender_id="alice")
+        assert launch_mod._log_state["alice"]["socials"]["website"] == "https://mycoin.xyz"
+
+    async def test_handle_only_at_falls_back(self):
+        # Edge case: just an @ with no handle. Falls back to raw value.
+        await launch_mod.handle_launch("twitter @", sender_id="alice")
+        assert launch_mod._log_state["alice"]["socials"]["twitter"] == "@"
+
+    async def test_platform_requires_value(self):
+        out = await launch_mod.handle_launch("twitter", sender_id="alice")
+        assert "Usage" in out
+        assert "/launch twitter" in out
+
+
+class TestConfirmIncludesMetadata:
+    async def test_confirm_passes_image(self, fake_svc):
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        await launch_mod.handle_launch("image https://i.imgur.com/x.png", sender_id="alice")
+        await launch_mod.handle_launch("confirm", sender_id="alice")
+        params = fake_svc.deploys[0]["params"]
+        assert params["image"] == "https://i.imgur.com/x.png"
+
+    async def test_confirm_packs_socials(self, fake_svc):
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        await launch_mod.handle_launch("twitter clawn", sender_id="alice")
+        await launch_mod.handle_launch("website mycoin.xyz", sender_id="alice")
+        await launch_mod.handle_launch("confirm", sender_id="alice")
+        params = fake_svc.deploys[0]["params"]
+        urls = params["metadata"]["socialMediaUrls"]
+        platforms = {entry["platform"]: entry["url"] for entry in urls}
+        assert platforms["twitter"] == "https://x.com/clawn"
+        assert platforms["website"] == "https://mycoin.xyz"
+
+    async def test_confirm_no_metadata_when_none_set(self, fake_svc):
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        await launch_mod.handle_launch("confirm", sender_id="alice")
+        params = fake_svc.deploys[0]["params"]
+        assert "metadata" not in params
+        assert "image" not in params
+
+
+class TestStatusRendersSocials:
+    async def test_status_groups_socials(self):
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("twitter clawn", sender_id="alice")
+        out = await launch_mod.handle_launch("status", sender_id="alice")
+        assert "socials:" in out
+        assert "twitter" in out
+        assert "https://x.com/clawn" in out
+
+
 class TestPerSenderIsolation:
     async def test_two_senders_independent(self):
         await launch_mod.handle_launch("name AliceCoin", sender_id="alice")

--- a/tests/tools/test_clawnch_launch.py
+++ b/tests/tools/test_clawnch_launch.py
@@ -81,6 +81,87 @@ class TestDeploy:
         assert params["description"] == "the foo coin"
         assert params["image"] == "https://x/foo.png"
 
+    def test_with_socials_normalized(self, fake_svc):
+        clawnch_launch(
+            {
+                "action": "deploy",
+                "name": "Foo",
+                "symbol": "FOO",
+                "twitter": "clawn",
+                "website": "https://mycoin.xyz",
+                "telegram": "@clawnchalerts",
+                "farcaster": "clawn",
+                "discord": "https://discord.gg/abc",
+            }
+        )
+        params = fake_svc.deploys[0]["params"]
+        urls = {entry["platform"]: entry["url"] for entry in params["metadata"]["socialMediaUrls"]}
+        assert urls["twitter"] == "https://x.com/clawn"
+        assert urls["website"] == "https://mycoin.xyz"
+        assert urls["telegram"] == "https://t.me/clawnchalerts"
+        assert urls["farcaster"] == "https://warpcast.com/clawn"
+        assert urls["discord"] == "https://discord.gg/abc"
+
+    def test_full_url_pass_through(self, fake_svc):
+        clawnch_launch(
+            {
+                "action": "deploy",
+                "name": "Foo",
+                "symbol": "FOO",
+                "twitter": "https://x.com/already-formatted",
+            }
+        )
+        params = fake_svc.deploys[0]["params"]
+        urls = params["metadata"]["socialMediaUrls"]
+        assert urls[0]["url"] == "https://x.com/already-formatted"
+
+    def test_bare_hostname_without_base_url_gets_https(self, fake_svc):
+        # website has no base URL — bare-hostname autocomplete applies
+        clawnch_launch(
+            {
+                "action": "deploy",
+                "name": "Foo",
+                "symbol": "FOO",
+                "website": "mycoin.xyz",
+            }
+        )
+        params = fake_svc.deploys[0]["params"]
+        urls = params["metadata"]["socialMediaUrls"]
+        assert urls[0]["url"] == "https://mycoin.xyz"
+
+    def test_no_metadata_when_no_socials(self, fake_svc):
+        clawnch_launch({"action": "deploy", "name": "Foo", "symbol": "FOO"})
+        params = fake_svc.deploys[0]["params"]
+        assert "metadata" not in params
+
+    def test_handle_only_at_falls_back(self, fake_svc):
+        # Edge case: bare @ for twitter — falls back to raw value
+        clawnch_launch(
+            {
+                "action": "deploy",
+                "name": "Foo",
+                "symbol": "FOO",
+                "twitter": "@",
+            }
+        )
+        params = fake_svc.deploys[0]["params"]
+        urls = params["metadata"]["socialMediaUrls"]
+        assert urls[0]["url"] == "@"
+
+    def test_non_url_passthrough_for_url_fields(self, fake_svc):
+        # website has empty base_url + the value doesn't look like a URL
+        clawnch_launch(
+            {
+                "action": "deploy",
+                "name": "Foo",
+                "symbol": "FOO",
+                "website": "not a url",
+            }
+        )
+        params = fake_svc.deploys[0]["params"]
+        urls = params["metadata"]["socialMediaUrls"]
+        assert urls[0]["url"] == "not a url"
+
     def test_with_bypass(self, fake_svc):
         clawnch_launch(
             {


### PR DESCRIPTION
## Summary

Closes the v0.2.0 gap: \`/launch\` and the \`clawnch_launch\` tool only collected name / symbol / description, but the launchpad API accepts richer \`tokenParams\` including an image URL and per-platform social links.

## New /launch subcommands

\`\`\`
/launch image <url>            — token image URL
/launch twitter <handle|url>   — X/Twitter (alias: /launch x)
/launch website <url>          — project website
/launch telegram <handle|url>  — Telegram
/launch farcaster <handle|url> — Farcaster / Warpcast
/launch discord <url>          — Discord invite
\`\`\`

## Normalization

Bare handles → full platform URLs; full URLs pass through:

| Input | Output |
|---|---|
| \`clawn\` (twitter) | \`https://x.com/clawn\` |
| \`@clawn\` (twitter) | \`https://x.com/clawn\` |
| \`clawn\` (telegram) | \`https://t.me/clawn\` |
| \`clawn\` (farcaster) | \`https://warpcast.com/clawn\` |
| \`mycoin.xyz\` (any URL-only field) | \`https://mycoin.xyz\` |
| Full \`http(s)://\` URL | passes through unchanged |

## clawnch_launch tool

Same args land on the LLM-facing schema (\`image\`, \`twitter\`, \`website\`, \`telegram\`, \`farcaster\`, \`discord\`). Lets the agent pass metadata directly when a user says "launch MyCoin with twitter @clawn and image https://...".

## On-chain shape

Collected metadata serializes to the format the launchpad already accepts:

\`\`\`json
{
  "tokenParams": {
    "name": "MyCoin",
    "symbol": "MC",
    "image": "https://i.imgur.com/x.png",
    "metadata": {
      "socialMediaUrls": [
        { "platform": "twitter", "url": "https://x.com/clawn" },
        { "platform": "website", "url": "https://mycoin.xyz" }
      ]
    }
  }
}
\`\`\`

The clawnch backend (\`api/deploy/confirm.ts\`) already threads \`metadata.socialMediaUrls\` through to the launch record — **zero server-side changes needed**.

## /launch status

Renders the \`socials\` sub-map nested for readability:

\`\`\`
Launch draft:
  name: MyCoin
  symbol: MC
  image: https://i.imgur.com/x.png
  socials:
    twitter: https://x.com/clawn
    website: https://mycoin.xyz
\`\`\`

## Quality

- **2703 tests passing** (up from 2677)
- **100% coverage maintained** on \`commands/launch.py\` (164 stmts) and \`tools/clawnch_launch.py\` (71 stmts)
- 26 new test cases covering all 5 platforms + edge cases (full URL pass-through, bare handle normalization, bare hostname autocomplete, \`@\`-only fallback, no-metadata case)
- ruff check + format clean