### PR TITLE
feat(commands): /buy, /trending, /my_launches, /launch burn — trading + discovery + vault burn from chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,75 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.3.0 — 2026-05-26
+
+### Added — trading, discovery, burn-to-vault
+
+Three new top-level commands wire the basic buy / discover / list loop into chat, plus a new `/launch burn` subcommand for $CLAWNCH-backed vault allocations.
+
+- **`/buy <token> <eth_amount> [--clawnch | --all]`** — two-step swap
+  flow (quote → confirm) over the existing `defi_swap` tool. 0x
+  Permit2 single-signature execution. Symbol resolution via
+  DexScreener defaults to `--all` (broadest Base universe);
+  `--clawnch` restricts resolution to launchpad-deployed tokens via
+  `/api/launches?address=`. `0x`-prefixed addresses bypass symbol
+  resolution. `/buy confirm` / `/buy cancel` / `/buy status` round
+  out the per-sender draft surface.
+
+- **`/trending [--clawnch | --all] [limit]`** — top tokens on Base by
+  24h volume. Default `--all` pulls from DexScreener (broadest);
+  `--clawnch` queries `/api/tokens?sort=volume&prices=1` for
+  launchpad-only ranking. Limit clamped to `[1, 25]`.
+
+- **`/my_launches [--clawnch | --all]`** — list this user's launches.
+  Default `--clawnch` returns the agent's Clawnch-API launch history
+  via `GET /api/agents/me`. `--all` scans the connected wallet's
+  contract-creation transactions on Base via the Basescan API and
+  enriches each with DexScreener market data; tokens with no DEX
+  listing render as `(no DEX listing)`. Caps at 25 results.
+
+- **`/launch burn <amount | tx_hash>`** — claim a Clanker vault
+  allocation by burning $CLAWNCH. Integer amounts (e.g. `1000000`,
+  with optional `_` / `,` separators) sign + submit an ERC-20
+  `transfer(burn_address, amount * 1e18)` from the active wallet,
+  wait for the receipt, and store the hash in the launch draft.
+  Existing tx hashes (`0x` + 64 hex) are recorded verbatim. The
+  backend verifies the burn (sender, recipient, amount, 24h
+  pre-launch window) and applies the corresponding vault percentage
+  — 1k tokens allocated per 1 CLAWNCH burned, capped at 10% (10M
+  CLAWNCH). `/launch confirm` forwards the hash as `burnTxHash` to
+  `/api/deploy`.
+
+### Changed
+
+- `ClawnchService.deploy()` and `start_deploy()` now accept
+  `burn_tx_hash` alongside the existing `bypass_tx_hash`. They're
+  independent — both can be supplied on the same launch.
+- `get_bypass_recipient()` fallback bumped from `0.001 ETH` to
+  `0.005 ETH` to match the server-side `BYPASS_FEE_WEI` default that
+  shipped in the recent `clawnch` operational changes.
+- New `get_burn_config()` helper on `ClawnchService` exposes the
+  CLAWNCH token address, burn address, and minimum burn amount.
+  Override via `CLAWNCH_TOKEN_ADDRESS` / `CLAWNCH_BURN_ADDRESS` /
+  `CLAWNCH_MIN_BURN_TOKENS` env vars (staging / test).
+
+### Added — internals
+
+- `clawmes.lib.dexscreener` — stateless helper over the public
+  DexScreener HTTP API (`/latest/dex/search` and
+  `/latest/dex/tokens/<addr>`). Surfaces `search`, `find_token`,
+  `top_pairs`, and a compact `format_pair_summary` used by both
+  `/buy` and `/trending`. No auth, no service lifecycle — lives in
+  `lib/` not `services/`.
+- README expanded with a "Trading + discovery from chat" section and
+  updated launch flow including the burn curve.
+
+### Tests
+
+- +176 new tests covering dexscreener, /buy, /trending, /my_launches,
+  /launch burn, and the burn / bypass plumbing in `ClawnchService`.
+  Full suite 2859 passing at 100% coverage.
+
 ## 0.2.1 — 2026-05-22
 
 ### Added — launch metadata (image + socials)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 
 ## Commands
 
-75 slash commands across 15 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
+78 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
 
 | Category | Commands |
 |---|---|
@@ -79,6 +79,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 | **Plans & triggers** (10) | `/plans` `/plan` `/plan_logs` `/interrupt_plan` `/pause_plan` `/resume_plan` `/triggers` `/watch` `/unwatch` `/cron` |
 | **Onboarding** (19) | `/welcome`, 5 personas (`/professional` `/degen` `/chill` `/technical` `/mentor`), 10 capability toggles (`/cap_wallet` `/cap_prices` `/cap_portfolio` `/cap_trading` `/cap_liquidity` `/cap_launchpad` `/cap_bridge` `/cap_routing` `/cap_clawnx` `/cap_hummingbot`), `/skip` `/back` `/reonboard` |
 | **Balance & portfolio** (2) | `/balance` `/portfolio` |
+| **Trading & discovery** (3) | `/buy` `/trending` `/my_launches` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches |
 | **Self-evolution** (3) | `/evolve` `/stable` `/evolution` — gates `agent_memory` and `skill_evolve` write actions; OFF by default |
 | **Endpoint allowlist** (3) | `/allowlist` `/allow` `/disallow` — session-scoped host allowlist + 100-entry block audit ring |
 | **Discoverability** (5) | `/skills` `/persona` `/chains` `/tools_list` `/safety_status` |
@@ -174,7 +175,18 @@ Clawmes wires the Clawnch launchpad end-to-end so any user can deploy a token fr
 
 Social handles get normalized (`mycoin` → `https://x.com/mycoin`); full URLs pass through unchanged. They're persisted to `tokenParams.metadata.socialMediaUrls` on the launchpad side and may render as badges on the launch detail page.
 
-Free-tier rate limit: 1 deploy per 24 hours per agent. To skip the cooldown, send `0.001 ETH` (or the current bypass amount) to the Clawnch bypass recipient on Base, then `/launch bypass <tx_hash>` and `/launch confirm`.
+Free-tier rate limit: 1 deploy per 24 hours per agent. To skip the cooldown, send `0.005 ETH` (or the current bypass amount) to the Clawnch bypass recipient on Base, then `/launch bypass <tx_hash>` and `/launch confirm`.
+
+To claim a vault allocation, burn $CLAWNCH within 24 hours of the launch:
+
+```
+/launch burn 1000000            # signs + submits a 1M CLAWNCH burn from the active wallet (= 1% vault)
+/launch burn 10000000           # max 10M CLAWNCH (= 10% vault, the Clanker maximum)
+/launch burn 0x<tx_hash>        # or paste a tx hash if you burned externally
+/launch confirm                 # deploy with vault allocation applied
+```
+
+Curve: 1k tokens allocated per 1 CLAWNCH burned (1M → 1%, 10M → 10%). Vault tokens are subject to the Clanker 7-day lockup. See [`api/lib/burn.ts`](https://github.com/clawnchdev/clawnch/blob/main/api/lib/burn.ts) for the exact verification rules.
 
 How the gate works:
 
@@ -184,6 +196,26 @@ How the gate works:
 → Clawnch's deployer wallet (server-side) pays gas and submits the underlying Clanker call
 
 Wallet signs only the off-chain captcha — Clawnch pays deploy gas. The `clawnch_launch` tool (LLM-callable) and `clawnch_fees` (read launches + fee accrual) follow the same path. See [`clawmes:clawnch-launch` skill](clawmes/skills/clawnch-launch/SKILL.md) for the LLM-facing surface.
+
+## Trading + discovery from chat
+
+After launching (or any time): three commands cover the basic loop of finding tokens and buying them.
+
+```
+/trending                          # top 10 tokens on Base by 24h volume (DexScreener)
+/trending --clawnch                # restrict to launchpad-deployed tokens
+/trending 25                       # bump the limit
+
+/buy MNEME 0.01                    # quote: resolves symbol via DexScreener
+/buy MNEME 0.01 --clawnch          # restrict resolution to Clawnch-launched tokens
+/buy 0x3FcD…7b07 0.01              # address bypasses symbol resolution
+/buy confirm                       # signs the Permit2 + submits via 0x
+
+/my_launches                       # tokens this agent deployed via Clawnch (default)
+/my_launches --all                 # any ERC-20 the connected wallet ever created on Base
+```
+
+`/buy` uses the existing `defi_swap` tool under the hood — 0x aggregator with Permit2 (single signature, no separate `approve` tx). The quote step always renders the resolved address before signing, so you can verify you're buying the right token. `--all` resolution returns the highest-volume Base pair for the symbol; `--clawnch` additionally verifies the address against the Clawnch launches table.
 
 ## Security
 

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -17,15 +17,18 @@ from clawmes.commands import (
     agent,
     allowlist,
     balance,
+    buy,
     discovery,
     doctor,
     evolve,
     identity,
     info,
     launch,
+    my_launches,
     onboarding,
     plans,
     policy,
+    trending,
     tx,
     wallet,
     wallet_recovery,
@@ -59,6 +62,9 @@ def register_all(ctx) -> None:
     bv7x_cmd.register(ctx)
     launch.register(ctx)
     agent.register(ctx)
+    buy.register(ctx)
+    trending.register(ctx)
+    my_launches.register(ctx)
     # TODO(v0.1.0+): model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
     # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/buy.py
+++ b/clawmes/commands/buy.py
@@ -1,0 +1,361 @@
+"""``/buy`` slash command — buy a token with ETH via 0x.
+
+Two-step flow (mirrors ``/launch``): first call previews a quote and
+stores a draft, second call (``/buy confirm``) executes the swap.
+This avoids accidental fat-finger trades — the user always sees the
+expected output amount + route before signing.
+
+Universes (token resolution):
+
+  * ``--all`` (default) — symbol resolution via DexScreener. Widest
+    discovery, returns the highest-volume pair on Base for the symbol.
+    The user is responsible for verifying the resolved address — the
+    confirm step prints it before signing.
+
+  * ``--clawnch`` — same DexScreener resolution but the resolved
+    address is additionally verified via Clawnch's
+    ``GET /api/launches?address=<addr>``. Rejects tokens that weren't
+    deployed via the launchpad. Useful when the user wants to scope
+    to vetted-by-Clawnch tokens only.
+
+Addresses (``0x...``) bypass universe resolution and are accepted
+verbatim — the caller has already done the lookup.
+
+The actual swap goes through the ``defi_swap`` tool which uses 0x's
+Permit2 endpoint (single-sig swap, no separate ``approve`` tx). The
+slash command is a thin sender over that tool.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+
+from clawmes.lib import dexscreener
+from clawmes.services.wallet import get_wallet_state
+
+_draft_state: dict[str, dict[str, Any]] = {}
+_state_lock = threading.RLock()
+
+
+# ── per-sender state helpers ────────────────────────────────────────
+
+
+def _record(name: str, args: str, result: str) -> None:
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _get_draft(sender_id: str) -> dict[str, Any] | None:
+    with _state_lock:
+        return _draft_state.get(sender_id)
+
+
+def _set_draft(sender_id: str, draft: dict[str, Any]) -> None:
+    with _state_lock:
+        _draft_state[sender_id] = draft
+
+
+def _clear_draft(sender_id: str) -> None:
+    with _state_lock:
+        _draft_state.pop(sender_id, None)
+
+
+def _resolve_sender(kwargs: dict[str, Any]) -> str:
+    return str(kwargs.get("sender_id") or "default")
+
+
+# ── arg parsing ─────────────────────────────────────────────────────
+
+
+def _parse_flags(tokens: list[str]) -> tuple[list[str], str]:
+    """Split ``tokens`` into ``(positional, universe)``.
+
+    ``universe`` is ``"clawnch"`` if ``--clawnch`` was passed, else
+    ``"all"`` (the default — broader). Unknown flags are dropped
+    silently rather than failing the parse.
+    """
+    universe = "all"
+    positional: list[str] = []
+    for tok in tokens:
+        if tok == "--clawnch":
+            universe = "clawnch"
+        elif tok == "--all":
+            universe = "all"
+        elif tok.startswith("--"):
+            # Unknown flag — ignore so future-flag forward-compat doesn't
+            # break older clients.
+            continue
+        else:
+            positional.append(tok)
+    return positional, universe
+
+
+# ── main handler ────────────────────────────────────────────────────
+
+
+async def handle_buy(raw_args: str, **kwargs: Any) -> str:
+    sender_id = _resolve_sender(kwargs)
+    arg = (raw_args or "").strip()
+    if not arg:
+        out = _render_usage(_get_draft(sender_id))
+        _record("buy", raw_args, out)
+        return out
+
+    parts = arg.split()
+    first = parts[0].lower()
+
+    if first == "confirm":
+        out = await _confirm(sender_id)
+    elif first == "cancel":
+        _clear_draft(sender_id)
+        out = "Buy draft cleared."
+    elif first == "status":
+        out = _render_status(_get_draft(sender_id))
+    else:
+        out = await _quote(sender_id, parts)
+
+    _record("buy", raw_args, out)
+    return out
+
+
+def _render_usage(draft: dict[str, Any] | None) -> str:
+    lines = [
+        "Buy a token with ETH on Base via the 0x aggregator.",
+        "",
+        "Usage:",
+        "  /buy <token> <eth_amount> [--clawnch | --all]",
+        "  /buy confirm        — execute the most recent quote",
+        "  /buy cancel         — clear the draft",
+        "  /buy status         — show the current draft",
+        "",
+        "<token> can be a symbol (resolved via DexScreener) or a 0x address.",
+        "Default universe is --all; pass --clawnch to restrict to launchpad-deployed tokens.",
+        "",
+        "A wallet must be connected (/connect or /connect_local).",
+    ]
+    if draft:
+        lines.append("")
+        lines.append("Current draft:")
+        lines.extend(_format_draft_lines(draft))
+    return "\n".join(lines)
+
+
+def _render_status(draft: dict[str, Any] | None) -> str:
+    if not draft:
+        return "No buy draft. Start with /buy <token> <eth_amount>."
+    lines = ["Buy draft:"]
+    lines.extend(_format_draft_lines(draft))
+    return "\n".join(lines)
+
+
+def _format_draft_lines(draft: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for key, value in draft.items():
+        out.append(f"  {key}: {value}")
+    return out
+
+
+# ── quote path ──────────────────────────────────────────────────────
+
+
+async def _quote(sender_id: str, parts: list[str]) -> str:
+    positional, universe = _parse_flags(parts)
+    if len(positional) < 2:
+        return "Usage: /buy <token> <eth_amount> [--clawnch | --all]"
+
+    token_in, amount_raw = positional[0], positional[1]
+    try:
+        amount = float(amount_raw)
+        if amount <= 0:
+            raise ValueError
+    except ValueError:
+        return f"Invalid ETH amount: {amount_raw!r}. Must be a positive number."
+
+    state = get_wallet_state()
+    if not state.connected or not state.address:
+        return "No wallet connected. Run /connect or /connect_local first."
+
+    resolved = _resolve_token(token_in, universe)
+    if isinstance(resolved, str):
+        # error message
+        return resolved
+    addr, label = resolved
+
+    # Quote via defi_swap. The tool returns a JSON envelope; we unwrap.
+    from clawmes.tools.defi_swap import defi_swap
+
+    raw = defi_swap(
+        {
+            "action": "quote",
+            "sell_token": "ETH",
+            "buy_token": addr,
+            "sell_amount": str(amount),
+        }
+    )
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return f"Quote failed (bad response): {raw}"
+    if payload.get("isError"):
+        msg = payload.get("content", [{}])[0].get("text", "quote failed")
+        return f"Quote failed: {msg}"
+
+    details = payload.get("details") or {}
+    expected_out = (
+        details.get("buy_amount") or details.get("buyAmount") or details.get("output_amount") or "?"
+    )
+    price = details.get("price") or details.get("guaranteedPrice") or ""
+    route = details.get("route") or details.get("sources") or ""
+
+    draft = {
+        "token": label,
+        "buy_token": addr,
+        "sell_eth": str(amount),
+        "expected_out": str(expected_out),
+        "universe": universe,
+        "price": str(price) if price else "",
+    }
+    _set_draft(sender_id, draft)
+
+    lines = [
+        f"Quote: {amount} ETH → {expected_out} {label}",
+        f"  Address: {addr}",
+        f"  Universe: {universe}",
+    ]
+    if price:
+        lines.append(f"  Price: {price}")
+    if route:
+        lines.append(f"  Route: {route}")
+    lines.append("")
+    lines.append("Run /buy confirm to execute, or /buy cancel to discard.")
+    return "\n".join(lines)
+
+
+def _resolve_token(token_in: str, universe: str) -> tuple[str, str] | str:
+    """Resolve ``token_in`` to ``(address, display_label)`` or an error.
+
+    Address inputs (``0x...``) are returned verbatim. Symbol inputs go
+    through DexScreener; if ``universe == "clawnch"`` the resolved
+    address is additionally verified against the Clawnch launches
+    endpoint.
+
+    Returns an error string when resolution fails — the caller surfaces
+    it directly to the user.
+    """
+    q = token_in.strip()
+    if _looks_like_address(q):
+        return (q, _short(q))
+
+    pair = dexscreener.find_token(q, chain="base")
+    if not pair:
+        return f"No Base pair found for {q!r} on DexScreener."
+    base = pair.get("baseToken") or {}
+    addr = base.get("address") or ""
+    sym = base.get("symbol") or q
+    if not addr:
+        return f"DexScreener match for {q!r} had no token address."
+
+    if universe == "clawnch":
+        ok, reason = _is_clawnch_launched(addr)
+        if not ok:
+            return (
+                f"{sym} ({_short(addr)}) is not a Clawnch-launched token "
+                f"({reason}). Drop --clawnch or pick another token."
+            )
+
+    return (addr, sym)
+
+
+def _is_clawnch_launched(address: str) -> tuple[bool, str]:
+    """True iff ``/api/launches?address=`` returns a record for ``address``."""
+    from clawmes.services.clawnch import ClawnchError, get_clawnch_service
+
+    try:
+        body = get_clawnch_service().get_launch(address)
+    except ClawnchError as exc:
+        return (False, exc.code)
+    except Exception as exc:  # noqa: BLE001
+        return (False, f"lookup error: {exc}")
+    # Empty / null body → not found.
+    if not body:
+        return (False, "not_found")
+    if isinstance(body, dict):
+        # Backend returns 200 + {"error": "..."} for missing rows in some
+        # branches; treat any explicit error field as "not Clawnch".
+        if body.get("error"):
+            return (False, "not_found")
+        return (True, "ok")
+    return (True, "ok")
+
+
+# ── confirm path ────────────────────────────────────────────────────
+
+
+async def _confirm(sender_id: str) -> str:
+    draft = _get_draft(sender_id)
+    if not draft:
+        return "No buy draft. Run /buy <token> <eth_amount> first."
+
+    state = get_wallet_state()
+    if not state.connected or not state.address:
+        return "No wallet connected. Run /connect or /connect_local first."
+
+    from clawmes.tools.defi_swap import defi_swap
+
+    raw = defi_swap(
+        {
+            "action": "swap",
+            "sell_token": "ETH",
+            "buy_token": draft["buy_token"],
+            "sell_amount": draft["sell_eth"],
+        }
+    )
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return f"Swap failed (bad response): {raw}"
+    if payload.get("isError"):
+        msg = payload.get("content", [{}])[0].get("text", "swap failed")
+        return f"Swap failed: {msg}"
+
+    details = payload.get("details") or {}
+    tx_hash = details.get("tx_hash") or details.get("txHash") or ""
+    _clear_draft(sender_id)
+    lines = [f"Buy submitted: {draft['sell_eth']} ETH → {draft['token']}"]
+    if tx_hash:
+        lines.append(f"  Tx: {tx_hash}")
+        lines.append(f"  Basescan: https://basescan.org/tx/{tx_hash}")
+    return "\n".join(lines)
+
+
+# ── small helpers ───────────────────────────────────────────────────
+
+
+def _looks_like_address(value: str) -> bool:
+    if not value.startswith("0x"):
+        return False
+    body = value[2:]
+    if len(body) != 40:
+        return False
+    return all(c in "0123456789abcdefABCDEF" for c in body)
+
+
+def _short(addr: str) -> str:
+    if not addr or len(addr) < 10:
+        return addr
+    return f"{addr[:6]}…{addr[-4:]}"
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="buy",
+        handler=handle_buy,
+        description="Buy a token with ETH on Base via 0x (quote → confirm)",
+        args_hint="<token> <eth_amount> [--clawnch | --all] | confirm | cancel | status",
+    )

--- a/clawmes/commands/launch.py
+++ b/clawmes/commands/launch.py
@@ -199,6 +199,8 @@ async def handle_launch(raw_args: str, **kwargs: Any) -> str:
         else:
             draft["bypass_tx_hash"] = rest
             out = "Bypass tx recorded. Next: /launch confirm."
+    elif action == "burn":
+        out = await _handle_burn(sender_id, rest)
     elif action == "confirm":
         out = await _confirm(sender_id)
     else:
@@ -215,6 +217,7 @@ async def handle_launch(raw_args: str, **kwargs: Any) -> str:
             "  /launch farcaster <handle>    — Farcaster\n"
             "  /launch discord <url>         — Discord\n"
             "  /launch bypass <tx_hash>      — skip 24h cooldown\n"
+            "  /launch burn <amount|tx_hash> — burn $CLAWNCH for vault allocation\n"
             "  /launch status                — show current draft\n"
             "  /launch confirm               — deploy\n"
             "  /launch cancel                — clear draft"
@@ -242,6 +245,7 @@ def _render_usage(draft: dict[str, Any]) -> str:
         "",
         "Flow:",
         "  /launch bypass <tx_hash>         (skip 24h cooldown)",
+        "  /launch burn <amount|tx_hash>    (burn $CLAWNCH for vault allocation)",
         "  /launch status                   (show draft)",
         "  /launch confirm                  (deploy)",
         "  /launch cancel                   (clear draft)",
@@ -277,6 +281,100 @@ def _format_draft_lines(draft: dict[str, Any]) -> list[str]:
     return out
 
 
+async def _handle_burn(sender_id: str, rest: str) -> str:
+    """Handle ``/launch burn <amount|tx_hash>``.
+
+    Two input modes:
+
+      * ``tx_hash`` (``0x`` + 64 hex chars) — record verbatim. The user
+        has already done the burn off-band and just wants to provide
+        the hash for verification.
+
+      * ``amount`` (positive integer >= 1,000,000) — sign + submit a
+        $CLAWNCH ``transfer(burn_address, amount * 1e18)`` from the
+        active wallet, wait for the receipt, and store the resulting
+        tx hash on the draft. Saves the user from having to manually
+        construct the burn tx in their wallet UI.
+
+    Either way the draft ends up with ``burn_tx_hash`` set, which is
+    forwarded to the Clawnch ``/api/deploy`` endpoint on confirm.
+    Clawnch's backend verifies the burn (sender, recipient, amount,
+    timing) and applies the corresponding vault allocation.
+    """
+    draft = _get_draft(sender_id)
+    if not rest:
+        return (
+            "Usage: /launch burn <amount> | /launch burn <tx_hash>\n"
+            "  Amount: whole CLAWNCH (>= 1,000,000 for 1% vault, max 10,000,000 for 10%).\n"
+            "  Tx hash: 0x... if you already burned externally."
+        )
+
+    if _looks_like_tx_hash(rest):
+        draft["burn_tx_hash"] = rest
+        return "Burn tx recorded. Next: /launch confirm."
+
+    try:
+        amount = int(rest.replace("_", "").replace(",", ""))
+    except ValueError:
+        return f"Invalid burn input {rest!r}. Expected an amount (e.g. 1000000) or 0x tx hash."
+    if amount < 1_000_000:
+        return (
+            f"Burn amount too low: {amount:,} CLAWNCH (minimum 1,000,000 for 1% vault).\n"
+            "See https://clawn.ch/docs/burn for the vault curve."
+        )
+
+    return await _submit_burn(draft, amount)
+
+
+async def _submit_burn(draft: dict[str, Any], whole_tokens: int) -> str:
+    """Sign + submit the CLAWNCH burn tx via the active wallet."""
+    from clawmes.lib.abi import encode_transfer
+    from clawmes.services.clawnch import get_clawnch_service
+    from clawmes.services.wallet import get_wallet_service, get_wallet_state
+
+    state = get_wallet_state()
+    if not state.connected:
+        return "No wallet connected. Run /connect or /connect_local first."
+    mode = get_wallet_service().active_mode()
+    if mode is None:
+        return "No active wallet mode. Run /connect."
+
+    cfg = get_clawnch_service().get_burn_config()
+    token_addr = cfg["token_address"]
+    burn_addr = cfg["burn_address"]
+    amount_wei = whole_tokens * (10**18)
+    calldata = encode_transfer(burn_addr, amount_wei)
+
+    try:
+        tx_hash = mode.send_transaction(
+            to=token_addr,
+            value=0,
+            data=calldata,
+            chain_id=8453,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return f"Burn tx submission failed: {exc}"
+
+    draft["burn_tx_hash"] = tx_hash
+    draft["burn_amount"] = whole_tokens
+    return (
+        f"Burn submitted: {whole_tokens:,} CLAWNCH → {burn_addr}\n"
+        f"  Tx: {tx_hash}\n"
+        f"  Basescan: https://basescan.org/tx/{tx_hash}\n"
+        "Wait for confirmation, then /launch confirm to deploy with vault allocation."
+    )
+
+
+def _looks_like_tx_hash(value: str) -> bool:
+    """Heuristic: ``0x`` + 64 hex chars."""
+    if not value.startswith("0x"):
+        return False
+    body = value[2:]
+    if len(body) != 64:
+        return False
+    return all(c in "0123456789abcdefABCDEF" for c in body)
+
+
 async def _confirm(sender_id: str) -> str:
     draft = _get_draft(sender_id)
     name = draft.get("name")
@@ -301,6 +399,7 @@ async def _confirm(sender_id: str) -> str:
         }
 
     bypass = draft.get("bypass_tx_hash")
+    burn = draft.get("burn_tx_hash")
 
     try:
         from clawmes.services.clawnch import ClawnchError, get_clawnch_service
@@ -308,6 +407,7 @@ async def _confirm(sender_id: str) -> str:
         result = get_clawnch_service().deploy(
             token_params=token_params,
             bypass_tx_hash=bypass,
+            burn_tx_hash=burn,
         )
     except ClawnchError as exc:
         msg = f"Launch failed ({exc.code}): {exc.message}"

--- a/clawmes/commands/my_launches.py
+++ b/clawmes/commands/my_launches.py
@@ -1,0 +1,217 @@
+"""``/my_launches`` slash command — list tokens this user has launched.
+
+Two universes:
+
+  * ``--clawnch`` (default) — tokens deployed via the Clawnch HTTP
+    API by this user's API key. Sourced from ``GET /api/agents/me``.
+    Requires ``CLAWNCH_API_KEY``. Most useful default — covers the
+    common case "what did I launch from clawmes".
+
+  * ``--all`` — tokens deployed by the *connected wallet*, not just
+    via Clawnch. Includes Clanker-direct deploys, custom factory
+    deploys, and any other ERC-20 the wallet has created. Sourced
+    from Basescan's ``account / txlist`` API filtered to
+    contract-creation transactions. Requires a connected wallet.
+
+The ``--all`` path adds DexScreener enrichment per-address so the
+output shows symbol / market cap / 24h volume for tokens that have
+since accrued liquidity. Tokens with no DexScreener entry render as
+"(no liquidity)" — the deploy succeeded, but no pair exists yet (or
+the token was abandoned).
+
+Both universes are de-duplicated by contract address so a token
+launched via Clawnch and re-listed in the wallet history shows up
+once.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawmes.lib import dexscreener
+from clawmes.lib.http import http_get
+from clawmes.services.clawnch import ClawnchError, get_clawnch_service
+from clawmes.services.wallet import get_wallet_state
+
+_BASESCAN_BASE = "https://api.basescan.org/api"
+_MAX_RESULTS = 25
+
+
+def _record(name: str, args: str, result: str) -> None:
+    """Best-effort recording into command_history."""
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _parse_args(raw: str) -> str:
+    """Return universe (``"clawnch"`` or ``"all"``). Default ``"clawnch"``."""
+    universe = "clawnch"
+    for tok in (raw or "").split():
+        if tok == "--clawnch":
+            universe = "clawnch"
+        elif tok == "--all":
+            universe = "all"
+    return universe
+
+
+async def handle_my_launches(raw_args: str, **_kwargs: Any) -> str:
+    universe = _parse_args(raw_args or "")
+    if universe == "all":
+        out = _render_all()
+    else:
+        out = _render_clawnch()
+    _record("my_launches", raw_args, out)
+    return out
+
+
+# ── --clawnch (Clawnch API) ─────────────────────────────────────────
+
+
+def _render_clawnch() -> str:
+    try:
+        body = get_clawnch_service().get_my_launches()
+    except ClawnchError as exc:
+        msg = f"Could not fetch Clawnch launches ({exc.code}): {exc.message}"
+        if exc.code == "no_credentials":
+            msg += "\n\nRun /register_agent <name> <description> first."
+        return msg
+
+    launches = _extract_launches(body)
+    if not launches:
+        return (
+            "No Clawnch launches found for this agent.\n"
+            "Pass --all to scan the connected wallet for any ERC-20 deploys."
+        )
+
+    lines = [f"Your Clawnch launches ({len(launches)}):", ""]
+    for i, lau in enumerate(launches, start=1):
+        lines.append(f"  {i}. {_format_clawnch_launch(lau)}")
+    lines.append("")
+    lines.append("Pass --all to also include non-Clawnch deploys from this wallet.")
+    return "\n".join(lines)
+
+
+def _extract_launches(body: Any) -> list[dict[str, Any]]:
+    """Tolerate /api/agents/me shape drift."""
+    if isinstance(body, list):
+        return [x for x in body if isinstance(x, dict)]
+    if isinstance(body, dict):
+        for key in ("launches", "tokens", "data", "results"):
+            inner = body.get(key)
+            if isinstance(inner, list):
+                return [x for x in inner if isinstance(x, dict)]
+    return []
+
+
+def _format_clawnch_launch(lau: dict[str, Any]) -> str:
+    symbol = lau.get("symbol") or lau.get("ticker") or "?"
+    name = lau.get("name") or ""
+    addr = lau.get("contractAddress") or lau.get("tokenAddress") or lau.get("address") or ""
+    parts = [symbol]
+    if name and name != symbol:
+        parts.append(f"({name})")
+    if addr:
+        parts.append(f"→ {_short(addr)}")
+    return "  ".join(parts)
+
+
+# ── --all (Basescan wallet scan) ────────────────────────────────────
+
+
+def _render_all() -> str:
+    state = get_wallet_state()
+    if not state.connected or not state.address:
+        return (
+            "No wallet connected — /my_launches --all needs to scan the "
+            "wallet's deploy history. Run /connect first, or use "
+            "/my_launches (defaults to --clawnch)."
+        )
+
+    try:
+        creations = _basescan_contract_creations(state.address)
+    except Exception as exc:  # noqa: BLE001
+        return f"Could not fetch wallet history from Basescan: {exc}"
+
+    if not creations:
+        return (
+            f"No contract creations found for {_short(state.address)} on Base.\n"
+            "If you launched via clawmes, try /my_launches --clawnch."
+        )
+
+    # Enrich with DexScreener; only token-shaped deploys (those with a
+    # pair) render with market data. Non-pair creations (helper contracts,
+    # factories, etc.) render as "(no DEX listing)" so the user still
+    # sees them. The basescan helper already guarantees ``contractAddress``
+    # is truthy, so no defensive skip needed here.
+    lines = [f"Contract deploys from {_short(state.address)} on Base:", ""]
+    for i, tx in enumerate(creations[:_MAX_RESULTS], start=1):
+        addr = tx["contractAddress"]
+        pair = dexscreener.find_token(addr, chain="base")
+        if pair:
+            lines.append(f"  {i}. {dexscreener.format_pair_summary(pair)}")
+        else:
+            lines.append(f"  {i}. {_short(addr)}  (no DEX listing)")
+    lines.append("")
+    lines.append("Pass --clawnch to restrict to launchpad-tracked launches.")
+    return "\n".join(lines)
+
+
+def _basescan_contract_creations(address: str) -> list[dict[str, Any]]:
+    """Return contract-creation txs (``to == ""``) from this address.
+
+    Uses the public Basescan v1 API. ``BASESCAN_API_KEY`` is optional —
+    free tier permits ~5 req/sec without a key, sufficient for a single
+    user listing their own history. With a key the rate-limit is
+    lifted.
+    """
+    import os
+
+    params = {
+        "module": "account",
+        "action": "txlist",
+        "address": address,
+        "startblock": "0",
+        "endblock": "99999999",
+        "sort": "desc",
+    }
+    api_key = os.environ.get("BASESCAN_API_KEY")
+    if api_key:
+        params["apikey"] = api_key
+
+    body = http_get(_BASESCAN_BASE, params=params, timeout=20.0)
+    if not isinstance(body, dict):
+        return []
+    if str(body.get("status")) != "1":
+        # Basescan returns status="0" + message="No transactions found" for
+        # empty histories — that's a normal empty result, not an error.
+        return []
+    items = body.get("result") or []
+    if not isinstance(items, list):
+        return []
+    creations: list[dict[str, Any]] = []
+    for tx in items:
+        if not isinstance(tx, dict):
+            continue
+        # Contract creation: ``to`` is empty + ``contractAddress`` is set.
+        if (tx.get("to") or "") == "" and tx.get("contractAddress"):
+            creations.append(tx)
+    return creations
+
+
+def _short(addr: str) -> str:
+    if not addr or len(addr) < 10:
+        return addr
+    return f"{addr[:6]}…{addr[-4:]}"
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="my_launches",
+        handler=handle_my_launches,
+        description="List tokens this user has launched (Clawnch API or full wallet)",
+        args_hint="[--clawnch | --all]",
+    )

--- a/clawmes/commands/trending.py
+++ b/clawmes/commands/trending.py
@@ -1,0 +1,175 @@
+"""``/trending`` slash command — discover hot tokens.
+
+Two universes:
+
+  * ``--clawnch`` — top tokens launched via the Clawnch launchpad,
+    sorted by the launchpad's own 24h volume ranking. Sourced from
+    ``GET /api/tokens?sort=volume&prices=1&limit=N`` on the Clawnch
+    backend (no auth required).
+
+  * ``--all`` (default) — top tokens on Base by 24h volume, sourced
+    from DexScreener. Broader universe — includes Clanker-direct
+    deploys, legacy launches, and tokens that pre-date Clawnch.
+
+The default is ``--all`` so newcomers see the widest discovery
+surface. Operators who only care about the launchpad cohort can
+pass ``--clawnch`` to restrict.
+
+No wallet required, no auth required, read-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawmes.lib import dexscreener
+from clawmes.lib.http import http_get
+
+_DEFAULT_LIMIT = 10
+_MAX_LIMIT = 25
+_CLAWNCH_API_BASE = "https://clawn.ch"
+
+
+def _record(name: str, args: str, result: str) -> None:
+    """Best-effort recording into command_history."""
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _parse_args(raw: str) -> tuple[str, int]:
+    """Return ``(universe, limit)``.
+
+    ``universe`` is one of ``"clawnch"`` / ``"all"``. ``limit`` is
+    clamped to ``[1, _MAX_LIMIT]``. Unknown bare args (not a flag, not
+    a number) are silently ignored — the command should never crash
+    on user typos.
+    """
+    universe = "all"
+    limit = _DEFAULT_LIMIT
+    # ``.split()`` with no arg already drops empties — no defensive
+    # empty-token guard needed.
+    for tok in (raw or "").split():
+        if tok == "--clawnch":
+            universe = "clawnch"
+        elif tok == "--all":
+            universe = "all"
+        elif tok.isdigit():
+            limit = max(1, min(_MAX_LIMIT, int(tok)))
+    return universe, limit
+
+
+async def handle_trending(raw_args: str, **_kwargs: Any) -> str:
+    universe, limit = _parse_args(raw_args or "")
+    if universe == "clawnch":
+        out = _render_clawnch(limit)
+    else:
+        out = _render_all(limit)
+    _record("trending", raw_args, out)
+    return out
+
+
+def _render_clawnch(limit: int) -> str:
+    """Render the top-N Clawnch tokens by 24h volume."""
+    try:
+        body = http_get(
+            f"{_CLAWNCH_API_BASE}/api/tokens",
+            params={"sort": "volume", "prices": "1", "limit": str(limit)},
+            timeout=15.0,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as user-facing
+        return f"Could not fetch Clawnch trending: {exc}"
+
+    tokens = _extract_clawnch_tokens(body)
+    if not tokens:
+        return "No Clawnch tokens found. Try /trending --all for the wider pool."
+
+    lines = [f"Top {len(tokens)} Clawnch tokens by 24h volume:", ""]
+    for i, tok in enumerate(tokens, start=1):
+        lines.append(f"  {i}. {_format_clawnch_token(tok)}")
+    lines.append("")
+    lines.append("Pass --all for the wider Base universe (DexScreener).")
+    return "\n".join(lines)
+
+
+def _extract_clawnch_tokens(body: Any) -> list[dict[str, Any]]:
+    """Pull the token list out of /api/tokens, tolerating shape drift."""
+    if isinstance(body, list):
+        return [t for t in body if isinstance(t, dict)]
+    if isinstance(body, dict):
+        for key in ("tokens", "data", "results"):
+            inner = body.get(key)
+            if isinstance(inner, list):
+                return [t for t in inner if isinstance(t, dict)]
+    return []
+
+
+def _format_clawnch_token(tok: dict[str, Any]) -> str:
+    """One-line render for a Clawnch token."""
+    symbol = tok.get("symbol") or tok.get("ticker") or "?"
+    name = tok.get("name") or ""
+    addr = tok.get("contractAddress") or tok.get("address") or ""
+    vol24 = tok.get("volume24h") or tok.get("volumeUSD") or tok.get("volume") or 0
+    price = tok.get("priceUsd") or tok.get("price") or None
+    mc = tok.get("marketCap") or tok.get("fdv") or None
+    parts = [symbol]
+    if name and name != symbol:
+        parts.append(f"({name})")
+    if price is not None:
+        parts.append(f"${price}")
+    if mc:
+        parts.append(f"mc {_compact(mc)}")
+    if vol24:
+        parts.append(f"vol24h {_compact(vol24)}")
+    if addr:
+        parts.append(f"→ {_short(addr)}")
+    return "  ".join(parts)
+
+
+def _render_all(limit: int) -> str:
+    """Render the top-N tokens on Base by 24h volume."""
+    pairs = dexscreener.top_pairs(chain="base", limit=limit)
+    if not pairs:
+        err = dexscreener.last_error()
+        suffix = f" ({err})" if err else ""
+        return f"No Base trending pairs returned by DexScreener{suffix}."
+
+    lines = [f"Top {len(pairs)} Base tokens by 24h volume (DexScreener):", ""]
+    for i, p in enumerate(pairs, start=1):
+        lines.append(f"  {i}. {dexscreener.format_pair_summary(p)}")
+    lines.append("")
+    lines.append("Pass --clawnch to restrict to launchpad-deployed tokens.")
+    return "\n".join(lines)
+
+
+def _compact(n: float | int | str) -> str:
+    """Compact USD: 1.3k / 55k / 1.3M / 2.4B."""
+    try:
+        v = float(n)
+    except (TypeError, ValueError):
+        return f"${n}"
+    if v >= 1_000_000_000:
+        return f"${v / 1_000_000_000:.2f}B"
+    if v >= 1_000_000:
+        return f"${v / 1_000_000:.2f}M"
+    if v >= 1_000:
+        return f"${v / 1_000:.1f}k"
+    return f"${v:.2f}"
+
+
+def _short(addr: str) -> str:
+    if not addr or len(addr) < 10:
+        return addr
+    return f"{addr[:6]}…{addr[-4:]}"
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="trending",
+        handler=handle_trending,
+        description="Top tokens by 24h volume on Base (or just Clawnch launches)",
+        args_hint="[--clawnch | --all] [limit]",
+    )

--- a/clawmes/lib/dexscreener.py
+++ b/clawmes/lib/dexscreener.py
@@ -1,0 +1,233 @@
+"""DexScreener — public token + pair search.
+
+Thin wrapper over the DexScreener HTTP API (no auth required) used to:
+
+  * resolve a user-typed symbol (``MNEME``) to an on-chain token
+    address on a specific chain (``find_token``), and
+  * list the top pairs on a chain by 24h volume (``top_pairs``) — the
+    backbone of ``/trending --all``.
+
+We intentionally don't build a stateful Service class for DexScreener
+because there's no lifecycle, no auth, and no shared connection
+state — every read is a one-shot HTTP GET. Lives in ``lib/`` (helper)
+instead of ``services/`` (lifecycle-bound).
+
+Endpoints used:
+
+  * ``GET /latest/dex/search?q=<query>`` — returns pairs across all
+    chains ranked by 24h volume. Free-form (matches token symbol,
+    name, or contract). The first Base pair (by default volume sort)
+    is usually the canonical liquidity venue.
+  * ``GET /latest/dex/tokens/<address>`` — returns all pairs for a
+    given token address. We use this when the caller already has an
+    address and just wants the canonical pair / market data.
+
+Response shape (relevant fields):
+
+    {
+      "schemaVersion": "1.0.0",
+      "pairs": [
+        {
+          "chainId": "base",
+          "dexId": "uniswap",
+          "url": "https://dexscreener.com/...",
+          "pairAddress": "0x...",
+          "baseToken": {"address": "0x...", "name": "...", "symbol": "..."},
+          "quoteToken": {...},
+          "priceUsd": "0.0000132",
+          "fdv": 1300000,
+          "marketCap": 1300000,
+          "volume": {"h24": 55000, ...},
+          "txns": {"h24": {"buys": 42, "sells": 38}, ...},
+          ...
+        },
+        ...
+      ]
+    }
+
+Errors: all helpers return empty lists / ``None`` on upstream
+failures rather than raising — surface commands render "no results"
+rather than tracebacks. Callers that need failure visibility can
+inspect ``last_error()``.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from clawmes.lib.http import http_get
+
+_BASE_URL = "https://api.dexscreener.com"
+_DEFAULT_CHAIN = "base"
+_DEFAULT_TIMEOUT = 15.0
+
+# Last upstream error stored for optional ``last_error()`` inspection by
+# callers that want to surface a diagnostic. We don't raise on errors so
+# that the command surface stays "no results" friendly.
+_last_error: str | None = None
+_err_lock = threading.RLock()
+
+
+def last_error() -> str | None:
+    """Return the most recent upstream error message, or ``None``."""
+    with _err_lock:
+        return _last_error
+
+
+def _set_error(msg: str | None) -> None:
+    global _last_error
+    with _err_lock:
+        _last_error = msg
+
+
+def _request(path: str, params: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    """One-shot GET. Returns parsed JSON or ``None`` on any failure."""
+    url = _BASE_URL + path
+    try:
+        body = http_get(url, params=params or {}, timeout=_DEFAULT_TIMEOUT)
+    except Exception as exc:  # noqa: BLE001 — record + swallow
+        _set_error(f"{type(exc).__name__}: {exc}")
+        return None
+    _set_error(None)
+    return body if isinstance(body, dict) else None
+
+
+def search(query: str) -> list[dict[str, Any]]:
+    """Raw cross-chain search. Returns the ``pairs`` array (may be []).
+
+    Use ``find_token`` / ``top_pairs`` instead unless you need the raw
+    multi-chain pair list.
+    """
+    if not query or not query.strip():
+        return []
+    body = _request("/latest/dex/search", {"q": query.strip()})
+    if not body:
+        return []
+    pairs = body.get("pairs") or []
+    return [p for p in pairs if isinstance(p, dict)]
+
+
+def find_token(
+    symbol_or_address: str,
+    *,
+    chain: str = _DEFAULT_CHAIN,
+) -> dict[str, Any] | None:
+    """Resolve a symbol or address to the canonical pair on ``chain``.
+
+    Selection rule:
+
+      * If ``symbol_or_address`` looks like an ``0x``-prefixed address
+        (40 hex chars), query ``/latest/dex/tokens/<address>`` directly
+        and return the highest-volume Base pair.
+      * Otherwise treat as a symbol — do a cross-chain search and pick
+        the first pair on ``chain`` whose ``baseToken.symbol`` matches
+        case-insensitively. If no exact symbol match, fall back to the
+        first pair on the chain (volume-sorted upstream).
+
+    Returns ``None`` when nothing matches.
+    """
+    if not symbol_or_address or not symbol_or_address.strip():
+        return None
+    q = symbol_or_address.strip()
+    if _looks_like_address(q):
+        body = _request(f"/latest/dex/tokens/{q}")
+        if not body:
+            return None
+        pairs = body.get("pairs") or []
+        chain_pairs = [p for p in pairs if isinstance(p, dict) and p.get("chainId") == chain]
+        return chain_pairs[0] if chain_pairs else None
+
+    # Symbol search — cross-chain.
+    pairs = search(q)
+    chain_pairs = [p for p in pairs if p.get("chainId") == chain]
+    if not chain_pairs:
+        return None
+    upper = q.upper()
+    # Prefer exact symbol matches on baseToken to disambiguate (e.g. avoid
+    # picking a quoteToken=USDC pair when the user wanted to buy USDC).
+    for p in chain_pairs:
+        base = p.get("baseToken") or {}
+        if str(base.get("symbol", "")).upper() == upper:
+            return p
+    return chain_pairs[0]
+
+
+def top_pairs(
+    *,
+    chain: str = _DEFAULT_CHAIN,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Top pairs on ``chain`` by 24h volume.
+
+    DexScreener doesn't expose a "trending by chain" endpoint, but the
+    search endpoint returns volume-sorted pairs across all chains. We
+    seed the search with the chain id (``"base"``) and filter, which
+    yields the same shape as a top-by-volume list.
+
+    For a more curated set, callers should fall back to the on-chain
+    Clawnch tokens endpoint (``--clawnch``) which is volume-sorted by
+    the launchpad backend.
+    """
+    if limit <= 0:
+        return []
+    pairs = search(chain)
+    chain_pairs = [p for p in pairs if p.get("chainId") == chain]
+    return chain_pairs[:limit]
+
+
+def _looks_like_address(value: str) -> bool:
+    """Heuristic: ``0x`` + 40 hex chars."""
+    if not value.startswith("0x"):
+        return False
+    body = value[2:]
+    if len(body) != 40:
+        return False
+    return all(c in "0123456789abcdefABCDEF" for c in body)
+
+
+def format_pair_summary(pair: dict[str, Any]) -> str:
+    """Human-friendly one-liner for a pair.
+
+    Example:
+        ``MNEME  $0.0000132  mc $1.3M  vol24h $55k  → 0x3FcD…7b07``
+
+    Used by ``/trending`` and ``/buy`` for the confirmation render.
+    """
+    base = pair.get("baseToken") or {}
+    symbol = base.get("symbol") or "?"
+    addr = base.get("address") or "?"
+    price_usd = pair.get("priceUsd")
+    mc = pair.get("marketCap") or pair.get("fdv")
+    vol24 = ((pair.get("volume") or {}).get("h24")) or 0
+    parts = [symbol]
+    if price_usd is not None:
+        parts.append(f"${price_usd}")
+    if mc:
+        parts.append(f"mc {_compact_usd(mc)}")
+    if vol24:
+        parts.append(f"vol24h {_compact_usd(vol24)}")
+    parts.append(f"→ {_short_addr(addr)}")
+    return "  ".join(parts)
+
+
+def _compact_usd(n: float | int | str) -> str:
+    """Format a USD figure compactly: 1.3k, 55k, 1.3M, 2.4B."""
+    try:
+        v = float(n)
+    except (TypeError, ValueError):
+        return f"${n}"
+    if v >= 1_000_000_000:
+        return f"${v / 1_000_000_000:.2f}B"
+    if v >= 1_000_000:
+        return f"${v / 1_000_000:.2f}M"
+    if v >= 1_000:
+        return f"${v / 1_000:.1f}k"
+    return f"${v:.2f}"
+
+
+def _short_addr(addr: str) -> str:
+    """Truncate ``0xabc…def`` for display."""
+    if not addr or len(addr) < 10:
+        return addr
+    return f"{addr[:6]}…{addr[-4:]}"

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.1.0
+version: 0.3.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/services/clawnch.py
+++ b/clawmes/services/clawnch.py
@@ -154,6 +154,7 @@ class ClawnchService(Service):
         *,
         token_params: dict[str, Any],
         bypass_tx_hash: str | None = None,
+        burn_tx_hash: str | None = None,
     ) -> dict[str, Any]:
         """Start a token deploy. Returns the captcha challenge.
 
@@ -163,9 +164,15 @@ class ClawnchService(Service):
         attribution badge on /pad/.
 
         Pass ``bypass_tx_hash`` to skip the 24h rate limit — must be a
-        confirmed tx hash of >= 0.001 ETH sent to the bypass recipient
+        confirmed tx hash of >= 0.005 ETH sent to the bypass recipient
         address on Base (call :meth:`get_bypass_recipient` for the
-        current address).
+        current address + required fee).
+
+        Pass ``burn_tx_hash`` to claim a vault allocation by burning
+        $CLAWNCH — must be a confirmed tx hash of >= 1,000,000 CLAWNCH
+        sent to the burn address within the 24h pre-launch window. The
+        backend verifies the burn and applies the corresponding vault
+        percentage (1M = 1%, 10M = max 10%). See ``api/lib/burn.ts``.
         """
         self._require_key()
         if not token_params.get("name"):
@@ -177,6 +184,8 @@ class ClawnchService(Service):
         body: dict[str, Any] = {"tokenParams": stamped}
         if bypass_tx_hash:
             body["bypassTxHash"] = bypass_tx_hash
+        if burn_tx_hash:
+            body["burnTxHash"] = burn_tx_hash
         return self._post("/api/deploy", body, auth=True)
 
     # ── deploy: phase 2 (solve + confirm) ───────────────────────────
@@ -237,13 +246,20 @@ class ClawnchService(Service):
         *,
         token_params: dict[str, Any],
         bypass_tx_hash: str | None = None,
+        burn_tx_hash: str | None = None,
     ) -> dict[str, Any]:
         """End-to-end deploy convenience: challenge -> solve -> confirm.
 
         Returns the confirm response on success. Raises ``ClawnchError``
-        with a classified ``code`` on any step failure.
+        with a classified ``code`` on any step failure. ``burn_tx_hash``
+        claims a vault allocation; ``bypass_tx_hash`` skips the 24h
+        cooldown — they're independent and can both be supplied.
         """
-        challenge = self.start_deploy(token_params=token_params, bypass_tx_hash=bypass_tx_hash)
+        challenge = self.start_deploy(
+            token_params=token_params,
+            bypass_tx_hash=bypass_tx_hash,
+            burn_tx_hash=burn_tx_hash,
+        )
         solution = self.solve_challenge(challenge)
         return self.confirm_deploy(
             challenge_id=challenge["challengeId"],
@@ -282,7 +298,34 @@ class ClawnchService(Service):
                 "CLAWNCH_BYPASS_RECIPIENT",
                 "0xFC426DFeAe55Dae2f936a592450C9ECEa87A5736",
             ),
-            "fee_eth": os.environ.get("CLAWNCH_BYPASS_FEE_ETH", "0.001"),
+            "fee_eth": os.environ.get("CLAWNCH_BYPASS_FEE_ETH", "0.005"),
+        }
+
+    def get_burn_config(self) -> dict[str, Any]:
+        """Return the $CLAWNCH burn config used by ``/launch burn``.
+
+        Returns the token address (the CLAWNCH ERC-20), the burn
+        address (dead address — 0x…dEaD), and the minimum burn amount
+        in whole tokens. The frontend uses these to construct a
+        ``transfer(burn_address, amount * 1e18)`` calldata that the
+        active wallet signs.
+
+        Stable values today (override via env for staging):
+
+          * ``CLAWNCH_TOKEN_ADDRESS``    — default ``0xa1F724…747be``
+          * ``CLAWNCH_BURN_ADDRESS``     — default ``0x000…dEaD``
+          * ``CLAWNCH_MIN_BURN_TOKENS``  — default ``1_000_000`` (1% vault)
+        """
+        return {
+            "token_address": os.environ.get(
+                "CLAWNCH_TOKEN_ADDRESS",
+                "0xa1F72459dfA10BAD200Ac160eCd78C6b77a747be",
+            ),
+            "burn_address": os.environ.get(
+                "CLAWNCH_BURN_ADDRESS",
+                "0x000000000000000000000000000000000000dEaD",
+            ),
+            "min_burn_tokens": int(os.environ.get("CLAWNCH_MIN_BURN_TOKENS", "1000000")),
         }
 
     # ── internals: HTTP ─────────────────────────────────────────────

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.1.0
+version: 0.3.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.2.1"
+version = "0.3.0"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_buy.py
+++ b/tests/commands/test_buy.py
@@ -1,0 +1,444 @@
+"""Tests for the /buy slash command."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawmes.commands import buy as buy_mod
+from clawmes.lib import dexscreener
+from clawmes.services.clawnch import ClawnchError
+from clawmes.wallet.state import WalletState
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    buy_mod._draft_state.clear()
+    yield
+    buy_mod._draft_state.clear()
+
+
+@pytest.fixture
+def fake_wallet(monkeypatch):
+    state: dict = {"connected": False, "address": "0x" + "a" * 40}
+
+    def _state():
+        if state["connected"]:
+            return WalletState.for_chain(mode="local", address=state["address"], chain_id=8453)
+        return WalletState.disconnected()
+
+    monkeypatch.setattr(buy_mod, "get_wallet_state", _state)
+    return state
+
+
+@pytest.fixture
+def fake_find_token(monkeypatch):
+    state: dict = {"result": None}
+
+    def _fake(q, *, chain="base"):  # noqa: ARG001
+        return state["result"]
+
+    monkeypatch.setattr(dexscreener, "find_token", _fake)
+    return state
+
+
+@pytest.fixture
+def fake_defi_swap(monkeypatch):
+    state: dict = {
+        "responses": {},  # action -> JSON-encoded envelope
+        "calls": [],
+    }
+
+    def _fake(args, **_kw):
+        state["calls"].append(args)
+        return state["responses"].get(args["action"], json.dumps({"isError": False, "details": {}}))
+
+    import clawmes.tools.defi_swap as ds_mod
+
+    monkeypatch.setattr(ds_mod, "defi_swap", _fake)
+    return state
+
+
+@pytest.fixture
+def fake_clawnch_get_launch(monkeypatch):
+    state: dict = {"return": {"address": "0x" + "1" * 40}, "raise": None}
+
+    class _Svc:
+        def get_launch(self, addr):  # noqa: ARG002
+            if state["raise"]:
+                raise state["raise"]
+            return state["return"]
+
+    import clawmes.services.clawnch as cl_mod
+
+    monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+    return state
+
+
+# ── usage / status / cancel ────────────────────────────────────────
+
+
+class TestUsage:
+    async def test_empty_shows_usage(self):
+        out = await buy_mod.handle_buy("")
+        assert "Buy a token with ETH" in out
+        assert "--clawnch" in out
+        assert "--all" in out
+
+    async def test_usage_includes_existing_draft(self):
+        buy_mod._set_draft("alice", {"token": "MNEME", "sell_eth": "0.01"})
+        out = await buy_mod.handle_buy("", sender_id="alice")
+        assert "Current draft" in out
+        assert "MNEME" in out
+
+    async def test_status_empty(self):
+        out = await buy_mod.handle_buy("status", sender_id="alice")
+        assert "No buy draft" in out
+
+    async def test_status_with_draft(self):
+        buy_mod._set_draft("alice", {"token": "X"})
+        out = await buy_mod.handle_buy("status", sender_id="alice")
+        assert "Buy draft" in out
+        assert "X" in out
+
+    async def test_cancel_clears(self):
+        buy_mod._set_draft("alice", {"token": "X"})
+        out = await buy_mod.handle_buy("cancel", sender_id="alice")
+        assert "cleared" in out
+        assert "alice" not in buy_mod._draft_state
+
+    async def test_default_sender(self):
+        await buy_mod.handle_buy("status")
+        # Just ensure no crash with sender_id missing
+        assert "default" not in buy_mod._draft_state  # no draft created
+
+
+# ── flag parsing ────────────────────────────────────────────────────
+
+
+class TestParseFlags:
+    def test_default_is_all(self):
+        positional, universe = buy_mod._parse_flags(["a", "b"])
+        assert positional == ["a", "b"]
+        assert universe == "all"
+
+    def test_clawnch_flag(self):
+        _, u = buy_mod._parse_flags(["a", "--clawnch", "b"])
+        assert u == "clawnch"
+
+    def test_all_flag_overrides(self):
+        _, u = buy_mod._parse_flags(["--clawnch", "--all"])
+        assert u == "all"
+
+    def test_unknown_flag_ignored(self):
+        pos, u = buy_mod._parse_flags(["a", "--unknown", "b"])
+        assert pos == ["a", "b"]
+        assert u == "all"
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+class TestLooksLikeAddress:
+    def test_valid(self):
+        assert buy_mod._looks_like_address("0x" + "a" * 40)
+
+    def test_wrong_prefix(self):
+        assert not buy_mod._looks_like_address("a" * 42)
+
+    def test_wrong_length(self):
+        assert not buy_mod._looks_like_address("0x" + "a" * 39)
+
+    def test_non_hex(self):
+        assert not buy_mod._looks_like_address("0x" + "z" * 40)
+
+
+class TestShort:
+    def test_short_input(self):
+        assert buy_mod._short("abc") == "abc"
+
+    def test_truncates(self):
+        out = buy_mod._short("0x" + "a" * 40)
+        assert "…" in out
+
+
+# ── quote path ─────────────────────────────────────────────────────
+
+
+class TestQuote:
+    async def test_too_few_args(self):
+        out = await buy_mod.handle_buy("MNEME")
+        assert "Usage" in out
+
+    async def test_bad_amount(self):
+        out = await buy_mod.handle_buy("MNEME notanumber")
+        assert "Invalid ETH amount" in out
+
+    async def test_zero_amount(self):
+        out = await buy_mod.handle_buy("MNEME 0")
+        assert "Invalid ETH amount" in out
+
+    async def test_negative_amount(self):
+        out = await buy_mod.handle_buy("MNEME -1")
+        assert "Invalid ETH amount" in out
+
+    async def test_no_wallet(self, fake_wallet):
+        fake_wallet["connected"] = False
+        out = await buy_mod.handle_buy("MNEME 0.01")
+        assert "No wallet connected" in out
+
+    async def test_address_input_skips_resolution(self, fake_wallet, fake_defi_swap):
+        fake_wallet["connected"] = True
+        addr = "0x" + "1" * 40
+        fake_defi_swap["responses"]["quote"] = json.dumps(
+            {"isError": False, "details": {"buy_amount": "1000000"}}
+        )
+        out = await buy_mod.handle_buy(f"{addr} 0.01", sender_id="alice")
+        assert "Quote" in out
+        assert addr in out
+        assert "alice" in buy_mod._draft_state
+        # defi_swap was called with the address verbatim
+        assert fake_defi_swap["calls"][0]["buy_token"] == addr
+
+    async def test_symbol_no_match(self, fake_wallet, fake_find_token):
+        fake_wallet["connected"] = True
+        fake_find_token["result"] = None
+        out = await buy_mod.handle_buy("UNKNOWN 0.01")
+        assert "No Base pair found" in out
+
+    async def test_symbol_pair_missing_address(self, fake_wallet, fake_find_token):
+        fake_wallet["connected"] = True
+        fake_find_token["result"] = {"baseToken": {"symbol": "X"}}
+        out = await buy_mod.handle_buy("X 0.01")
+        assert "no token address" in out
+
+    async def test_clawnch_universe_rejects_non_clawnch(
+        self, fake_wallet, fake_find_token, fake_clawnch_get_launch
+    ):
+        fake_wallet["connected"] = True
+        addr = "0x" + "1" * 40
+        fake_find_token["result"] = {"baseToken": {"symbol": "MNEME", "address": addr}}
+        fake_clawnch_get_launch["raise"] = ClawnchError("not_found", "no row")
+        out = await buy_mod.handle_buy("MNEME 0.01 --clawnch")
+        assert "not a Clawnch-launched token" in out
+        assert "not_found" in out
+
+    async def test_clawnch_universe_accepts_clawnch(
+        self, fake_wallet, fake_find_token, fake_clawnch_get_launch, fake_defi_swap
+    ):
+        fake_wallet["connected"] = True
+        addr = "0x" + "1" * 40
+        fake_find_token["result"] = {"baseToken": {"symbol": "FOO", "address": addr}}
+        fake_clawnch_get_launch["return"] = {"address": addr, "name": "Foo"}
+        fake_defi_swap["responses"]["quote"] = json.dumps(
+            {"isError": False, "details": {"buy_amount": "1000"}}
+        )
+        out = await buy_mod.handle_buy("FOO 0.01 --clawnch", sender_id="alice")
+        assert "Quote" in out
+        assert "clawnch" in out
+        assert "alice" in buy_mod._draft_state
+
+    async def test_clawnch_lookup_error_other_than_not_found(
+        self, fake_wallet, fake_find_token, fake_clawnch_get_launch
+    ):
+        fake_wallet["connected"] = True
+        fake_find_token["result"] = {"baseToken": {"symbol": "FOO", "address": "0x" + "1" * 40}}
+        fake_clawnch_get_launch["raise"] = RuntimeError("upstream down")
+        out = await buy_mod.handle_buy("FOO 0.01 --clawnch")
+        assert "not a Clawnch-launched token" in out
+        assert "upstream down" in out
+
+    async def test_clawnch_empty_body_rejected(
+        self, fake_wallet, fake_find_token, fake_clawnch_get_launch
+    ):
+        fake_wallet["connected"] = True
+        fake_find_token["result"] = {"baseToken": {"symbol": "FOO", "address": "0x" + "1" * 40}}
+        fake_clawnch_get_launch["return"] = None
+        out = await buy_mod.handle_buy("FOO 0.01 --clawnch")
+        assert "not a Clawnch-launched token" in out
+
+    async def test_clawnch_body_with_error_field_rejected(
+        self, fake_wallet, fake_find_token, fake_clawnch_get_launch
+    ):
+        fake_wallet["connected"] = True
+        fake_find_token["result"] = {"baseToken": {"symbol": "FOO", "address": "0x" + "1" * 40}}
+        fake_clawnch_get_launch["return"] = {"error": "no such token"}
+        out = await buy_mod.handle_buy("FOO 0.01 --clawnch")
+        assert "not a Clawnch-launched token" in out
+
+    async def test_clawnch_non_dict_body_accepted(
+        self, fake_wallet, fake_find_token, fake_clawnch_get_launch, fake_defi_swap
+    ):
+        # Some upstream branches return a list — treat as ok.
+        fake_wallet["connected"] = True
+        fake_find_token["result"] = {"baseToken": {"symbol": "FOO", "address": "0x" + "1" * 40}}
+        fake_clawnch_get_launch["return"] = ["some", "list"]
+        fake_defi_swap["responses"]["quote"] = json.dumps(
+            {"isError": False, "details": {"buy_amount": "1000"}}
+        )
+        out = await buy_mod.handle_buy("FOO 0.01 --clawnch")
+        assert "Quote" in out
+
+    async def test_quote_error_envelope(self, fake_wallet, fake_find_token, fake_defi_swap):
+        fake_wallet["connected"] = True
+        fake_find_token["result"] = {"baseToken": {"symbol": "MNEME", "address": "0x" + "1" * 40}}
+        fake_defi_swap["responses"]["quote"] = json.dumps(
+            {"isError": True, "content": [{"text": "out of inventory"}]}
+        )
+        out = await buy_mod.handle_buy("MNEME 0.01")
+        assert "Quote failed" in out
+        assert "out of inventory" in out
+
+    async def test_quote_unparseable_response(self, fake_wallet, fake_find_token, fake_defi_swap):
+        fake_wallet["connected"] = True
+        fake_find_token["result"] = {"baseToken": {"symbol": "MNEME", "address": "0x" + "1" * 40}}
+        fake_defi_swap["responses"]["quote"] = "not-json"
+        out = await buy_mod.handle_buy("MNEME 0.01")
+        assert "Quote failed (bad response)" in out
+
+    async def test_quote_renders_price_and_route(
+        self, fake_wallet, fake_find_token, fake_defi_swap
+    ):
+        fake_wallet["connected"] = True
+        fake_find_token["result"] = {"baseToken": {"symbol": "MNEME", "address": "0x" + "1" * 40}}
+        fake_defi_swap["responses"]["quote"] = json.dumps(
+            {
+                "isError": False,
+                "details": {
+                    "buyAmount": "1000000",
+                    "guaranteedPrice": "0.00001",
+                    "sources": "uniswap-v3 -> aerodrome",
+                },
+            }
+        )
+        out = await buy_mod.handle_buy("MNEME 0.01")
+        assert "Price: 0.00001" in out
+        assert "Route: uniswap-v3 -> aerodrome" in out
+
+
+# ── confirm path ───────────────────────────────────────────────────
+
+
+class TestConfirm:
+    async def test_no_draft(self):
+        out = await buy_mod.handle_buy("confirm", sender_id="alice")
+        assert "No buy draft" in out
+
+    async def test_no_wallet(self, fake_wallet):
+        fake_wallet["connected"] = False
+        buy_mod._set_draft(
+            "alice",
+            {
+                "token": "X",
+                "buy_token": "0x" + "1" * 40,
+                "sell_eth": "0.01",
+                "expected_out": "1000",
+                "universe": "all",
+            },
+        )
+        out = await buy_mod.handle_buy("confirm", sender_id="alice")
+        assert "No wallet connected" in out
+
+    async def test_swap_error_envelope(self, fake_wallet, fake_defi_swap):
+        fake_wallet["connected"] = True
+        buy_mod._set_draft(
+            "alice",
+            {
+                "token": "X",
+                "buy_token": "0x" + "1" * 40,
+                "sell_eth": "0.01",
+                "expected_out": "1000",
+                "universe": "all",
+            },
+        )
+        fake_defi_swap["responses"]["swap"] = json.dumps(
+            {"isError": True, "content": [{"text": "slippage too high"}]}
+        )
+        out = await buy_mod.handle_buy("confirm", sender_id="alice")
+        assert "Swap failed" in out
+        assert "slippage" in out
+
+    async def test_swap_unparseable_response(self, fake_wallet, fake_defi_swap):
+        fake_wallet["connected"] = True
+        buy_mod._set_draft(
+            "alice",
+            {
+                "token": "X",
+                "buy_token": "0x" + "1" * 40,
+                "sell_eth": "0.01",
+                "expected_out": "1000",
+                "universe": "all",
+            },
+        )
+        fake_defi_swap["responses"]["swap"] = "garbage"
+        out = await buy_mod.handle_buy("confirm", sender_id="alice")
+        assert "Swap failed (bad response)" in out
+
+    async def test_success_clears_draft(self, fake_wallet, fake_defi_swap):
+        fake_wallet["connected"] = True
+        buy_mod._set_draft(
+            "alice",
+            {
+                "token": "MNEME",
+                "buy_token": "0x" + "1" * 40,
+                "sell_eth": "0.01",
+                "expected_out": "1000",
+                "universe": "all",
+            },
+        )
+        fake_defi_swap["responses"]["swap"] = json.dumps(
+            {"isError": False, "details": {"tx_hash": "0xabc"}}
+        )
+        out = await buy_mod.handle_buy("confirm", sender_id="alice")
+        assert "Buy submitted" in out
+        assert "0xabc" in out
+        assert "basescan.org/tx/0xabc" in out
+        assert "alice" not in buy_mod._draft_state
+
+    async def test_success_no_tx_hash(self, fake_wallet, fake_defi_swap):
+        # Edge: swap returns success envelope without tx_hash (shouldn't
+        # happen in practice, but the renderer handles it gracefully).
+        fake_wallet["connected"] = True
+        buy_mod._set_draft(
+            "alice",
+            {
+                "token": "MNEME",
+                "buy_token": "0x" + "1" * 40,
+                "sell_eth": "0.01",
+                "expected_out": "1000",
+                "universe": "all",
+            },
+        )
+        fake_defi_swap["responses"]["swap"] = json.dumps({"isError": False, "details": {}})
+        out = await buy_mod.handle_buy("confirm", sender_id="alice")
+        assert "Buy submitted" in out
+        # No Tx line when hash missing
+        assert "Tx:" not in out
+
+
+# ── command_history best-effort ────────────────────────────────────
+
+
+class TestRecordingBestEffort:
+    async def test_recording_failure(self, monkeypatch):
+        from clawmes.services import command_history as ch_mod
+
+        def _boom(*a, **kw):
+            raise RuntimeError("history broken")
+
+        monkeypatch.setattr(ch_mod, "record_command_call", _boom)
+        out = await buy_mod.handle_buy("")
+        assert isinstance(out, str)
+
+
+class TestRegister:
+    def test_registers(self):
+        captured = []
+
+        class FakeCtx:
+            def register_command(self, **kw):
+                captured.append(kw["name"])
+
+        buy_mod.register(FakeCtx())
+        assert captured == ["buy"]

--- a/tests/commands/test_launch.py
+++ b/tests/commands/test_launch.py
@@ -22,14 +22,27 @@ class _FakeSvc:
         self.deploy_return: dict = {"txHash": "0xtx", "tokenAddress": "0xtok"}
         self.deploy_raise: Exception | None = None
 
-    def deploy(self, *, token_params, bypass_tx_hash=None):
-        self.deploys.append({"params": token_params, "bypass": bypass_tx_hash})
+    def deploy(self, *, token_params, bypass_tx_hash=None, burn_tx_hash=None):
+        self.deploys.append(
+            {
+                "params": token_params,
+                "bypass": bypass_tx_hash,
+                "burn": burn_tx_hash,
+            }
+        )
         if self.deploy_raise:
             raise self.deploy_raise
         return self.deploy_return
 
     def get_bypass_recipient(self):
-        return {"recipient": "0xbypass", "fee_eth": "0.001"}
+        return {"recipient": "0xbypass", "fee_eth": "0.005"}
+
+    def get_burn_config(self):
+        return {
+            "token_address": "0x" + "c" * 40,
+            "burn_address": "0x" + "d" * 40,
+            "min_burn_tokens": 1_000_000,
+        }
 
 
 @pytest.fixture
@@ -286,7 +299,7 @@ class TestConfirm:
         await launch_mod.handle_launch("symbol MC", sender_id="alice")
         out = await launch_mod.handle_launch("confirm", sender_id="alice")
         assert "0xbypass" in out
-        assert "0.001 ETH" in out
+        assert "0.005 ETH" in out
         assert "/launch bypass" in out
 
     async def test_other_clawnch_error(self, fake_svc):
@@ -312,6 +325,154 @@ class TestConfirm:
         await launch_mod.handle_launch("symbol MC", sender_id="alice")
         out = await launch_mod.handle_launch("confirm", sender_id="alice")
         assert "0xtx" in out
+
+
+class TestBurn:
+    async def test_burn_no_args_shows_usage(self):
+        out = await launch_mod.handle_launch("burn", sender_id="alice")
+        assert "Usage" in out
+        assert "1,000,000" in out
+
+    async def test_burn_tx_hash_recorded(self):
+        tx_hash = "0x" + "a" * 64
+        out = await launch_mod.handle_launch(f"burn {tx_hash}", sender_id="alice")
+        assert "Burn tx recorded" in out
+        assert launch_mod._log_state["alice"]["burn_tx_hash"] == tx_hash
+
+    async def test_burn_invalid_input(self):
+        out = await launch_mod.handle_launch("burn notanumber", sender_id="alice")
+        assert "Invalid burn input" in out
+
+    async def test_burn_amount_too_low(self):
+        out = await launch_mod.handle_launch("burn 500000", sender_id="alice")
+        assert "too low" in out
+        assert "1,000,000" in out
+
+    async def test_burn_underscores_and_commas_parse(self):
+        # Should parse "1_000_000" and "1,000,000" and "1000000" identically
+        out = await launch_mod.handle_launch("burn 1_000_000", sender_id="alice")
+        # Without a wallet mocked, the actual submit fails — but at least
+        # the parse succeeded (no "Invalid burn input" / "too low").
+        assert "Invalid" not in out
+        assert "too low" not in out
+
+    async def test_burn_amount_submits_via_wallet(self, monkeypatch, fake_svc):
+        from clawmes.commands import launch as launch_mod_inner
+        from clawmes.wallet.state import WalletState
+
+        captured = {}
+
+        class _FakeMode:
+            def send_transaction(self, **kwargs):
+                captured.update(kwargs)
+                return "0xburntx"
+
+        monkeypatch.setattr(
+            launch_mod_inner,
+            "_log_state",
+            launch_mod._log_state,
+        )
+
+        # Patch wallet
+        def _state():
+            return WalletState.for_chain(mode="local", address="0x" + "1" * 40, chain_id=8453)
+
+        def _get_svc():
+            class _S:
+                def active_mode(self_inner):  # noqa: ARG002, N805
+                    return _FakeMode()
+
+            return _S()
+
+        import clawmes.services.wallet as ws_mod
+
+        monkeypatch.setattr(ws_mod, "get_wallet_state", _state)
+        monkeypatch.setattr(ws_mod, "get_wallet_service", _get_svc)
+
+        out = await launch_mod.handle_launch("burn 1000000", sender_id="alice")
+        assert "Burn submitted" in out
+        assert "0xburntx" in out
+        assert launch_mod._log_state["alice"]["burn_tx_hash"] == "0xburntx"
+        assert launch_mod._log_state["alice"]["burn_amount"] == 1_000_000
+        # send_transaction got the right shape
+        assert captured["to"] == "0x" + "c" * 40
+        assert captured["value"] == 0
+        assert captured["chain_id"] == 8453
+
+    async def test_burn_amount_no_wallet_connected(self, monkeypatch, fake_svc):
+        from clawmes.wallet.state import WalletState
+
+        def _state():
+            return WalletState.disconnected()
+
+        import clawmes.services.wallet as ws_mod
+
+        monkeypatch.setattr(ws_mod, "get_wallet_state", _state)
+        out = await launch_mod.handle_launch("burn 1000000", sender_id="alice")
+        assert "No wallet connected" in out
+
+    async def test_burn_amount_no_active_mode(self, monkeypatch, fake_svc):
+        from clawmes.wallet.state import WalletState
+
+        def _state():
+            return WalletState.for_chain(mode="local", address="0x" + "1" * 40, chain_id=8453)
+
+        class _Svc:
+            def active_mode(self):
+                return None
+
+        import clawmes.services.wallet as ws_mod
+
+        monkeypatch.setattr(ws_mod, "get_wallet_state", _state)
+        monkeypatch.setattr(ws_mod, "get_wallet_service", lambda: _Svc())
+        out = await launch_mod.handle_launch("burn 1000000", sender_id="alice")
+        assert "No active wallet mode" in out
+
+    async def test_burn_send_tx_fails(self, monkeypatch, fake_svc):
+        from clawmes.wallet.state import WalletState
+
+        def _state():
+            return WalletState.for_chain(mode="local", address="0x" + "1" * 40, chain_id=8453)
+
+        class _FakeMode:
+            def send_transaction(self, **kwargs):  # noqa: ARG002
+                raise RuntimeError("rpc down")
+
+        class _Svc:
+            def active_mode(self):
+                return _FakeMode()
+
+        import clawmes.services.wallet as ws_mod
+
+        monkeypatch.setattr(ws_mod, "get_wallet_state", _state)
+        monkeypatch.setattr(ws_mod, "get_wallet_service", lambda: _Svc())
+        out = await launch_mod.handle_launch("burn 1000000", sender_id="alice")
+        assert "Burn tx submission failed" in out
+        assert "rpc down" in out
+
+
+class TestBurnPassesThroughToDeploy:
+    async def test_burn_tx_hash_forwarded_to_deploy(self, fake_svc):
+        tx_hash = "0x" + "a" * 64
+        await launch_mod.handle_launch("name MyCoin", sender_id="alice")
+        await launch_mod.handle_launch("symbol MC", sender_id="alice")
+        await launch_mod.handle_launch(f"burn {tx_hash}", sender_id="alice")
+        await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert fake_svc.deploys[0]["burn"] == tx_hash
+
+
+class TestLooksLikeTxHash:
+    def test_valid(self):
+        assert launch_mod._looks_like_tx_hash("0x" + "a" * 64)
+
+    def test_wrong_prefix(self):
+        assert not launch_mod._looks_like_tx_hash("a" * 64)
+
+    def test_wrong_length(self):
+        assert not launch_mod._looks_like_tx_hash("0x" + "a" * 63)
+
+    def test_non_hex(self):
+        assert not launch_mod._looks_like_tx_hash("0x" + "z" * 64)
 
 
 class TestRegister:

--- a/tests/commands/test_my_launches.py
+++ b/tests/commands/test_my_launches.py
@@ -1,0 +1,335 @@
+"""Tests for the /my_launches slash command."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.commands import my_launches as ml_mod
+from clawmes.lib import dexscreener
+from clawmes.services.clawnch import ClawnchError
+from clawmes.wallet.state import WalletState
+
+
+class _FakeSvc:
+    def __init__(self):
+        self.return_body: object = {"launches": []}
+        self.raise_exc: Exception | None = None
+
+    def get_my_launches(self):
+        if self.raise_exc:
+            raise self.raise_exc
+        return self.return_body
+
+
+@pytest.fixture
+def fake_svc(monkeypatch):
+    s = _FakeSvc()
+    monkeypatch.setattr(ml_mod, "get_clawnch_service", lambda: s)
+    return s
+
+
+@pytest.fixture
+def fake_wallet(monkeypatch):
+    state: dict = {"connected": False, "address": None}
+
+    def _state():
+        if state["connected"]:
+            return WalletState.for_chain(
+                mode="local",
+                address=state["address"] or "0x" + "a" * 40,
+                chain_id=8453,
+            )
+        return WalletState.disconnected()
+
+    monkeypatch.setattr(ml_mod, "get_wallet_state", _state)
+    return state
+
+
+@pytest.fixture
+def fake_basescan_get(monkeypatch):
+    state: dict = {"body": {"status": "1", "result": []}, "raises": None}
+
+    def _fake(url, *, params=None, timeout=None):  # noqa: ARG001
+        if state["raises"]:
+            raise state["raises"]
+        return state["body"]
+
+    monkeypatch.setattr(ml_mod, "http_get", _fake)
+    return state
+
+
+@pytest.fixture
+def fake_find_token(monkeypatch):
+    state: dict = {"by_addr": {}}
+
+    def _fake(addr, *, chain="base"):  # noqa: ARG001
+        return state["by_addr"].get(addr)
+
+    monkeypatch.setattr(dexscreener, "find_token", _fake)
+    return state
+
+
+# ── arg parsing ─────────────────────────────────────────────────────
+
+
+class TestParseArgs:
+    def test_default(self):
+        assert ml_mod._parse_args("") == "clawnch"
+
+    def test_clawnch(self):
+        assert ml_mod._parse_args("--clawnch") == "clawnch"
+
+    def test_all(self):
+        assert ml_mod._parse_args("--all") == "all"
+
+    def test_last_wins(self):
+        assert ml_mod._parse_args("--all --clawnch") == "clawnch"
+
+
+# ── --clawnch path ──────────────────────────────────────────────────
+
+
+class TestClawnchUniverse:
+    async def test_no_credentials(self, fake_svc):
+        fake_svc.raise_exc = ClawnchError("no_credentials", "no key")
+        out = await ml_mod.handle_my_launches("--clawnch")
+        assert "no_credentials" in out
+        assert "/register_agent" in out
+
+    async def test_other_error(self, fake_svc):
+        fake_svc.raise_exc = ClawnchError("api_error", "boom")
+        out = await ml_mod.handle_my_launches("--clawnch")
+        assert "api_error" in out
+        assert "/register_agent" not in out
+
+    async def test_empty_list(self, fake_svc):
+        fake_svc.return_body = {"launches": []}
+        out = await ml_mod.handle_my_launches("--clawnch")
+        assert "No Clawnch launches" in out
+        assert "--all" in out
+
+    async def test_renders(self, fake_svc):
+        fake_svc.return_body = {
+            "launches": [
+                {
+                    "symbol": "MNEME",
+                    "name": "MNEME",
+                    "tokenAddress": "0x" + "1" * 40,
+                }
+            ]
+        }
+        out = await ml_mod.handle_my_launches("--clawnch")
+        assert "Your Clawnch launches (1)" in out
+        assert "MNEME" in out
+
+    async def test_default_is_clawnch(self, fake_svc):
+        fake_svc.return_body = {"launches": []}
+        out = await ml_mod.handle_my_launches("")
+        assert "No Clawnch launches" in out
+
+
+# ── --all path ──────────────────────────────────────────────────────
+
+
+class TestAllUniverse:
+    async def test_no_wallet(self, fake_wallet):
+        fake_wallet["connected"] = False
+        out = await ml_mod.handle_my_launches("--all")
+        assert "No wallet connected" in out
+        assert "/my_launches" in out
+
+    async def test_basescan_error(self, fake_wallet, fake_basescan_get):
+        fake_wallet["connected"] = True
+        fake_wallet["address"] = "0x" + "1" * 40
+        fake_basescan_get["raises"] = RuntimeError("rate limited")
+        out = await ml_mod.handle_my_launches("--all")
+        assert "rate limited" in out
+
+    async def test_no_creations(self, fake_wallet, fake_basescan_get):
+        fake_wallet["connected"] = True
+        fake_wallet["address"] = "0x" + "1" * 40
+        fake_basescan_get["body"] = {"status": "1", "result": []}
+        out = await ml_mod.handle_my_launches("--all")
+        assert "No contract creations" in out
+
+    async def test_basescan_status_0_means_empty(self, fake_wallet, fake_basescan_get):
+        # status="0" + "No transactions found" is normal-empty, not an error
+        fake_wallet["connected"] = True
+        fake_basescan_get["body"] = {"status": "0", "message": "No transactions found"}
+        out = await ml_mod.handle_my_launches("--all")
+        assert "No contract creations" in out
+
+    async def test_basescan_non_dict_body(self, fake_wallet, fake_basescan_get):
+        fake_wallet["connected"] = True
+        fake_basescan_get["body"] = ["not", "a", "dict"]
+        out = await ml_mod.handle_my_launches("--all")
+        assert "No contract creations" in out
+
+    async def test_basescan_non_list_result(self, fake_wallet, fake_basescan_get):
+        fake_wallet["connected"] = True
+        fake_basescan_get["body"] = {"status": "1", "result": "garbage"}
+        out = await ml_mod.handle_my_launches("--all")
+        assert "No contract creations" in out
+
+    async def test_basescan_filter_drops_non_creations(
+        self, fake_wallet, fake_basescan_get, fake_find_token
+    ):
+        # All rows fail the (to=="" AND contractAddress truthy) filter,
+        # so basescan helper returns []. Surface message is the same as
+        # "no creations at all".
+        fake_wallet["connected"] = True
+        fake_basescan_get["body"] = {
+            "status": "1",
+            "result": [
+                {"to": "0xnonempty", "contractAddress": "0xshouldbeskipped"},
+                "garbage",
+                {"to": "", "contractAddress": ""},
+            ],
+        }
+        out = await ml_mod.handle_my_launches("--all")
+        assert "No contract creations" in out
+
+    async def test_renders_with_and_without_dex_listing(
+        self, fake_wallet, fake_basescan_get, fake_find_token
+    ):
+        fake_wallet["connected"] = True
+        addr_listed = "0x" + "1" * 40
+        addr_unlisted = "0x" + "2" * 40
+        fake_basescan_get["body"] = {
+            "status": "1",
+            "result": [
+                {"to": "", "contractAddress": addr_listed},
+                {"to": "", "contractAddress": addr_unlisted},
+            ],
+        }
+        fake_find_token["by_addr"][addr_listed] = {
+            "baseToken": {"symbol": "L", "address": addr_listed},
+            "priceUsd": "1",
+            "marketCap": 100_000,
+            "volume": {"h24": 10_000},
+        }
+        out = await ml_mod.handle_my_launches("--all")
+        assert "L" in out
+        assert "no DEX listing" in out
+        assert "Pass --clawnch" in out
+
+    async def test_max_results_cap(self, fake_wallet, fake_basescan_get, fake_find_token):
+        fake_wallet["connected"] = True
+        # 30 creations — should cap at _MAX_RESULTS (25)
+        results = [{"to": "", "contractAddress": f"0x{i:040x}"} for i in range(1, 31)]
+        fake_basescan_get["body"] = {"status": "1", "result": results}
+        out = await ml_mod.handle_my_launches("--all")
+        assert "no DEX listing" in out
+        # Should see #25 but not #26
+        rendered = out.split("\n")
+        hit25 = [line for line in rendered if line.strip().startswith("25.")]
+        assert len(hit25) == 1
+        assert not any(line.strip().startswith("26.") for line in rendered)
+
+
+# ── basescan_contract_creations env var path ───────────────────────
+
+
+class TestBasescanApiKey:
+    def test_with_api_key(self, monkeypatch):
+        captured: dict = {}
+
+        def _fake(url, *, params=None, timeout=None):  # noqa: ARG001
+            captured["params"] = params
+            return {"status": "1", "result": []}
+
+        monkeypatch.setattr(ml_mod, "http_get", _fake)
+        monkeypatch.setenv("BASESCAN_API_KEY", "my-key")
+        ml_mod._basescan_contract_creations("0x" + "1" * 40)
+        assert captured["params"]["apikey"] == "my-key"
+
+    def test_without_api_key(self, monkeypatch):
+        captured: dict = {}
+
+        def _fake(url, *, params=None, timeout=None):  # noqa: ARG001
+            captured["params"] = params
+            return {"status": "1", "result": []}
+
+        monkeypatch.setattr(ml_mod, "http_get", _fake)
+        monkeypatch.delenv("BASESCAN_API_KEY", raising=False)
+        ml_mod._basescan_contract_creations("0x" + "1" * 40)
+        assert "apikey" not in captured["params"]
+
+
+# ── shape extractors / formatters ───────────────────────────────────
+
+
+class TestExtractLaunches:
+    def test_none(self):
+        assert ml_mod._extract_launches(None) == []
+
+    def test_list_filters_non_dicts(self):
+        assert ml_mod._extract_launches([{"a": 1}, "garbage"]) == [{"a": 1}]
+
+    def test_tokens_key(self):
+        assert ml_mod._extract_launches({"tokens": [{"a": 1}]}) == [{"a": 1}]
+
+    def test_data_key(self):
+        assert ml_mod._extract_launches({"data": [{"a": 1}]}) == [{"a": 1}]
+
+    def test_results_key(self):
+        assert ml_mod._extract_launches({"results": [{"a": 1}]}) == [{"a": 1}]
+
+    def test_dict_no_known_key(self):
+        assert ml_mod._extract_launches({"random": "value"}) == []
+
+
+class TestFormatLaunch:
+    def test_minimal(self):
+        out = ml_mod._format_clawnch_launch({})
+        assert "?" in out
+
+    def test_full(self):
+        out = ml_mod._format_clawnch_launch(
+            {
+                "symbol": "MNEME",
+                "name": "MNEME Coin",
+                "tokenAddress": "0x" + "1" * 40,
+            }
+        )
+        assert "MNEME" in out
+        assert "MNEME Coin" in out
+
+    def test_redundant_name_dropped(self):
+        out = ml_mod._format_clawnch_launch({"symbol": "X", "name": "X"})
+        assert out.count("X") == 1
+
+
+class TestShort:
+    def test_short_input(self):
+        assert ml_mod._short("0xabc") == "0xabc"
+
+    def test_truncates(self):
+        assert "…" in ml_mod._short("0x" + "1" * 40)
+
+
+# ── command_history best-effort ────────────────────────────────────
+
+
+class TestRecordingBestEffort:
+    async def test_recording_failure_does_not_break(self, monkeypatch, fake_svc):
+        from clawmes.services import command_history as ch_mod
+
+        def _boom(*a, **kw):
+            raise RuntimeError("history broken")
+
+        monkeypatch.setattr(ch_mod, "record_command_call", _boom)
+        out = await ml_mod.handle_my_launches("--clawnch")
+        assert isinstance(out, str)
+
+
+class TestRegister:
+    def test_registers(self):
+        captured = []
+
+        class FakeCtx:
+            def register_command(self, **kw):
+                captured.append(kw["name"])
+
+        ml_mod.register(FakeCtx())
+        assert captured == ["my_launches"]

--- a/tests/commands/test_trending.py
+++ b/tests/commands/test_trending.py
@@ -1,0 +1,237 @@
+"""Tests for the /trending slash command."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.commands import trending as trending_mod
+from clawmes.lib import dexscreener
+
+
+@pytest.fixture
+def fake_clawnch_get(monkeypatch):
+    state: dict = {"body": None, "raises": None}
+
+    def _fake(url, *, params=None, timeout=None):  # noqa: ARG001
+        if state["raises"]:
+            raise state["raises"]
+        return state["body"]
+
+    monkeypatch.setattr(trending_mod, "http_get", _fake)
+    return state
+
+
+@pytest.fixture
+def fake_top_pairs(monkeypatch):
+    state: dict = {"pairs": [], "error": None}
+
+    def _fake(chain="base", limit=10):  # noqa: ARG001
+        return state["pairs"]
+
+    def _fake_err():
+        return state["error"]
+
+    monkeypatch.setattr(dexscreener, "top_pairs", _fake)
+    monkeypatch.setattr(dexscreener, "last_error", _fake_err)
+    return state
+
+
+# ── arg parsing ─────────────────────────────────────────────────────
+
+
+class TestParseArgs:
+    def test_defaults(self):
+        assert trending_mod._parse_args("") == ("all", 10)
+
+    def test_clawnch_flag(self):
+        assert trending_mod._parse_args("--clawnch")[0] == "clawnch"
+
+    def test_all_flag(self):
+        assert trending_mod._parse_args("--clawnch --all")[0] == "all"
+
+    def test_limit_parses(self):
+        assert trending_mod._parse_args("5")[1] == 5
+
+    def test_limit_clamped_high(self):
+        _, lim = trending_mod._parse_args("999")
+        assert lim == trending_mod._MAX_LIMIT
+
+    def test_limit_clamped_low(self):
+        _, lim = trending_mod._parse_args("0")
+        assert lim == 1
+
+    def test_unknown_token_ignored(self):
+        assert trending_mod._parse_args("garbage --clawnch") == ("clawnch", 10)
+
+
+# ── --all path (DexScreener) ────────────────────────────────────────
+
+
+class TestRenderAll:
+    async def test_no_pairs_no_error(self, fake_top_pairs):
+        fake_top_pairs["pairs"] = []
+        fake_top_pairs["error"] = None
+        out = await trending_mod.handle_trending("")
+        assert "No Base trending pairs" in out
+        assert "(" not in out  # No error suffix in parens
+
+    async def test_no_pairs_with_error(self, fake_top_pairs):
+        fake_top_pairs["pairs"] = []
+        fake_top_pairs["error"] = "upstream timeout"
+        out = await trending_mod.handle_trending("")
+        assert "upstream timeout" in out
+
+    async def test_renders_pairs(self, fake_top_pairs):
+        fake_top_pairs["pairs"] = [
+            {
+                "baseToken": {"symbol": "MNEME", "address": "0x" + "1" * 40},
+                "priceUsd": "0.00001",
+                "marketCap": 1_000_000,
+                "volume": {"h24": 50_000},
+            }
+        ]
+        out = await trending_mod.handle_trending("")
+        assert "MNEME" in out
+        assert "DexScreener" in out
+        assert "--clawnch" in out
+
+
+# ── --clawnch path (Clawnch API) ───────────────────────────────────
+
+
+class TestRenderClawnch:
+    async def test_http_error(self, fake_clawnch_get):
+        fake_clawnch_get["raises"] = RuntimeError("connection refused")
+        out = await trending_mod.handle_trending("--clawnch")
+        assert "Could not fetch Clawnch trending" in out
+        assert "connection refused" in out
+
+    async def test_empty_response(self, fake_clawnch_get):
+        fake_clawnch_get["body"] = {"tokens": []}
+        out = await trending_mod.handle_trending("--clawnch")
+        assert "No Clawnch tokens" in out
+        assert "--all" in out
+
+    async def test_renders_tokens(self, fake_clawnch_get):
+        fake_clawnch_get["body"] = {
+            "tokens": [
+                {
+                    "symbol": "MNEME",
+                    "name": "MNEME",
+                    "contractAddress": "0x" + "1" * 40,
+                    "priceUsd": "0.00001",
+                    "marketCap": 1_300_000,
+                    "volume24h": 55_000,
+                }
+            ]
+        }
+        out = await trending_mod.handle_trending("--clawnch")
+        assert "MNEME" in out
+        assert "Top 1 Clawnch tokens" in out
+
+    async def test_list_response_shape(self, fake_clawnch_get):
+        # Some backends return the array directly
+        fake_clawnch_get["body"] = [{"symbol": "A", "address": "0x" + "1" * 40, "name": "Alpha"}]
+        out = await trending_mod.handle_trending("--clawnch")
+        assert "Alpha" in out
+
+
+# ── shape extractors / formatters ───────────────────────────────────
+
+
+class TestExtractClawnchTokens:
+    def test_none(self):
+        assert trending_mod._extract_clawnch_tokens(None) == []
+
+    def test_list(self):
+        assert trending_mod._extract_clawnch_tokens([{"a": 1}, "junk"]) == [{"a": 1}]
+
+    def test_dict_data_key(self):
+        assert trending_mod._extract_clawnch_tokens({"data": [{"a": 1}]}) == [{"a": 1}]
+
+    def test_dict_results_key(self):
+        assert trending_mod._extract_clawnch_tokens({"results": [{"a": 1}]}) == [{"a": 1}]
+
+    def test_dict_no_known_key(self):
+        assert trending_mod._extract_clawnch_tokens({"weird": [1]}) == []
+
+
+class TestFormatClawnchToken:
+    def test_bare(self):
+        out = trending_mod._format_clawnch_token({})
+        assert "?" in out
+
+    def test_skips_redundant_name(self):
+        out = trending_mod._format_clawnch_token({"symbol": "X", "name": "X"})
+        # "X" appears once (no "(X)" parenthetical)
+        assert out.count("X") == 1
+
+    def test_full(self):
+        out = trending_mod._format_clawnch_token(
+            {
+                "symbol": "X",
+                "name": "Xtra",
+                "price": "0.001",
+                "marketCap": 1_200_000,
+                "volume": 3_400,
+                "address": "0x" + "1" * 40,
+            }
+        )
+        assert "Xtra" in out
+        assert "$0.001" in out
+        assert "$1.20M" in out
+        assert "$3.4k" in out
+
+
+# ── _compact / _short ───────────────────────────────────────────────
+
+
+class TestCompact:
+    @pytest.mark.parametrize(
+        ("inp", "want"),
+        [
+            (42, "$42.00"),
+            (1500, "$1.5k"),
+            (2_500_000, "$2.50M"),
+            (7_300_000_000, "$7.30B"),
+            ("bad", "$bad"),
+        ],
+    )
+    def test_compact(self, inp, want):
+        assert trending_mod._compact(inp) == want
+
+
+class TestShort:
+    def test_short_input(self):
+        assert trending_mod._short("0xabc") == "0xabc"
+
+    def test_truncates(self):
+        out = trending_mod._short("0x" + "a" * 40)
+        assert "…" in out
+
+
+# ── command_history best-effort ────────────────────────────────────
+
+
+class TestRecordingBestEffort:
+    async def test_recording_failure_does_not_break(self, monkeypatch, fake_top_pairs):
+        from clawmes.services import command_history as ch_mod
+
+        def _boom(*a, **kw):
+            raise RuntimeError("history broken")
+
+        monkeypatch.setattr(ch_mod, "record_command_call", _boom)
+        out = await trending_mod.handle_trending("")
+        assert isinstance(out, str)
+
+
+class TestRegister:
+    def test_registers(self):
+        captured = []
+
+        class FakeCtx:
+            def register_command(self, **kw):
+                captured.append(kw["name"])
+
+        trending_mod.register(FakeCtx())
+        assert captured == ["trending"]

--- a/tests/lib/test_dexscreener.py
+++ b/tests/lib/test_dexscreener.py
@@ -1,0 +1,249 @@
+"""Tests for clawmes.lib.dexscreener."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.lib import dexscreener
+
+
+@pytest.fixture(autouse=True)
+def _reset_error():
+    dexscreener._set_error(None)
+    yield
+    dexscreener._set_error(None)
+
+
+@pytest.fixture
+def fake_get(monkeypatch):
+    """Patch ``http_get`` to return canned responses keyed by URL substring."""
+    responses: dict[str, dict] = {}
+    raises: dict[str, Exception] = {}
+
+    def _fake(url, *, params=None, timeout=None):  # noqa: ARG001
+        for needle, exc in raises.items():
+            if needle in url:
+                raise exc
+        for needle, body in responses.items():
+            if needle in url:
+                return body
+        return None
+
+    monkeypatch.setattr(dexscreener, "http_get", _fake)
+    return type("FH", (), {"responses": responses, "raises": raises})()
+
+
+# ── _looks_like_address ─────────────────────────────────────────────
+
+
+class TestLooksLikeAddress:
+    def test_valid_address(self):
+        assert dexscreener._looks_like_address("0x" + "a" * 40)
+        assert dexscreener._looks_like_address("0xA1F72459dfA10BAD200Ac160eCd78C6b77a747be")
+
+    def test_missing_prefix(self):
+        assert not dexscreener._looks_like_address("a" * 40)
+
+    def test_wrong_length(self):
+        assert not dexscreener._looks_like_address("0x" + "a" * 39)
+        assert not dexscreener._looks_like_address("0x" + "a" * 41)
+
+    def test_non_hex(self):
+        assert not dexscreener._looks_like_address("0x" + "z" * 40)
+
+
+# ── search ──────────────────────────────────────────────────────────
+
+
+class TestSearch:
+    def test_empty_query(self, fake_get):
+        assert dexscreener.search("") == []
+        assert dexscreener.search("   ") == []
+
+    def test_returns_pairs(self, fake_get):
+        fake_get.responses["/latest/dex/search"] = {
+            "pairs": [{"chainId": "base", "baseToken": {"symbol": "X"}}, "garbage"]
+        }
+        out = dexscreener.search("X")
+        assert len(out) == 1
+        assert out[0]["chainId"] == "base"
+
+    def test_handles_none_body(self, fake_get):
+        # http_get returns None (e.g. upstream gave non-dict)
+        assert dexscreener.search("X") == []
+
+    def test_records_error_on_exception(self, fake_get):
+        fake_get.raises["/latest/dex/search"] = RuntimeError("boom")
+        out = dexscreener.search("X")
+        assert out == []
+        assert "boom" in (dexscreener.last_error() or "")
+
+    def test_non_dict_response_returns_empty(self, fake_get, monkeypatch):
+        monkeypatch.setattr(dexscreener, "http_get", lambda *a, **k: ["not", "a", "dict"])
+        assert dexscreener.search("X") == []
+
+
+# ── find_token ──────────────────────────────────────────────────────
+
+
+class TestFindToken:
+    def test_empty_input(self, fake_get):
+        assert dexscreener.find_token("") is None
+        assert dexscreener.find_token("   ") is None
+
+    def test_address_path_hits_tokens_endpoint(self, fake_get):
+        addr = "0x" + "a" * 40
+        fake_get.responses[f"/latest/dex/tokens/{addr}"] = {
+            "pairs": [
+                {"chainId": "ethereum", "baseToken": {"symbol": "X"}},
+                {"chainId": "base", "baseToken": {"symbol": "X", "address": addr}},
+            ]
+        }
+        out = dexscreener.find_token(addr)
+        assert out is not None
+        assert out["chainId"] == "base"
+
+    def test_address_path_no_base_pair(self, fake_get):
+        addr = "0x" + "a" * 40
+        fake_get.responses[f"/latest/dex/tokens/{addr}"] = {
+            "pairs": [{"chainId": "ethereum", "baseToken": {"symbol": "X"}}]
+        }
+        assert dexscreener.find_token(addr) is None
+
+    def test_address_path_empty_body(self, fake_get):
+        addr = "0x" + "a" * 40
+        # No response configured -> http_get returns None
+        assert dexscreener.find_token(addr) is None
+
+    def test_symbol_no_match(self, fake_get):
+        fake_get.responses["/latest/dex/search"] = {"pairs": []}
+        assert dexscreener.find_token("UNKNOWN") is None
+
+    def test_symbol_exact_match_preferred(self, fake_get):
+        addr_x = "0x" + "1" * 40
+        addr_y = "0x" + "2" * 40
+        fake_get.responses["/latest/dex/search"] = {
+            "pairs": [
+                {"chainId": "base", "baseToken": {"symbol": "WRAPPED-X", "address": addr_y}},
+                {"chainId": "base", "baseToken": {"symbol": "X", "address": addr_x}},
+            ]
+        }
+        out = dexscreener.find_token("X")
+        assert out["baseToken"]["address"] == addr_x
+
+    def test_symbol_falls_back_to_first_chain_pair(self, fake_get):
+        fake_get.responses["/latest/dex/search"] = {
+            "pairs": [
+                {"chainId": "ethereum", "baseToken": {"symbol": "X"}},
+                {"chainId": "base", "baseToken": {"symbol": "X-LP"}},
+            ]
+        }
+        out = dexscreener.find_token("X")
+        # No exact "X" baseToken on base — falls back to first base pair
+        assert out["baseToken"]["symbol"] == "X-LP"
+
+    def test_symbol_no_base_pairs(self, fake_get):
+        fake_get.responses["/latest/dex/search"] = {
+            "pairs": [{"chainId": "ethereum", "baseToken": {"symbol": "X"}}]
+        }
+        assert dexscreener.find_token("X") is None
+
+
+# ── top_pairs ───────────────────────────────────────────────────────
+
+
+class TestTopPairs:
+    def test_zero_limit(self, fake_get):
+        assert dexscreener.top_pairs(limit=0) == []
+
+    def test_negative_limit(self, fake_get):
+        assert dexscreener.top_pairs(limit=-5) == []
+
+    def test_filters_to_chain_and_caps(self, fake_get):
+        fake_get.responses["/latest/dex/search"] = {
+            "pairs": [
+                {"chainId": "base", "baseToken": {"symbol": "A"}},
+                {"chainId": "ethereum", "baseToken": {"symbol": "B"}},
+                {"chainId": "base", "baseToken": {"symbol": "C"}},
+                {"chainId": "base", "baseToken": {"symbol": "D"}},
+            ]
+        }
+        out = dexscreener.top_pairs(chain="base", limit=2)
+        assert [p["baseToken"]["symbol"] for p in out] == ["A", "C"]
+
+
+# ── format_pair_summary ─────────────────────────────────────────────
+
+
+class TestFormatPairSummary:
+    def test_minimal_pair(self):
+        out = dexscreener.format_pair_summary({})
+        # Symbol "?" and address "?" with no other fields
+        assert "?" in out
+
+    def test_full_pair(self):
+        pair = {
+            "baseToken": {"symbol": "MNEME", "address": "0x" + "1" * 40},
+            "priceUsd": "0.0000132",
+            "marketCap": 1_300_000,
+            "volume": {"h24": 55_000},
+        }
+        out = dexscreener.format_pair_summary(pair)
+        assert "MNEME" in out
+        assert "$0.0000132" in out
+        assert "$1.30M" in out
+        assert "$55.0k" in out
+
+    def test_fdv_fallback_when_no_mc(self):
+        pair = {
+            "baseToken": {"symbol": "X", "address": "0x" + "1" * 40},
+            "fdv": 2_400_000_000,
+        }
+        out = dexscreener.format_pair_summary(pair)
+        assert "$2.40B" in out
+
+
+# ── _compact_usd / _short_addr ──────────────────────────────────────
+
+
+class TestCompactUsd:
+    def test_under_1k(self):
+        assert dexscreener._compact_usd(42) == "$42.00"
+
+    def test_thousand_range(self):
+        assert dexscreener._compact_usd(1500) == "$1.5k"
+
+    def test_million_range(self):
+        assert dexscreener._compact_usd(2_500_000) == "$2.50M"
+
+    def test_billion_range(self):
+        assert dexscreener._compact_usd(7_300_000_000) == "$7.30B"
+
+    def test_non_numeric_passthrough(self):
+        assert dexscreener._compact_usd("garbage") == "$garbage"
+
+
+class TestShortAddr:
+    def test_short_input_returned_verbatim(self):
+        assert dexscreener._short_addr("0xabc") == "0xabc"
+
+    def test_truncates(self):
+        addr = "0x" + "a" * 40
+        out = dexscreener._short_addr(addr)
+        assert out.startswith("0xaaaa")
+        assert out.endswith("aaaa")
+        assert "…" in out
+
+
+# ── last_error / _set_error ────────────────────────────────────────
+
+
+class TestErrorState:
+    def test_initial_none(self):
+        assert dexscreener.last_error() is None
+
+    def test_set_and_clear(self):
+        dexscreener._set_error("oops")
+        assert dexscreener.last_error() == "oops"
+        dexscreener._set_error(None)
+        assert dexscreener.last_error() is None

--- a/tests/services/test_clawnch.py
+++ b/tests/services/test_clawnch.py
@@ -201,6 +201,52 @@ class TestStartDeploy:
         )
         assert captured[0]["bypassTxHash"] == "0xdeadbeef"
 
+    def test_includes_burn_tx(self, svc_with_key, monkeypatch):
+        captured: list[dict] = []
+
+        def _post(url, json, headers, timeout):  # noqa: A002
+            captured.append(json)
+            return {
+                "challengeId": "cid",
+                "message": "m",
+                "nonce": "n",
+                "contractAddress": "0x42",
+                "storageSlot": "0x00",
+                "deadline": "2030",
+            }
+
+        monkeypatch.setattr("clawmes.services.clawnch.http_post", _post)
+        svc_with_key.start_deploy(
+            token_params={"name": "x", "symbol": "X"},
+            burn_tx_hash="0xburn",
+        )
+        assert captured[0]["burnTxHash"] == "0xburn"
+        # No bypass key when bypass not requested.
+        assert "bypassTxHash" not in captured[0]
+
+    def test_burn_and_bypass_independent(self, svc_with_key, monkeypatch):
+        captured: list[dict] = []
+
+        def _post(url, json, headers, timeout):  # noqa: A002
+            captured.append(json)
+            return {
+                "challengeId": "cid",
+                "message": "m",
+                "nonce": "n",
+                "contractAddress": "0x42",
+                "storageSlot": "0x00",
+                "deadline": "2030",
+            }
+
+        monkeypatch.setattr("clawmes.services.clawnch.http_post", _post)
+        svc_with_key.start_deploy(
+            token_params={"name": "x", "symbol": "X"},
+            bypass_tx_hash="0xbypass",
+            burn_tx_hash="0xburn",
+        )
+        assert captured[0]["bypassTxHash"] == "0xbypass"
+        assert captured[0]["burnTxHash"] == "0xburn"
+
 
 # ──────────────────────────────────────────────────────────────────────
 #  solve_challenge
@@ -434,6 +480,42 @@ class TestDeployConvenience:
         assert result["success"] is True
         assert result["tokenAddress"] == "0xtok"
 
+    def test_deploy_forwards_burn_tx(self, svc_with_key, monkeypatch):
+        # Deploy convenience must forward burn_tx_hash through start_deploy
+        # into the body of the /api/deploy POST.
+        captured: list[dict] = []
+        responses = [
+            {
+                "challengeId": "cid",
+                "message": "msg",
+                "nonce": "nonce",
+                "contractAddress": "0x4200000000000000000000000000000000000006",
+                "storageSlot": "0x00",
+                "deadline": "2030",
+            },
+            {"success": True, "txHash": "0xtx", "tokenAddress": "0xtok"},
+        ]
+
+        def _post(url, json, headers, timeout):  # noqa: A002
+            captured.append(json)
+            return responses.pop(0)
+
+        monkeypatch.setattr("clawmes.services.clawnch.http_post", _post)
+        monkeypatch.setattr(
+            "clawmes.services.wallet.get_wallet_service",
+            lambda: _FakeWalletSvc(_FakeWalletMode()),
+        )
+        monkeypatch.setattr(
+            "clawmes.services.rpc.get_rpc_service",
+            lambda: _FakeRpc("0xff"),
+        )
+        svc_with_key.deploy(
+            token_params={"name": "x", "symbol": "X"},
+            burn_tx_hash="0xburn",
+        )
+        # First call is /api/deploy with the start_deploy body.
+        assert captured[0]["burnTxHash"] == "0xburn"
+
 
 # ──────────────────────────────────────────────────────────────────────
 #  reads
@@ -489,7 +571,8 @@ class TestReads:
     def test_get_bypass_recipient_default(self, svc):
         info = svc.get_bypass_recipient()
         assert info["recipient"].startswith("0x")
-        assert info["fee_eth"] == "0.001"
+        # Matches server-side default in api/lib/launch-bypass.ts.
+        assert info["fee_eth"] == "0.005"
 
     def test_get_bypass_recipient_env_override(self, monkeypatch, svc):
         monkeypatch.setenv("CLAWNCH_BYPASS_RECIPIENT", "0xabc")
@@ -497,6 +580,21 @@ class TestReads:
         info = svc.get_bypass_recipient()
         assert info["recipient"] == "0xabc"
         assert info["fee_eth"] == "0.01"
+
+    def test_get_burn_config_default(self, svc):
+        cfg = svc.get_burn_config()
+        assert cfg["token_address"].startswith("0x")
+        assert cfg["burn_address"].lower().endswith("dead")
+        assert cfg["min_burn_tokens"] == 1_000_000
+
+    def test_get_burn_config_env_override(self, monkeypatch, svc):
+        monkeypatch.setenv("CLAWNCH_TOKEN_ADDRESS", "0xtoken")
+        monkeypatch.setenv("CLAWNCH_BURN_ADDRESS", "0xburn")
+        monkeypatch.setenv("CLAWNCH_MIN_BURN_TOKENS", "500000")
+        cfg = svc.get_burn_config()
+        assert cfg["token_address"] == "0xtoken"
+        assert cfg["burn_address"] == "0xburn"
+        assert cfg["min_burn_tokens"] == 500000
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Ships the first cut of in-chat trading + discovery for clawmes, plus $CLAWNCH burn-to-vault on launch.

- **/buy <token> <eth_amount> [--clawnch | --all]** → quote → confirm swap via 0x Permit2 (wraps existing `defi_swap` tool). Symbol resolution via DexScreener; `--clawnch` verifies the resolved address against `/api/launches`. Addresses (`0x...`) bypass symbol resolution.
- **/trending [--clawnch | --all] [limit]** → top Base tokens by 24h volume. `--clawnch` queries the launchpad's `/api/tokens?sort=volume`; `--all` defaults to DexScreener.
- **/my_launches [--clawnch | --all]** → Clawnch agent launch history (default) or full Basescan contract-creation scan against the connected wallet, enriched with DexScreener.
- **/launch burn <amount | tx_hash>** → sign + submit the CLAWNCH ERC-20 transfer to the burn address from the active wallet (integer amount), or record a pre-existing tx hash. Forwarded to `/api/deploy` as `burnTxHash` on `/launch confirm`. Backend verifies + applies vault % (1M CLAWNCH = 1%, 10M = 10% max).

## Universe flags

Default is `--all` (broadest Base universe via DexScreener) for `/trending` and `/buy`. `--clawnch` restricts to launchpad-deployed tokens. Default is `--clawnch` for `/my_launches` (the API-key-scoped history is the more useful default) — `--all` adds the wallet-wide Basescan scan.

## Internals

- New `clawmes/lib/dexscreener.py` — stateless helper over the public DexScreener API (no auth, no lifecycle). Exposes `search`, `find_token`, `top_pairs`, `format_pair_summary`.
- `ClawnchService.start_deploy()` + `deploy()` gain optional `burn_tx_hash`; new `get_burn_config()` exposes CLAWNCH token addr + burn addr + min burn (overridable via env).
- `get_bypass_recipient()` fallback bumped from 0.001 ETH → 0.005 ETH to match the server-side default.
- Version bump to 0.3.0 across pyproject.toml, `_version.py`, and both `plugin.yaml` copies.

## Tests

176 new tests across `tests/lib/test_dexscreener.py`, `tests/commands/test_{buy,trending,my_launches,launch}.py`, and the burn-plumbing tests in `tests/services/test_clawnch.py`. Full suite 2859 passing at 100% coverage. Ruff clean.

## Docs

- README "Commands" table updated (78 commands / 16 categories).
- New README section "Trading + discovery from chat" walks through the new loop.
- Launch flow updated with `/launch burn` curve + 0.005 ETH bypass amount.
- CHANGELOG 0.3.0 entry.