### PR TITLE
feat(base-mcp): non-custodial /launch + /burn + /launch export + alerts (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,85 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.4.0 — 2026-05-26
+
+### Added — Base ecosystem integration
+
+clawmes now wires deeply into the Base MCP plugin work that landed
+in the clawnch backend. The headline change is that `/launch` no
+longer requires a Clawnch API key — when a wallet is connected, deploys
+go through the new non-custodial path (`GET /api/prepare/deploy`) and
+the user signs + pays gas directly.
+
+- **Non-custodial `/launch confirm` (new default)** — when a wallet is
+  connected, `/launch confirm` hits `/api/prepare/deploy` for unsigned
+  Clanker factory calldata and submits it via the active wallet mode.
+  No `CLAWNCH_API_KEY`, no `/register_agent` step, no 24h cooldown, no
+  captcha. The 80% / 20% fee split is preserved in the rewards array
+  of the prepared calldata.
+- **`/launch confirm --custodial`** — explicit opt-in to the old path
+  (server-paid gas, captcha challenge, API key required). Same flow as
+  v0.3.0's default `/launch confirm`.
+- **`/launch confirm --noncustodial`** — explicit opt-in to the new
+  path even without a connected wallet (will error out with a clear
+  message). Useful for scripted flows.
+- **`/launch export`** — emits unsigned Clanker calldata as a
+  JSON-shaped `{chain, calls}` block ready to paste into Base MCP's
+  `send_calls`, Claude Desktop, Cursor, or any other agent surface
+  with its own signing UX. No wallet operation on the clawmes side.
+- **`/launch alerts [source]`** — points users at the public
+  `@ClawnchAlerts` Telegram channel and documents how to filter the
+  feed client-side. Sources: `clawmes`, `moltbook`, `4claw`,
+  `clawtomaton`, `moltx`, `base-mcp`, `clawncher`.
+
+### Added — `/burn` command
+
+- **`/burn <amount>`** — standalone CLAWNCH burn, decoupled from
+  `/launch`. Signs an ERC-20 transfer to the burn address from the
+  active wallet. Range: 1,000,000 (1% vault) to 10,000,000 (10% max
+  vault, Clanker limit). Returns the burn tx hash you can plug into
+  `/launch burn <tx_hash>`, `/api/prepare/deploy?burnTxHash=…`, or
+  any other surface that takes a burn-tx receipt.
+- **`/burn last`** — shows the most recent burn tx hash submitted via
+  this command, useful for piping between flows without scrolling.
+
+### Added — `/buy` Clawnch attribution
+
+- `/buy <token> <eth>` quotes now include a Clawnch-attribution line
+  when the buy token is in the launchpad index. Format:
+  `Clawnch: source <X> · agent <Y> · launched <ISO>`. Best-effort —
+  lookup failures silently skip the line, no impact on the swap.
+
+### Added — `ClawnchService.prepare_deploy()`
+
+- New service method wrapping `GET /api/prepare/deploy`. Public
+  endpoint, no auth required. Returns the envelope shape
+  `{ok, data: {to, data, value, chainId}, meta: {…}}` and maps upstream
+  error codes (`rate_limited`, `invalid_burn`, `invalid_from`, etc.)
+  to clawmes' standard `ClawnchError` classifications. Used by both
+  `/launch confirm` (non-custodial path) and `/launch export`.
+- `ClawnchService._get()` gains an optional `params` kwarg so the
+  query string for `/api/prepare/deploy` doesn't have to be
+  constructed by hand.
+
+### Tests
+
+- +77 new tests across `tests/services/test_clawnch.py` (prepare_deploy
+  full error-code coverage), `tests/commands/test_launch.py`
+  (non-custodial path: 19 cases covering wallet states, receipt parsing,
+  prepare errors, mode resolution, export, alerts), `tests/commands/test_buy.py`
+  (8 attribution cases), `tests/commands/test_burn.py` (20 cases for
+  the new command). Full suite 2936 passing at 100% coverage.
+
+### Notes
+
+- Existing custodial flow remains fully supported behind
+  `/launch confirm --custodial`. The `CLAWNCH_API_KEY` environment
+  variable is still honored when set. Users on v0.3.0 who relied on
+  the custodial default get a one-line behavior change: passing
+  `--custodial` to confirm now preserves the old path, otherwise the
+  new non-custodial path runs (which is almost always what they want).
+
 ## 0.3.0 — 2026-05-26
 
 ### Added — trading, discovery, burn-to-vault

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 
 ## Commands
 
-78 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
+79 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
 
 | Category | Commands |
 |---|---|
@@ -79,7 +79,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 | **Plans & triggers** (10) | `/plans` `/plan` `/plan_logs` `/interrupt_plan` `/pause_plan` `/resume_plan` `/triggers` `/watch` `/unwatch` `/cron` |
 | **Onboarding** (19) | `/welcome`, 5 personas (`/professional` `/degen` `/chill` `/technical` `/mentor`), 10 capability toggles (`/cap_wallet` `/cap_prices` `/cap_portfolio` `/cap_trading` `/cap_liquidity` `/cap_launchpad` `/cap_bridge` `/cap_routing` `/cap_clawnx` `/cap_hummingbot`), `/skip` `/back` `/reonboard` |
 | **Balance & portfolio** (2) | `/balance` `/portfolio` |
-| **Trading & discovery** (3) | `/buy` `/trending` `/my_launches` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches |
+| **Trading & discovery** (4) | `/buy` `/trending` `/my_launches` `/burn` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault % |
 | **Self-evolution** (3) | `/evolve` `/stable` `/evolution` — gates `agent_memory` and `skill_evolve` write actions; OFF by default |
 | **Endpoint allowlist** (3) | `/allowlist` `/allow` `/disallow` — session-scoped host allowlist + 100-entry block audit ring |
 | **Discoverability** (5) | `/skills` `/persona` `/chains` `/tools_list` `/safety_status` |
@@ -151,12 +151,10 @@ Clawmes wires the following partner / ecosystem projects directly into the tool 
 
 ## Launch a token from chat
 
-Clawmes wires the Clawnch launchpad end-to-end so any user can deploy a token from a chat message:
+Clawmes wires the Clawnch launchpad end-to-end so any user can deploy a token from a chat message. As of v0.4.0, the default is **non-custodial** — your wallet signs the deploy tx directly, no API key needed:
 
 ```
-/register_agent MyAgent | An agent that launches tokens
-# clawmes posts a challenge, your wallet signs it, clawn.ch
-# returns an apiKey. Save it as CLAWNCH_API_KEY in ~/.hermes/.env.
+/connect_local                               # or /connect (WalletConnect) / /connect_bankr
 
 /launch name MyCoin
 /launch symbol MC
@@ -168,34 +166,70 @@ Clawmes wires the Clawnch launchpad end-to-end so any user can deploy a token fr
 /launch farcaster mycoin                     # optional
 /launch discord https://discord.gg/abc       # optional
 /launch confirm
-# Clawnch's deployer wallet submits the Clanker tx server-side;
-# your wallet only signs the captcha. Returns tx hash + token
-# address.
+# clawmes calls https://www.clawn.ch/api/prepare/deploy for unsigned
+# Clanker factory calldata, then your wallet signs and submits.
+# 80% fees to you, 20% platform fee preserved in the rewards array.
+# Returns tx hash + token address.
 ```
 
 Social handles get normalized (`mycoin` → `https://x.com/mycoin`); full URLs pass through unchanged. They're persisted to `tokenParams.metadata.socialMediaUrls` on the launchpad side and may render as badges on the launch detail page.
 
-Free-tier rate limit: 1 deploy per 24 hours per agent. To skip the cooldown, send `0.005 ETH` (or the current bypass amount) to the Clawnch bypass recipient on Base, then `/launch bypass <tx_hash>` and `/launch confirm`.
-
-To claim a vault allocation, burn $CLAWNCH within 24 hours of the launch:
+To claim a vault allocation, burn $CLAWNCH before confirming:
 
 ```
-/launch burn 1000000            # signs + submits a 1M CLAWNCH burn from the active wallet (= 1% vault)
-/launch burn 10000000           # max 10M CLAWNCH (= 10% vault, the Clanker maximum)
+/burn 1000000                   # standalone burn: signs + submits 1M CLAWNCH = 1% vault
+/burn 10000000                  # max 10M CLAWNCH = 10% vault (Clanker maximum)
+/burn last                      # show the last burn tx hash you signed via clawmes
+
+# Or via the legacy /launch burn path (same outcome):
+/launch burn 1000000            # signs + submits a 1M CLAWNCH burn from the active wallet
 /launch burn 0x<tx_hash>        # or paste a tx hash if you burned externally
 /launch confirm                 # deploy with vault allocation applied
 ```
 
-Curve: 1k tokens allocated per 1 CLAWNCH burned (1M → 1%, 10M → 10%). Vault tokens are subject to the Clanker 7-day lockup. See [`api/lib/burn.ts`](https://github.com/clawnchdev/clawnch/blob/main/api/lib/burn.ts) for the exact verification rules.
+Curve: 1k tokens allocated per 1 CLAWNCH burned (1M → 1%, 10M → 10%). Vault tokens are subject to the Clanker 7-day lockup. See [`api/lib/burn.ts`](https://github.com/clawnchdev/clawnch/blob/main/api/lib/burn.ts) for the exact verification rules. Server-side verification happens on every deploy — passing `tokenParams.vault.percentage` without a verified `burnTxHash` is rejected with `VAULT_REQUIRES_BURN`.
 
-How the gate works:
+### Custodial deploys (legacy path)
 
-→ `CLAWNCH_API_KEY` authenticates the agent to the Clawnch API
-→ The launchpad returns a 5-second captcha challenge (storage-slot read + signed message + keccak proof)
-→ Clawmes solves the captcha using the active wallet's `personal_sign`
-→ Clawnch's deployer wallet (server-side) pays gas and submits the underlying Clanker call
+For users who can't pay deploy gas themselves, or who want server-paid gas with the existing agent-registration tracking:
 
-Wallet signs only the off-chain captcha — Clawnch pays deploy gas. The `clawnch_launch` tool (LLM-callable) and `clawnch_fees` (read launches + fee accrual) follow the same path. See [`clawmes:clawnch-launch` skill](clawmes/skills/clawnch-launch/SKILL.md) for the LLM-facing surface.
+```
+/register_agent MyAgent | An agent that launches tokens
+# clawmes posts a challenge, your wallet signs, clawn.ch returns an apiKey.
+# Save it as CLAWNCH_API_KEY in ~/.hermes/.env.
+
+/launch ... (same drafting steps)
+/launch confirm --custodial
+# Clawnch's deployer wallet submits the Clanker tx server-side;
+# your wallet only signs the captcha. Subject to the 24h cooldown.
+```
+
+Bypass the cooldown by sending `0.005 ETH` to the Clawnch bypass recipient on Base, then `/launch bypass <tx_hash>` + `/launch confirm --custodial`.
+
+### Export-only mode (for Base MCP, Claude Desktop, Cursor, ChatGPT)
+
+clawmes can also emit the unsigned calldata for you to paste into another agent surface — useful if you want to launch via Base MCP's `send_calls` from Claude Desktop or any other MCP-compatible client:
+
+```
+/launch name MyCoin
+/launch symbol MC
+/launch export
+# Prints a JSON {chain: "base", calls: [{to, data, value}]} block
+# ready to paste into Base MCP's send_calls.
+```
+
+### Launch alerts
+
+```
+/launch alerts                          # subscribe link + filter docs
+/launch alerts base-mcp                 # client-side filter docs for base-mcp source
+```
+
+All Clawnch deploys post to the public `@ClawnchAlerts` Telegram channel — custodial ones from the server, non-custodial / base-mcp ones from the on-chain indexer cron. Filter client-side using Telegram's built-in keyword highlighting.
+
+### How both deploy paths preserve fees
+
+Whether custodial or non-custodial, every deploy hard-codes Clawnch's 20% platform fee into the Clanker `rewards.recipients` array (the user gets 80%). The non-custodial path verifies this server-side before returning calldata and refuses to return anything if the platform fee recipient env var is misconfigured — fail-closed on fee economics. See [`clawmes:clawnch-launch` skill](clawmes/skills/clawnch-launch/SKILL.md) for the LLM-facing surface and `clawnch_launch` / `clawnch_fees` tools for the same path under the LLM.
 
 ## Trading + discovery from chat
 

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -17,6 +17,7 @@ from clawmes.commands import (
     agent,
     allowlist,
     balance,
+    burn,
     buy,
     discovery,
     doctor,
@@ -65,6 +66,7 @@ def register_all(ctx) -> None:
     buy.register(ctx)
     trending.register(ctx)
     my_launches.register(ctx)
+    burn.register(ctx)
     # TODO(v0.1.0+): model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
     # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/burn.py
+++ b/clawmes/commands/burn.py
@@ -1,0 +1,189 @@
+"""``/burn`` slash command — standalone $CLAWNCH burn.
+
+Decoupled from the launch flow so users can burn at any time —
+before drafting a launch, between launches, or just to claim a
+Clanker vault allocation on a deploy they're planning to do
+later from Base MCP / Claude Desktop / another agent surface.
+
+Two input modes:
+
+  * ``/burn <amount>`` — sign + submit a CLAWNCH transfer to the burn
+    address from the active wallet. Amount in whole tokens (e.g.
+    ``1000000`` for 1M CLAWNCH = 1% vault on next deploy).
+  * ``/burn last`` — show the most recent burn tx hash submitted via
+    this command, useful for piping into ``/launch burn <tx_hash>``
+    or ``/api/prepare/deploy?burnTxHash=<hash>``.
+
+Vault curve (verified server-side on every deploy that supplies the
+hash):
+
+  *   1,000,000 CLAWNCH → 1% vault
+  *  10,000,000 CLAWNCH → 10% vault (Clanker maximum)
+  *      between → linear (1k allocated tokens per 1 CLAWNCH burned)
+
+The 7-day Clanker lockup applies to vault tokens.
+
+State: per-sender, in-process. The most recent successful burn tx
+hash is cached so the user can copy/reference it without scrolling.
+Clears at process restart.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+_burn_state: dict[str, dict[str, Any]] = {}
+_state_lock = threading.RLock()
+
+_MIN_BURN_TOKENS = 1_000_000
+_MAX_BURN_TOKENS = 10_000_000
+
+
+def _record(name: str, args: str, result: str) -> None:
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _resolve_sender(kwargs: dict[str, Any]) -> str:
+    return str(kwargs.get("sender_id") or "default")
+
+
+def _remember_burn(sender_id: str, tx_hash: str, amount: int) -> None:
+    with _state_lock:
+        _burn_state[sender_id] = {"tx_hash": tx_hash, "amount": amount}
+
+
+def _recall_burn(sender_id: str) -> dict[str, Any] | None:
+    with _state_lock:
+        return _burn_state.get(sender_id)
+
+
+def _parse_amount(raw: str) -> int | str:
+    """Return the parsed amount or an error string."""
+    try:
+        amount = int(raw.replace("_", "").replace(",", ""))
+    except ValueError:
+        return f"Invalid amount {raw!r}. Expected a positive integer (e.g. 1000000)."
+    if amount < _MIN_BURN_TOKENS:
+        return (
+            f"Burn amount too low: {amount:,} CLAWNCH (minimum {_MIN_BURN_TOKENS:,} for 1% vault)."
+        )
+    if amount > _MAX_BURN_TOKENS:
+        return (
+            f"Burn amount above cap: {amount:,} CLAWNCH "
+            f"(max {_MAX_BURN_TOKENS:,} = 10% vault, the Clanker limit). "
+            "Anything above this is wasted."
+        )
+    return amount
+
+
+async def handle_burn(raw_args: str, **kwargs: Any) -> str:
+    sender_id = _resolve_sender(kwargs)
+    arg = (raw_args or "").strip()
+    if not arg:
+        out = _render_usage(_recall_burn(sender_id))
+        _record("burn", raw_args, out)
+        return out
+
+    parts = arg.split()
+    first = parts[0].lower()
+
+    if first == "last":
+        out = _render_last(_recall_burn(sender_id))
+    else:
+        parsed = _parse_amount(parts[0])
+        if isinstance(parsed, str):
+            out = parsed
+        else:
+            out = await _submit(sender_id, parsed)
+
+    _record("burn", raw_args, out)
+    return out
+
+
+def _render_usage(last: dict[str, Any] | None) -> str:
+    lines = [
+        "Burn $CLAWNCH for vault allocation on your next launch.",
+        "",
+        "Usage:",
+        "  /burn <amount>          — sign + submit a CLAWNCH burn from your wallet",
+        "  /burn last              — show the most recent burn tx hash",
+        "",
+        "Vault curve: 1M CLAWNCH = 1% vault, 10M = 10% (Clanker max).",
+        "             1k allocated tokens per 1 CLAWNCH burned.",
+        "             7-day Clanker lockup applies.",
+        "",
+        "After burning, either:",
+        "  /launch confirm                       (vault auto-applied if recent burn)",
+        "  /launch burn <tx_hash>                (explicit attach to draft)",
+        "  /api/prepare/deploy?burnTxHash=<hash> (Base MCP / external flow)",
+    ]
+    if last:
+        lines.append("")
+        lines.append("Most recent burn:")
+        lines.append(f"  amount: {last['amount']:,} CLAWNCH")
+        lines.append(f"  tx:     {last['tx_hash']}")
+    return "\n".join(lines)
+
+
+def _render_last(last: dict[str, Any] | None) -> str:
+    if not last:
+        return "No burn recorded this session. Run /burn <amount> first."
+    return (
+        f"Most recent burn: {last['amount']:,} CLAWNCH\n"
+        f"  Tx: {last['tx_hash']}\n"
+        f"  Basescan: https://basescan.org/tx/{last['tx_hash']}"
+    )
+
+
+async def _submit(sender_id: str, whole_tokens: int) -> str:
+    """Sign + submit the CLAWNCH burn transfer via the active wallet."""
+    from clawmes.lib.abi import encode_transfer
+    from clawmes.services.clawnch import get_clawnch_service
+    from clawmes.services.wallet import get_wallet_service, get_wallet_state
+
+    state = get_wallet_state()
+    if not state.connected:
+        return "No wallet connected. Run /connect or /connect_local first."
+    mode = get_wallet_service().active_mode()
+    if mode is None:
+        return "No active wallet mode. Run /connect."
+
+    cfg = get_clawnch_service().get_burn_config()
+    token_addr = cfg["token_address"]
+    burn_addr = cfg["burn_address"]
+    amount_wei = whole_tokens * (10**18)
+    calldata = encode_transfer(burn_addr, amount_wei)
+
+    try:
+        tx_hash = mode.send_transaction(
+            to=token_addr,
+            value=0,
+            data=calldata,
+            chain_id=8453,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return f"Burn tx submission failed: {exc}"
+
+    _remember_burn(sender_id, tx_hash, whole_tokens)
+    return (
+        f"Burn submitted: {whole_tokens:,} CLAWNCH → {burn_addr}\n"
+        f"  Tx: {tx_hash}\n"
+        f"  Basescan: https://basescan.org/tx/{tx_hash}\n"
+        "\n"
+        "Next: /launch burn <tx_hash> + /launch confirm  (claims vault on next deploy)."
+    )
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="burn",
+        handler=handle_burn,
+        description="Burn $CLAWNCH from the active wallet for vault allocation",
+        args_hint="<amount> | last",
+    )

--- a/clawmes/commands/buy.py
+++ b/clawmes/commands/buy.py
@@ -223,6 +223,13 @@ async def _quote(sender_id: str, parts: list[str]) -> str:
     }
     _set_draft(sender_id, draft)
 
+    # Best-effort Clawnch attribution — look the token up in the
+    # launchpad index. Doesn't affect the quote; just adds context so
+    # the user knows whether they're buying something Clawnch tracks.
+    # Failures (HTTP issues, address not in the index) silently skip
+    # the attribution line.
+    attribution = _lookup_clawnch_attribution(addr)
+
     lines = [
         f"Quote: {amount} ETH → {expected_out} {label}",
         f"  Address: {addr}",
@@ -232,9 +239,48 @@ async def _quote(sender_id: str, parts: list[str]) -> str:
         lines.append(f"  Price: {price}")
     if route:
         lines.append(f"  Route: {route}")
+    if attribution:
+        lines.append(f"  {attribution}")
     lines.append("")
     lines.append("Run /buy confirm to execute, or /buy cancel to discard.")
     return "\n".join(lines)
+
+
+def _lookup_clawnch_attribution(address: str) -> str | None:
+    """Return a one-line Clawnch attribution string, or None if not found.
+
+    Hits ``/api/launches?address=`` (the same endpoint /buy --clawnch
+    uses to verify). Renders source + agent + age when available so the
+    user can tell at a glance "yes, this is a Clawnch-launched token,
+    deployed N hours ago by source X."
+
+    Best-effort — never raises, never blocks the quote.
+    """
+    try:
+        from clawmes.services.clawnch import ClawnchError, get_clawnch_service
+
+        body = get_clawnch_service().get_launch(address)
+    except ClawnchError:
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+    if not isinstance(body, dict):
+        return None
+    if body.get("error") or body.get("success") is False:
+        return None
+    launch = body.get("launch") if "launch" in body else body
+    if not isinstance(launch, dict):
+        return None
+    source = launch.get("source") or "clawnch"
+    agent = launch.get("agentName") or launch.get("agent") or ""
+    launched_at = launch.get("launchedAt") or ""
+
+    parts = [f"Clawnch: source {source}"]
+    if agent:
+        parts.append(f"agent {agent}")
+    if launched_at:
+        parts.append(launched_at)
+    return " · ".join(parts)
 
 
 def _resolve_token(token_in: str, universe: str) -> tuple[str, str] | str:

--- a/clawmes/commands/launch.py
+++ b/clawmes/commands/launch.py
@@ -202,7 +202,11 @@ async def handle_launch(raw_args: str, **kwargs: Any) -> str:
     elif action == "burn":
         out = await _handle_burn(sender_id, rest)
     elif action == "confirm":
-        out = await _confirm(sender_id)
+        out = await _confirm(sender_id, rest)
+    elif action == "export":
+        out = await _export(sender_id)
+    elif action == "alerts":
+        out = _render_alerts(rest)
     else:
         out = (
             f"Unknown /launch arg {action!r}. Use:\n"
@@ -216,10 +220,13 @@ async def handle_launch(raw_args: str, **kwargs: Any) -> str:
             "  /launch telegram <handle|url> — Telegram\n"
             "  /launch farcaster <handle>    — Farcaster\n"
             "  /launch discord <url>         — Discord\n"
-            "  /launch bypass <tx_hash>      — skip 24h cooldown\n"
+            "  /launch bypass <tx_hash>      — skip 24h cooldown (custodial mode only)\n"
             "  /launch burn <amount|tx_hash> — burn $CLAWNCH for vault allocation\n"
             "  /launch status                — show current draft\n"
-            "  /launch confirm               — deploy\n"
+            "  /launch confirm               — deploy (non-custodial by default)\n"
+            "  /launch confirm --custodial   — deploy via Clawnch's custodial deployer\n"
+            "  /launch export                — emit unsigned calldata for Base MCP / external signing\n"
+            "  /launch alerts [source]       — subscribe to launch alerts (Telegram channel + filter docs)\n"
             "  /launch cancel                — clear draft"
         )
     _record("launch", raw_args, out)
@@ -244,10 +251,12 @@ def _render_usage(draft: dict[str, Any]) -> str:
         "  /launch discord <url>",
         "",
         "Flow:",
-        "  /launch bypass <tx_hash>         (skip 24h cooldown)",
+        "  /launch bypass <tx_hash>         (skip 24h cooldown — custodial only)",
         "  /launch burn <amount|tx_hash>    (burn $CLAWNCH for vault allocation)",
         "  /launch status                   (show draft)",
-        "  /launch confirm                  (deploy)",
+        "  /launch confirm                  (deploy via wallet — non-custodial default)",
+        "  /launch confirm --custodial      (deploy via Clawnch deployer wallet)",
+        "  /launch export                   (emit unsigned calldata for Base MCP)",
         "  /launch cancel                   (clear draft)",
         "",
         "Requires CLAWNCH_API_KEY. Use /register_agent if you need a key.",
@@ -375,7 +384,52 @@ def _looks_like_tx_hash(value: str) -> bool:
     return all(c in "0123456789abcdefABCDEF" for c in body)
 
 
-async def _confirm(sender_id: str) -> str:
+def _resolve_confirm_mode(flag_str: str, wallet_connected: bool) -> str:
+    """Pick the deploy path from the confirm-arg flag + wallet state.
+
+    Returns one of ``"noncustodial"`` or ``"custodial"``.
+
+    Rules:
+      * ``--custodial`` → custodial (regardless of wallet state).
+      * ``--noncustodial`` → non-custodial (errors later if no wallet).
+      * Default (no flag) → non-custodial when a wallet is connected,
+        else custodial. The new non-custodial path is the better
+        default — no API key required, no 24h cooldown, user pays gas.
+        But we fall back to custodial when no wallet is connected so
+        chat-only users on a stale install don't get a confusing
+        "no wallet" error.
+    """
+    flags = flag_str.split()
+    if "--custodial" in flags:
+        return "custodial"
+    if "--noncustodial" in flags:
+        return "noncustodial"
+    return "noncustodial" if wallet_connected else "custodial"
+
+
+def _build_token_params(draft: dict[str, Any], *, name: str, symbol: str) -> dict[str, Any]:
+    """Build the ``tokenParams`` dict that gets passed to ``ClawnchService.deploy``.
+
+    Shared between custodial and non-custodial flows so social-media URLs +
+    description + image render identically on the launchpad regardless of
+    which deploy path the user picked.
+    """
+    params: dict[str, Any] = {"name": name, "symbol": symbol}
+    if description := draft.get("description"):
+        params["description"] = description
+    if image := draft.get("image"):
+        params["image"] = image
+    socials = draft.get("socials") or {}
+    if socials:
+        params["metadata"] = {
+            "socialMediaUrls": [
+                {"platform": platform, "url": url} for platform, url in socials.items()
+            ]
+        }
+    return params
+
+
+async def _confirm(sender_id: str, flag_str: str) -> str:
     draft = _get_draft(sender_id)
     name = draft.get("name")
     symbol = draft.get("symbol")
@@ -385,19 +439,139 @@ async def _confirm(sender_id: str) -> str:
             "Run /launch name <…> and /launch symbol <TICKER> first."
         )
 
-    token_params: dict[str, Any] = {"name": name, "symbol": symbol}
-    if description := draft.get("description"):
-        token_params["description"] = description
-    if image := draft.get("image"):
-        token_params["image"] = image
-    socials = draft.get("socials") or {}
-    if socials:
-        token_params["metadata"] = {
-            "socialMediaUrls": [
-                {"platform": platform, "url": url} for platform, url in socials.items()
-            ]
-        }
+    from clawmes.services.wallet import get_wallet_state
 
+    wallet_state = get_wallet_state()
+    mode = _resolve_confirm_mode(flag_str, wallet_connected=wallet_state.connected)
+
+    if mode == "noncustodial":
+        if not wallet_state.connected or not wallet_state.address:
+            return (
+                "Non-custodial /launch needs a connected wallet to sign the deploy.\n"
+                "Run /connect or /connect_local first, or use /launch confirm --custodial "
+                "for the API-key path."
+            )
+        return await _confirm_noncustodial(sender_id, draft, wallet_state)
+    return await _confirm_custodial(sender_id, draft, name=name, symbol=symbol)
+
+
+async def _confirm_noncustodial(
+    sender_id: str,
+    draft: dict[str, Any],
+    wallet_state: Any,
+) -> str:
+    """Non-custodial path: prepare unsigned calldata, sign + submit via wallet.
+
+    The Clawnch backend's ``/api/prepare/deploy`` returns a
+    ``deployToken`` calldata for the Clanker factory, with the 20%
+    platform fee already embedded in the rewards array. We sign it via
+    the active wallet mode's ``send_transaction`` — the user (or their
+    phone, in WalletConnect mode) approves the tx and pays gas.
+
+    No API key required. No captcha. No 24h cooldown. Just one signed
+    transaction.
+    """
+    from clawmes.services.clawnch import ClawnchError, get_clawnch_service
+    from clawmes.services.rpc import RpcError, get_rpc_service
+    from clawmes.services.wallet import get_wallet_service
+
+    name = draft["name"]
+    symbol = draft["symbol"]
+    description = draft.get("description") or None
+    image = draft.get("image") or None
+    socials = draft.get("socials") or {}
+    burn = draft.get("burn_tx_hash")
+
+    try:
+        prepared = get_clawnch_service().prepare_deploy(
+            from_address=wallet_state.address,
+            name=name,
+            symbol=symbol,
+            description=description,
+            image=image,
+            twitter=socials.get("twitter"),
+            website=socials.get("website"),
+            telegram=socials.get("telegram"),
+            farcaster=socials.get("farcaster"),
+            discord=socials.get("discord"),
+            burn_tx_hash=burn,
+        )
+    except ClawnchError as exc:
+        msg = f"Prepare failed ({exc.code}): {exc.message}"
+        if exc.code == "rate_limited":
+            msg += "\n\nPer-wallet prepare limit reached (10/day). Try again after 00:00 UTC."
+        elif exc.code == "bad_request":
+            msg += "\n\nCheck /launch status — name, symbol, and any burn tx hash all need to be valid."
+        return msg
+    except Exception as exc:  # noqa: BLE001
+        return f"Prepare failed: {exc}"
+
+    data = prepared.get("data") or {}
+    meta = prepared.get("meta") or {}
+    to_addr = data.get("to")
+    calldata = data.get("data")
+    chain_id = data.get("chainId") or 8453
+    if not to_addr or not calldata:
+        return f"Prepare returned an unexpected shape: {prepared!r}"
+
+    mode = get_wallet_service().active_mode()
+    if mode is None:
+        return "No active wallet mode. Run /connect."
+    try:
+        tx_hash = mode.send_transaction(
+            to=to_addr,
+            value=0,
+            data=calldata,
+            chain_id=chain_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return f"Deploy submission failed: {exc}"
+
+    # Wait for receipt so we can surface the new token address. Best
+    # effort — if the receipt poll fails we still show the tx hash.
+    token_address = ""
+    try:
+        receipt = get_rpc_service().wait_for_receipt(tx_hash, chain_id, timeout=180.0)
+        # Clanker factory emits TokenCreated(address indexed token, ...)
+        # as its first log; the token address is in topics[1].
+        logs = receipt.get("logs") or []
+        if logs:
+            topics = (logs[0] or {}).get("topics") or []
+            if len(topics) >= 2:
+                topic = topics[1]
+                if isinstance(topic, str) and len(topic) >= 42:
+                    token_address = "0x" + topic[-40:]
+    except (RpcError, Exception):  # noqa: BLE001 — receipt is best-effort
+        pass
+
+    _clear_draft(sender_id)
+    lines = [
+        f"Launched (non-custodial). {meta.get('platformFeeBps', 2000) / 100:.0f}% platform fee preserved.",
+        f"  Tx: {tx_hash}",
+        f"  Basescan: https://basescan.org/tx/{tx_hash}",
+    ]
+    if token_address:
+        lines.append(f"  Token: {token_address}")
+        lines.append(f"  Chart: https://dexscreener.com/base/{token_address}")
+    vault_pct = meta.get("vaultPercentage") or 0
+    if vault_pct:
+        lines.append(f"  Vault: {vault_pct}% (Clanker lockup applies)")
+    return "\n".join(lines)
+
+
+async def _confirm_custodial(
+    sender_id: str,
+    draft: dict[str, Any],
+    *,
+    name: str,
+    symbol: str,
+) -> str:
+    """Custodial path: original Clawnch API flow (captcha + server deploys).
+
+    Kept for backwards-compat and for users who can't / don't want to
+    pay deploy gas themselves. Requires ``CLAWNCH_API_KEY``.
+    """
+    token_params = _build_token_params(draft, name=name, symbol=symbol)
     bypass = draft.get("bypass_tx_hash")
     burn = draft.get("burn_tx_hash")
 
@@ -412,7 +586,7 @@ async def _confirm(sender_id: str) -> str:
     except ClawnchError as exc:
         msg = f"Launch failed ({exc.code}): {exc.message}"
         if exc.code == "no_credentials":
-            msg += "\n\nRun /register_agent <name> <description> to get a key."
+            msg += "\n\nRun /register_agent <name> <description> to get a key, or drop --custodial to use the wallet-signed path."
         elif exc.code == "rate_limited":
             from clawmes.services.clawnch import get_clawnch_service as _svc
 
@@ -420,7 +594,8 @@ async def _confirm(sender_id: str) -> str:
             msg += (
                 f"\n\nBypass: send {bypass_info['fee_eth']} ETH to "
                 f"{bypass_info['recipient']} on Base, then "
-                f"/launch bypass <tx_hash> and /launch confirm."
+                f"/launch bypass <tx_hash> and /launch confirm --custodial.\n"
+                f"Or drop --custodial to use the non-custodial path (no cooldown)."
             )
         return msg
     except Exception as exc:  # noqa: BLE001
@@ -429,12 +604,143 @@ async def _confirm(sender_id: str) -> str:
     _clear_draft(sender_id)
     tx_hash = result.get("txHash") or result.get("tx_hash")
     token_address = result.get("tokenAddress") or result.get("token_address")
-    lines = ["Launched."]
+    lines = ["Launched (custodial)."]
     if token_address:
         lines.append(f"  Token: {token_address}")
     if tx_hash:
         lines.append(f"  Tx: {tx_hash}")
         lines.append(f"  Chart: https://dexscreener.com/base/{token_address or tx_hash}")
+    return "\n".join(lines)
+
+
+def _render_alerts(rest: str) -> str:
+    """``/launch alerts [source]`` — point users at the launch-alerts feed.
+
+    The Clawnch backend posts every successful deploy to the public
+    Telegram channel ``@ClawnchAlerts``. This command surfaces the
+    subscription link + documents how to filter the feed client-side
+    (Telegram's built-in keyword filters / muted words).
+
+    Optional ``source`` argument shows the exact keyword to filter on
+    so the user can mute everything except (e.g.) ``base-mcp`` deploys
+    in their own client.
+    """
+    valid_sources = {
+        "clawmes",
+        "moltbook",
+        "4claw",
+        "clawtomaton",
+        "moltx",
+        "base-mcp",
+        "clawncher",
+    }
+    arg = (rest or "").strip().lower()
+    if arg and arg not in valid_sources:
+        return (
+            f"Unknown source {arg!r}. Known sources: "
+            f"{', '.join(sorted(valid_sources))}. Drop the arg to see general subscribe info."
+        )
+
+    lines = [
+        "Launch alerts feed:",
+        "",
+        "  Channel:  https://t.me/ClawnchAlerts",
+        "  Web:      https://www.clawn.ch/api/launches (read-only JSON feed)",
+        "",
+        "Every successful Clawnch deploy lands in the channel within seconds. "
+        "Custodial deploys post from the server. Non-custodial (base-mcp) "
+        "deploys post via the on-chain indexer cron, with up to ~5min latency.",
+    ]
+    if arg:
+        lines.extend(
+            [
+                "",
+                f"Filtering for source = {arg!r}:",
+                f"  In Telegram, mute the channel and add {arg!r} to your client's keyword highlights. "
+                f"Each post tags the source as `via {arg.capitalize() if arg != 'base-mcp' else 'Base MCP'}`, so a substring "
+                f"match catches the lot.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "",
+                "To filter to a specific source (clawmes, moltbook, 4claw, base-mcp, etc.), "
+                "run /launch alerts <source> for client-side filter docs.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+async def _export(sender_id: str) -> str:
+    """``/launch export`` — emit unsigned Clanker calldata for external signing.
+
+    Useful when the user is on Base MCP, Claude Desktop, Cursor, or any
+    other agent surface that has its own wallet-signing UX. clawmes
+    prepares the calldata locally; the user copies the JSON and pastes
+    it into the other surface's ``send_calls`` flow.
+
+    Doesn't touch the user's clawmes wallet — purely a prepare-only
+    path. ``from`` is the active wallet's address if connected, else
+    a placeholder the user must replace.
+    """
+    draft = _get_draft(sender_id)
+    name = draft.get("name")
+    symbol = draft.get("symbol")
+    if not name or not symbol:
+        return (
+            "Export needs at minimum a name and a symbol. "
+            "Run /launch name <…> and /launch symbol <TICKER> first."
+        )
+
+    from clawmes.services.clawnch import ClawnchError, get_clawnch_service
+    from clawmes.services.wallet import get_wallet_state
+
+    state = get_wallet_state()
+    from_addr = state.address or "0x" + "0" * 40
+    socials = draft.get("socials") or {}
+
+    try:
+        prepared = get_clawnch_service().prepare_deploy(
+            from_address=from_addr,
+            name=name,
+            symbol=symbol,
+            description=draft.get("description") or None,
+            image=draft.get("image") or None,
+            twitter=socials.get("twitter"),
+            website=socials.get("website"),
+            telegram=socials.get("telegram"),
+            farcaster=socials.get("farcaster"),
+            discord=socials.get("discord"),
+            burn_tx_hash=draft.get("burn_tx_hash"),
+        )
+    except ClawnchError as exc:
+        return f"Export failed ({exc.code}): {exc.message}"
+    except Exception as exc:  # noqa: BLE001
+        return f"Export failed: {exc}"
+
+    import json
+
+    data = prepared.get("data") or {}
+    meta = prepared.get("meta") or {}
+    block = json.dumps({"chain": "base", "calls": [data]}, indent=2)
+    lines = [
+        "Unsigned calldata ready to paste into Base MCP / Claude Desktop / Cursor:",
+        "",
+        block,
+        "",
+        f"Platform fee preserved: {meta.get('platformFeeBps', 2000)} bps (20% to Clawnch).",
+        f"User fee share: {meta.get('userFeeBps', 8000)} bps.",
+        f"Vault: {meta.get('vaultPercentage', 0)}%.",
+        "",
+        "On the receiving surface, pass `calls` to `send_calls`. The user signs in their wallet — no clawmes action needed.",
+    ]
+    if not state.address:
+        lines.append("")
+        lines.append(
+            "⚠ No wallet connected — `from` is set to the zero address. "
+            "Edit the calldata's `from` before signing, or /connect first and re-run."
+        )
     return "\n".join(lines)
 
 

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.3.0
+version: 0.4.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/services/clawnch.py
+++ b/clawmes/services/clawnch.py
@@ -267,6 +267,103 @@ class ClawnchService(Service):
             token_params=token_params,
         )
 
+    # ── non-custodial deploy (GET /api/prepare/deploy) ──────────────
+
+    def prepare_deploy(
+        self,
+        *,
+        from_address: str,
+        name: str,
+        symbol: str,
+        description: str | None = None,
+        image: str | None = None,
+        twitter: str | None = None,
+        website: str | None = None,
+        telegram: str | None = None,
+        farcaster: str | None = None,
+        discord: str | None = None,
+        burn_tx_hash: str | None = None,
+    ) -> dict[str, Any]:
+        """Get unsigned Clanker factory calldata for a non-custodial deploy.
+
+        Hits ``GET /api/prepare/deploy``. Returns the envelope shape:
+
+            {
+                "ok": True,
+                "data": {"to": "0xE85A…", "data": "0xdf40224a…", "value": "0x0", "chainId": 8453},
+                "meta": {
+                    "platformFeeBps": 2000,
+                    "userFeeBps": 8000,
+                    "vaultPercentage": 0,
+                    "source": "base-mcp",
+                    ...
+                },
+            }
+
+        On any 4xx (``ok: false``) Clawnch error, raises ``ClawnchError``
+        with the upstream ``code`` mapped to one of the standard
+        clawmes error classifications.
+
+        Unlike :meth:`deploy`, this path is non-custodial:
+        - No API key required (``/api/prepare/deploy`` is public).
+        - No captcha solving — the wallet signs the deploy tx directly.
+        - The user's wallet pays gas.
+        - Same 20% platform fee preserved in the rewards array.
+
+        ``burn_tx_hash`` is verified server-side; if valid, the
+        corresponding vault clause gets baked into the returned
+        calldata.
+        """
+        if not from_address:
+            raise ClawnchError("bad_request", "from_address is required")
+        if not name:
+            raise ClawnchError("bad_request", "name is required")
+        if not symbol:
+            raise ClawnchError("bad_request", "symbol is required")
+
+        params: dict[str, str] = {
+            "from": from_address,
+            "name": name,
+            "symbol": symbol,
+        }
+        if description:
+            params["description"] = description
+        if image:
+            params["image"] = image
+        if twitter:
+            params["twitter"] = twitter
+        if website:
+            params["website"] = website
+        if telegram:
+            params["telegram"] = telegram
+        if farcaster:
+            params["farcaster"] = farcaster
+        if discord:
+            params["discord"] = discord
+        if burn_tx_hash:
+            params["burnTxHash"] = burn_tx_hash
+
+        # Public endpoint — no auth header sent.
+        body = self._get("/api/prepare/deploy", params=params)
+        if not isinstance(body, dict):
+            raise ClawnchError("api_error", "prepare_deploy returned non-dict body")
+        if body.get("ok") is False:
+            code = str(body.get("code") or "api_error")
+            msg = str(body.get("error") or "prepare_deploy failed")
+            # Map a couple of upstream codes to clawmes' classification.
+            if code == "rate_limited":
+                raise ClawnchError("rate_limited", msg)
+            if code in (
+                "invalid_from",
+                "invalid_name",
+                "invalid_symbol",
+                "missing_required",
+                "invalid_burn",
+            ):
+                raise ClawnchError("bad_request", msg)
+            raise ClawnchError("api_error", msg)
+        return body
+
     # ── reads ───────────────────────────────────────────────────────
 
     def get_my_launches(self) -> dict[str, Any]:
@@ -344,7 +441,12 @@ class ClawnchService(Service):
             self._reclassify(exc)
             raise
 
-    def _get(self, path: str) -> dict[str, Any]:
+    def _get(
+        self,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
         url = self._base_url + path
         headers: dict[str, str] = {}
         with self._lock:
@@ -352,7 +454,7 @@ class ClawnchService(Service):
         if key:
             headers["Authorization"] = f"Bearer {key}"
         try:
-            return http_get(url, headers=headers, timeout=15.0)
+            return http_get(url, params=params, headers=headers, timeout=15.0)
         except Exception as exc:  # noqa: BLE001
             self._reclassify(exc)
             raise

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.3.0
+version: 0.4.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.3.0"
+version = "0.4.0"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_burn.py
+++ b/tests/commands/test_burn.py
@@ -1,0 +1,216 @@
+"""Tests for the /burn slash command."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.commands import burn as burn_mod
+from clawmes.wallet.state import WalletState
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    burn_mod._burn_state.clear()
+    yield
+    burn_mod._burn_state.clear()
+
+
+@pytest.fixture
+def fake_wallet(monkeypatch):
+    state: dict = {"connected": False, "mode": None}
+
+    def _state():
+        if state["connected"]:
+            return WalletState.for_chain(mode="local", address="0x" + "1" * 40, chain_id=8453)
+        return WalletState.disconnected()
+
+    class _FakeMode:
+        def __init__(self):
+            self.calls: list[dict] = []
+            self.next_hash = "0xburntx"
+            self.raise_exc: Exception | None = None
+
+        def send_transaction(self, **kwargs):
+            self.calls.append(kwargs)
+            if self.raise_exc:
+                raise self.raise_exc
+            return self.next_hash
+
+    class _SvcStub:
+        def __init__(self, mode):
+            self._mode = mode
+
+        def active_mode(self):
+            return self._mode
+
+    state["mode"] = _FakeMode()
+    svc_stub = _SvcStub(state["mode"])
+
+    import clawmes.services.wallet as ws_mod
+
+    monkeypatch.setattr(ws_mod, "get_wallet_state", _state)
+    monkeypatch.setattr(ws_mod, "get_wallet_service", lambda: svc_stub)
+    return state
+
+
+@pytest.fixture
+def fake_clawnch_burn_config(monkeypatch):
+    class _Svc:
+        def get_burn_config(self):
+            return {
+                "token_address": "0x" + "c" * 40,
+                "burn_address": "0x" + "d" * 40,
+                "min_burn_tokens": 1_000_000,
+            }
+
+    import clawmes.services.clawnch as cl_mod
+
+    monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+    return _Svc
+
+
+# ── parsing ─────────────────────────────────────────────────────────
+
+
+class TestParseAmount:
+    def test_valid(self):
+        assert burn_mod._parse_amount("1000000") == 1_000_000
+
+    def test_with_underscore(self):
+        assert burn_mod._parse_amount("1_000_000") == 1_000_000
+
+    def test_with_comma(self):
+        assert burn_mod._parse_amount("1,000,000") == 1_000_000
+
+    def test_invalid(self):
+        out = burn_mod._parse_amount("notanumber")
+        assert isinstance(out, str)
+        assert "Invalid amount" in out
+
+    def test_too_low(self):
+        out = burn_mod._parse_amount("500000")
+        assert isinstance(out, str)
+        assert "too low" in out
+
+    def test_too_high(self):
+        out = burn_mod._parse_amount("11000000")
+        assert isinstance(out, str)
+        assert "above cap" in out
+
+
+# ── usage / last ────────────────────────────────────────────────────
+
+
+class TestUsage:
+    async def test_empty_shows_help(self):
+        out = await burn_mod.handle_burn("")
+        assert "Burn $CLAWNCH" in out
+        assert "1M CLAWNCH" in out
+
+    async def test_empty_with_prior_burn_shows_it(self):
+        burn_mod._remember_burn("alice", "0xprior", 1_000_000)
+        out = await burn_mod.handle_burn("", sender_id="alice")
+        assert "0xprior" in out
+        assert "1,000,000" in out
+
+    async def test_last_no_prior(self):
+        out = await burn_mod.handle_burn("last", sender_id="alice")
+        assert "No burn recorded" in out
+
+    async def test_last_with_prior(self):
+        burn_mod._remember_burn("alice", "0xprior", 2_000_000)
+        out = await burn_mod.handle_burn("last", sender_id="alice")
+        assert "0xprior" in out
+        assert "2,000,000" in out
+        assert "basescan.org/tx/0xprior" in out
+
+    async def test_default_sender(self):
+        out = await burn_mod.handle_burn("")
+        assert isinstance(out, str)
+
+
+# ── submit path ─────────────────────────────────────────────────────
+
+
+class TestSubmit:
+    async def test_no_wallet(self, fake_wallet, fake_clawnch_burn_config):
+        fake_wallet["connected"] = False
+        out = await burn_mod.handle_burn("1000000", sender_id="alice")
+        assert "No wallet connected" in out
+
+    async def test_no_active_mode(self, monkeypatch, fake_clawnch_burn_config):
+        from clawmes.wallet.state import WalletState
+
+        def _state():
+            return WalletState.for_chain(mode="local", address="0x" + "1" * 40, chain_id=8453)
+
+        class _Svc:
+            def active_mode(self):
+                return None
+
+        import clawmes.services.wallet as ws_mod
+
+        monkeypatch.setattr(ws_mod, "get_wallet_state", _state)
+        monkeypatch.setattr(ws_mod, "get_wallet_service", lambda: _Svc())
+        out = await burn_mod.handle_burn("1000000", sender_id="alice")
+        assert "No active wallet mode" in out
+
+    async def test_submission_failure(self, fake_wallet, fake_clawnch_burn_config):
+        fake_wallet["connected"] = True
+        fake_wallet["mode"].raise_exc = RuntimeError("rpc down")
+        out = await burn_mod.handle_burn("1000000", sender_id="alice")
+        assert "Burn tx submission failed" in out
+        assert "rpc down" in out
+
+    async def test_success(self, fake_wallet, fake_clawnch_burn_config):
+        fake_wallet["connected"] = True
+        out = await burn_mod.handle_burn("1000000", sender_id="alice")
+        assert "Burn submitted" in out
+        assert "0xburntx" in out
+        # State persists for /burn last
+        last = burn_mod._recall_burn("alice")
+        assert last == {"tx_hash": "0xburntx", "amount": 1_000_000}
+        # send_transaction shape
+        call = fake_wallet["mode"].calls[0]
+        assert call["to"] == "0x" + "c" * 40
+        assert call["value"] == 0
+        assert call["chain_id"] == 8453
+
+    async def test_invalid_amount(self, fake_clawnch_burn_config):
+        out = await burn_mod.handle_burn("notanumber", sender_id="alice")
+        assert "Invalid amount" in out
+
+    async def test_too_low(self, fake_clawnch_burn_config):
+        out = await burn_mod.handle_burn("500000", sender_id="alice")
+        assert "too low" in out
+
+    async def test_too_high(self, fake_clawnch_burn_config):
+        out = await burn_mod.handle_burn("11000000", sender_id="alice")
+        assert "above cap" in out
+
+
+# ── command_history best-effort ────────────────────────────────────
+
+
+class TestRecordingBestEffort:
+    async def test_recording_failure(self, monkeypatch):
+        from clawmes.services import command_history as ch_mod
+
+        def _boom(*a, **kw):
+            raise RuntimeError("history broken")
+
+        monkeypatch.setattr(ch_mod, "record_command_call", _boom)
+        out = await burn_mod.handle_burn("")
+        assert isinstance(out, str)
+
+
+class TestRegister:
+    def test_registers(self):
+        captured = []
+
+        class FakeCtx:
+            def register_command(self, **kw):
+                captured.append(kw["name"])
+
+        burn_mod.register(FakeCtx())
+        assert captured == ["burn"]

--- a/tests/commands/test_buy.py
+++ b/tests/commands/test_buy.py
@@ -19,6 +19,23 @@ def _isolate():
     buy_mod._draft_state.clear()
 
 
+@pytest.fixture(autouse=True)
+def _stub_clawnch_attribution(monkeypatch):
+    """Default the Clawnch attribution lookup to a no-result stub so
+    /buy quote tests don't make real network calls. Tests that need
+    a specific attribution explicitly override the patch (see
+    ``TestClawnchAttribution``)."""
+
+    class _NoResultSvc:
+        def get_launch(self, addr):  # noqa: ARG002
+            return {"error": "not found"}
+
+    import clawmes.services.clawnch as cl_mod
+
+    monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _NoResultSvc())
+    yield
+
+
 @pytest.fixture
 def fake_wallet(monkeypatch):
     state: dict = {"connected": False, "address": "0x" + "a" * 40}
@@ -430,6 +447,139 @@ class TestRecordingBestEffort:
         monkeypatch.setattr(ch_mod, "record_command_call", _boom)
         out = await buy_mod.handle_buy("")
         assert isinstance(out, str)
+
+
+class TestClawnchAttribution:
+    """`_lookup_clawnch_attribution` adds context to /buy quotes when
+    the buy token is in the Clawnch launch index."""
+
+    def test_not_a_dict_returns_none(self, monkeypatch):
+        class _Svc:
+            def get_launch(self, addr):  # noqa: ARG002
+                return "not a dict"
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        assert buy_mod._lookup_clawnch_attribution("0x" + "1" * 40) is None
+
+    def test_error_field_returns_none(self, monkeypatch):
+        class _Svc:
+            def get_launch(self, addr):  # noqa: ARG002
+                return {"error": "not found"}
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        assert buy_mod._lookup_clawnch_attribution("0x" + "1" * 40) is None
+
+    def test_success_false_returns_none(self, monkeypatch):
+        class _Svc:
+            def get_launch(self, addr):  # noqa: ARG002
+                return {"success": False, "launch": None}
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        assert buy_mod._lookup_clawnch_attribution("0x" + "1" * 40) is None
+
+    def test_non_dict_launch_returns_none(self, monkeypatch):
+        class _Svc:
+            def get_launch(self, addr):  # noqa: ARG002
+                return {"success": True, "launch": "garbage"}
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        assert buy_mod._lookup_clawnch_attribution("0x" + "1" * 40) is None
+
+    def test_full_attribution(self, monkeypatch):
+        class _Svc:
+            def get_launch(self, addr):  # noqa: ARG002
+                return {
+                    "success": True,
+                    "launch": {
+                        "source": "base-mcp",
+                        "agentName": "MyAgent",
+                        "launchedAt": "2026-05-26T10:00:00.000Z",
+                    },
+                }
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        attr = buy_mod._lookup_clawnch_attribution("0x" + "1" * 40)
+        assert attr is not None
+        assert "base-mcp" in attr
+        assert "MyAgent" in attr
+        assert "2026-05-26" in attr
+
+    def test_no_launch_key_falls_back_to_top_level(self, monkeypatch):
+        # Some upstream branches return the launch directly (no wrapping)
+        class _Svc:
+            def get_launch(self, addr):  # noqa: ARG002
+                return {
+                    "source": "clawmes",
+                    "agent": "AgentX",
+                }
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        attr = buy_mod._lookup_clawnch_attribution("0x" + "1" * 40)
+        assert attr is not None
+        assert "clawmes" in attr
+        assert "AgentX" in attr
+
+    def test_clawnch_error_returns_none(self, monkeypatch):
+        from clawmes.services.clawnch import ClawnchError
+
+        class _Svc:
+            def get_launch(self, addr):  # noqa: ARG002
+                raise ClawnchError("not_found", "no row")
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        assert buy_mod._lookup_clawnch_attribution("0x" + "1" * 40) is None
+
+    def test_unexpected_error_returns_none(self, monkeypatch):
+        class _Svc:
+            def get_launch(self, addr):  # noqa: ARG002
+                raise RuntimeError("upstream down")
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        assert buy_mod._lookup_clawnch_attribution("0x" + "1" * 40) is None
+
+    async def test_attribution_renders_in_quote(
+        self, fake_wallet, fake_find_token, fake_defi_swap, monkeypatch
+    ):
+        # Full smoke: a Clawnch-attributed token shows up in the quote
+        fake_wallet["connected"] = True
+        fake_find_token["result"] = {"baseToken": {"symbol": "MNEME", "address": "0x" + "1" * 40}}
+        fake_defi_swap["responses"]["quote"] = json.dumps(
+            {"isError": False, "details": {"buy_amount": "1000"}}
+        )
+
+        class _Svc:
+            def get_launch(self, addr):  # noqa: ARG002
+                return {
+                    "success": True,
+                    "launch": {
+                        "source": "clawmes",
+                        "agentName": "Agent42",
+                        "launchedAt": "2026-05-22T18:36:27.000Z",
+                    },
+                }
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        out = await buy_mod.handle_buy("MNEME 0.01")
+        assert "Clawnch: source clawmes" in out
+        assert "agent Agent42" in out
 
 
 class TestRegister:

--- a/tests/commands/test_launch.py
+++ b/tests/commands/test_launch.py
@@ -487,6 +487,419 @@ class TestRegister:
         assert captured == ["launch"]
 
 
+# ── non-custodial / mode resolution ────────────────────────────────
+
+
+class TestResolveConfirmMode:
+    def test_default_with_wallet_is_noncustodial(self):
+        assert launch_mod._resolve_confirm_mode("", wallet_connected=True) == "noncustodial"
+
+    def test_default_without_wallet_is_custodial(self):
+        assert launch_mod._resolve_confirm_mode("", wallet_connected=False) == "custodial"
+
+    def test_custodial_flag_forces(self):
+        assert launch_mod._resolve_confirm_mode("--custodial", wallet_connected=True) == "custodial"
+
+    def test_noncustodial_flag_forces_even_without_wallet(self):
+        assert (
+            launch_mod._resolve_confirm_mode("--noncustodial", wallet_connected=False)
+            == "noncustodial"
+        )
+
+    def test_custodial_wins_when_both_present(self):
+        # First flag in the parse wins; --custodial appears first
+        result = launch_mod._resolve_confirm_mode(
+            "--custodial --noncustodial", wallet_connected=True
+        )
+        assert result == "custodial"
+
+
+class TestNonCustodialConfirm:
+    """Wallet-connected path through ``/launch confirm`` (default mode)."""
+
+    @pytest.fixture
+    def fake_wallet_state(self, monkeypatch):
+        from clawmes.services import wallet as ws_mod
+        from clawmes.wallet.state import WalletState
+
+        state: dict = {"connected": True, "address": "0x" + "1" * 40}
+
+        def _state():
+            if state["connected"]:
+                return WalletState.for_chain(mode="local", address=state["address"], chain_id=8453)
+            return WalletState.disconnected()
+
+        monkeypatch.setattr(ws_mod, "get_wallet_state", _state)
+        return state
+
+    @pytest.fixture
+    def fake_prepare(self, monkeypatch):
+        state: dict = {
+            "return": {
+                "ok": True,
+                "data": {
+                    "to": "0xE85A59c628F7d27878ACeB4bf3b35733630083a9",
+                    "data": "0xdf40224a" + "00" * 32,
+                    "value": "0x0",
+                    "chainId": 8453,
+                },
+                "meta": {
+                    "platformFeeBps": 2000,
+                    "vaultPercentage": 0,
+                    "source": "base-mcp",
+                },
+            },
+            "raise": None,
+            "calls": [],
+        }
+
+        class _Svc:
+            def prepare_deploy(self_inner, **kwargs):  # noqa: ARG002, N805
+                state["calls"].append(kwargs)
+                if state["raise"]:
+                    raise state["raise"]
+                return state["return"]
+
+            def get_bypass_recipient(self_inner):  # noqa: ARG002, N805
+                return {"recipient": "0xbypass", "fee_eth": "0.005"}
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        return state
+
+    @pytest.fixture
+    def fake_wallet_mode(self, monkeypatch):
+        state: dict = {"tx_hash": "0xdeploytx", "raise": None, "calls": []}
+
+        class _FakeMode:
+            def send_transaction(self_inner, **kwargs):  # noqa: ARG002, N805
+                state["calls"].append(kwargs)
+                if state["raise"]:
+                    raise state["raise"]
+                return state["tx_hash"]
+
+        class _Svc:
+            def active_mode(self_inner):  # noqa: ARG002, N805
+                return _FakeMode() if not state.get("none_mode") else None
+
+        import clawmes.services.wallet as ws_mod
+
+        monkeypatch.setattr(ws_mod, "get_wallet_service", lambda: _Svc())
+        return state
+
+    @pytest.fixture
+    def fake_receipt(self, monkeypatch):
+        # Receipt returns logs with the token address in topics[1] so we can
+        # surface "Token: 0x..." in the success message.
+        state: dict = {"raise": None, "receipt": None}
+
+        class _Rpc:
+            def wait_for_receipt(self_inner, tx_hash, chain_id, *, timeout=120.0):  # noqa: ARG002, N805
+                if state["raise"]:
+                    raise state["raise"]
+                if state["receipt"] is not None:
+                    return state["receipt"]
+                return {
+                    "logs": [
+                        {
+                            "topics": [
+                                "0xeventsig",
+                                "0x" + "0" * 24 + "deadbeef" * 5,
+                            ]
+                        }
+                    ]
+                }
+
+        import clawmes.services.rpc as rpc_mod
+
+        monkeypatch.setattr(rpc_mod, "get_rpc_service", lambda: _Rpc())
+        return state
+
+    async def test_no_wallet_returns_hint(self, fake_wallet_state, fake_svc):
+        fake_wallet_state["connected"] = False
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm --noncustodial", sender_id="alice")
+        assert "needs a connected wallet" in out
+
+    async def test_happy_path_returns_tx_hash(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode, fake_receipt
+    ):
+        await launch_mod.handle_launch("name MyCoin", sender_id="alice")
+        await launch_mod.handle_launch("symbol MC", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "Launched (non-custodial)" in out
+        assert "0xdeploytx" in out
+        assert "basescan.org/tx/0xdeploytx" in out
+        # Token address surfaced from receipt
+        assert "deadbeef" in out
+        # Draft cleared
+        assert "alice" not in launch_mod._log_state
+
+    async def test_prepare_rate_limited(self, fake_wallet_state, fake_prepare, fake_wallet_mode):
+        fake_prepare["raise"] = ClawnchError("rate_limited", "10/day cap")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "Prepare failed (rate_limited)" in out
+        assert "00:00 UTC" in out
+
+    async def test_prepare_bad_request(self, fake_wallet_state, fake_prepare, fake_wallet_mode):
+        fake_prepare["raise"] = ClawnchError("bad_request", "bad name")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "Prepare failed (bad_request)" in out
+        assert "/launch status" in out
+
+    async def test_prepare_other_clawnch_error(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode
+    ):
+        fake_prepare["raise"] = ClawnchError("api_error", "upstream down")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "Prepare failed (api_error)" in out
+
+    async def test_prepare_unexpected_error(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode
+    ):
+        fake_prepare["raise"] = RuntimeError("network")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "Prepare failed" in out
+
+    async def test_prepare_returns_bad_shape(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode
+    ):
+        fake_prepare["return"] = {"ok": True}  # Missing data
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "unexpected shape" in out
+
+    async def test_no_active_wallet_mode(self, fake_wallet_state, fake_prepare, fake_wallet_mode):
+        fake_wallet_mode["none_mode"] = True
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "No active wallet mode" in out
+
+    async def test_send_transaction_fails(self, fake_wallet_state, fake_prepare, fake_wallet_mode):
+        fake_wallet_mode["raise"] = RuntimeError("user rejected")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "Deploy submission failed" in out
+
+    async def test_receipt_failure_falls_back_gracefully(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode, fake_receipt
+    ):
+        fake_receipt["raise"] = RuntimeError("rpc timeout")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        # Still surfaces the tx hash, just no token address
+        assert "0xdeploytx" in out
+        assert "Token:" not in out
+
+    async def test_receipt_no_logs_no_token(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode, fake_receipt
+    ):
+        fake_receipt["receipt"] = {"logs": []}
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "Token:" not in out
+
+    async def test_receipt_short_topic_skipped(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode, fake_receipt
+    ):
+        # topic too short to slice an address from
+        fake_receipt["receipt"] = {"logs": [{"topics": ["0xshort", "0xabc"]}]}
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "Token:" not in out
+
+    async def test_vault_pct_surfaced(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode, fake_receipt
+    ):
+        fake_prepare["return"]["meta"]["vaultPercentage"] = 5
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "Vault: 5%" in out
+
+    async def test_socials_pass_through_to_prepare(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode, fake_receipt
+    ):
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        await launch_mod.handle_launch("twitter clawnch", sender_id="alice")
+        await launch_mod.handle_launch("website clawn.ch", sender_id="alice")
+        await launch_mod.handle_launch("confirm", sender_id="alice")
+        call = fake_prepare["calls"][0]
+        assert call["twitter"] == "https://x.com/clawnch"
+        assert call["website"] == "https://clawn.ch"
+
+    async def test_custodial_flag_routes_to_custodial(self, fake_wallet_state, fake_svc):
+        # Even with wallet connected, --custodial uses the legacy path
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm --custodial", sender_id="alice")
+        assert "Launched (custodial)" in out
+        assert len(fake_svc.deploys) == 1
+
+
+class TestCustodialErrorHints:
+    async def test_no_credentials_hint_mentions_dropping_custodial(self, fake_svc):
+        fake_svc.deploy_raise = ClawnchError("no_credentials", "no key")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm --custodial", sender_id="alice")
+        assert "/register_agent" in out
+        assert "drop --custodial" in out
+
+    async def test_rate_limited_hint_mentions_noncustodial_option(self, fake_svc):
+        fake_svc.deploy_raise = ClawnchError("rate_limited", "wait 24h")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm --custodial", sender_id="alice")
+        assert "non-custodial path" in out
+
+
+# ── /launch export ─────────────────────────────────────────────────
+
+
+class TestExport:
+    @pytest.fixture
+    def fake_wallet_optional(self, monkeypatch):
+        from clawmes.services import wallet as ws_mod
+        from clawmes.wallet.state import WalletState
+
+        state: dict = {"connected": False, "address": "0x" + "1" * 40}
+
+        def _state():
+            if state["connected"]:
+                return WalletState.for_chain(mode="local", address=state["address"], chain_id=8453)
+            return WalletState.disconnected()
+
+        monkeypatch.setattr(ws_mod, "get_wallet_state", _state)
+        return state
+
+    @pytest.fixture
+    def fake_prepare_for_export(self, monkeypatch):
+        state: dict = {"raise": None, "return": None}
+
+        class _Svc:
+            def prepare_deploy(self_inner, **kwargs):  # noqa: ARG002, N805
+                if state["raise"]:
+                    raise state["raise"]
+                return state["return"] or {
+                    "ok": True,
+                    "data": {
+                        "to": "0xE85A",
+                        "data": "0xdf40",
+                        "value": "0x0",
+                        "chainId": 8453,
+                    },
+                    "meta": {
+                        "platformFeeBps": 2000,
+                        "userFeeBps": 8000,
+                        "vaultPercentage": 0,
+                    },
+                }
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        return state
+
+    async def test_no_draft(self):
+        out = await launch_mod.handle_launch("export", sender_id="alice")
+        assert "Export needs at minimum a name and a symbol" in out
+
+    async def test_no_wallet_warns(self, fake_wallet_optional, fake_prepare_for_export):
+        fake_wallet_optional["connected"] = False
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("export", sender_id="alice")
+        assert "No wallet connected" in out
+        assert "Unsigned calldata" in out
+
+    async def test_happy_path(self, fake_wallet_optional, fake_prepare_for_export):
+        fake_wallet_optional["connected"] = True
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("export", sender_id="alice")
+        assert "Unsigned calldata" in out
+        assert "send_calls" in out
+        assert "0xE85A" in out
+
+    async def test_prepare_error(self, fake_wallet_optional, fake_prepare_for_export):
+        fake_wallet_optional["connected"] = True
+        fake_prepare_for_export["raise"] = ClawnchError("api_error", "down")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("export", sender_id="alice")
+        assert "Export failed" in out
+        assert "api_error" in out
+
+    async def test_prepare_unexpected_error(self, fake_wallet_optional, fake_prepare_for_export):
+        fake_wallet_optional["connected"] = True
+        fake_prepare_for_export["raise"] = RuntimeError("boom")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("export", sender_id="alice")
+        assert "Export failed" in out
+
+
+# ── /launch alerts ─────────────────────────────────────────────────
+
+
+class TestAlerts:
+    async def test_no_arg(self):
+        out = await launch_mod.handle_launch("alerts", sender_id="alice")
+        assert "https://t.me/ClawnchAlerts" in out
+        assert "/launch alerts <source>" in out
+
+    async def test_known_source(self):
+        out = await launch_mod.handle_launch("alerts base-mcp", sender_id="alice")
+        assert "base-mcp" in out
+        assert "Base MCP" in out
+
+    async def test_known_source_capitalized_for_clawmes(self):
+        out = await launch_mod.handle_launch("alerts clawmes", sender_id="alice")
+        assert "Clawmes" in out
+
+    async def test_unknown_source(self):
+        out = await launch_mod.handle_launch("alerts garbage", sender_id="alice")
+        assert "Unknown source" in out
+
+
+class TestBuildTokenParamsHelper:
+    """The extracted ``_build_token_params`` keeps custodial/non-custodial
+    socials in sync. Direct unit tests guard against drift."""
+
+    def test_minimal(self):
+        params = launch_mod._build_token_params({}, name="X", symbol="X")
+        assert params == {"name": "X", "symbol": "X"}
+
+    def test_full(self):
+        draft = {
+            "description": "d",
+            "image": "https://i",
+            "socials": {"twitter": "https://x.com/x", "website": "https://x"},
+        }
+        params = launch_mod._build_token_params(draft, name="N", symbol="S")
+        assert params["description"] == "d"
+        assert params["image"] == "https://i"
+        assert params["metadata"]["socialMediaUrls"][0]["platform"] == "twitter"
+
+
 class TestCommandHistoryBestEffort:
     async def test_recording_failure_does_not_break_command(self, monkeypatch):
         from clawmes.services import command_history as ch_mod

--- a/tests/services/test_clawnch.py
+++ b/tests/services/test_clawnch.py
@@ -522,6 +522,156 @@ class TestDeployConvenience:
 # ──────────────────────────────────────────────────────────────────────
 
 
+class TestPrepareDeploy:
+    """``prepare_deploy`` — non-custodial calldata flow."""
+
+    def _ok_payload(self):
+        return {
+            "ok": True,
+            "data": {
+                "to": "0xE85A59c628F7d27878ACeB4bf3b35733630083a9",
+                "data": "0xdf40224a" + "00" * 32,
+                "value": "0x0",
+                "chainId": 8453,
+            },
+            "meta": {
+                "platformFeeBps": 2000,
+                "userFeeBps": 8000,
+                "vaultPercentage": 0,
+                "source": "base-mcp",
+            },
+        }
+
+    def test_requires_from(self, svc):
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="", name="X", symbol="X")
+        assert exc_info.value.code == "bad_request"
+
+    def test_requires_name(self, svc):
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="0x" + "1" * 40, name="", symbol="X")
+        assert exc_info.value.code == "bad_request"
+
+    def test_requires_symbol(self, svc):
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="")
+        assert exc_info.value.code == "bad_request"
+
+    def test_returns_envelope_on_ok(self, svc, monkeypatch):
+        captured: list[dict] = []
+        payload = self._ok_payload()
+
+        def _get(url, params=None, headers=None, timeout=None):
+            captured.append({"url": url, "params": params})
+            return payload
+
+        monkeypatch.setattr("clawmes.services.clawnch.http_get", _get)
+        out = svc.prepare_deploy(
+            from_address="0x" + "1" * 40,
+            name="MyCoin",
+            symbol="MYC",
+            description="hello",
+            image="https://example.com/x.png",
+            twitter="https://x.com/clawnch",
+            website="clawn.ch",
+            telegram="https://t.me/clawnch",
+            farcaster="https://warpcast.com/clawnch",
+            discord="https://discord.gg/clawnch",
+            burn_tx_hash="0x" + "a" * 64,
+        )
+        assert out == payload
+        # All optional params propagated to the query string
+        sent = captured[0]["params"]
+        assert sent["from"] == "0x" + "1" * 40
+        assert sent["name"] == "MyCoin"
+        assert sent["symbol"] == "MYC"
+        assert sent["description"] == "hello"
+        assert sent["image"] == "https://example.com/x.png"
+        assert sent["twitter"] == "https://x.com/clawnch"
+        assert sent["website"] == "clawn.ch"
+        assert sent["telegram"] == "https://t.me/clawnch"
+        assert sent["farcaster"] == "https://warpcast.com/clawnch"
+        assert sent["discord"] == "https://discord.gg/clawnch"
+        assert sent["burnTxHash"] == "0x" + "a" * 64
+
+    def test_minimal_params_omit_optionals(self, svc, monkeypatch):
+        captured: list[dict] = []
+
+        def _get(url, params=None, headers=None, timeout=None):
+            captured.append({"params": params})
+            return self._ok_payload()
+
+        monkeypatch.setattr("clawmes.services.clawnch.http_get", _get)
+        svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="X")
+        sent = captured[0]["params"]
+        assert "description" not in sent
+        assert "image" not in sent
+        assert "twitter" not in sent
+        assert "burnTxHash" not in sent
+
+    def test_non_dict_body_raises(self, svc, monkeypatch):
+        monkeypatch.setattr(
+            "clawmes.services.clawnch.http_get",
+            lambda *a, **k: ["not", "a", "dict"],
+        )
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="X")
+        assert exc_info.value.code == "api_error"
+
+    def test_ok_false_rate_limited(self, svc, monkeypatch):
+        monkeypatch.setattr(
+            "clawmes.services.clawnch.http_get",
+            lambda *a, **k: {
+                "ok": False,
+                "error": "Wallet has hit the 10 prepare/day cap.",
+                "code": "rate_limited",
+            },
+        )
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="X")
+        assert exc_info.value.code == "rate_limited"
+
+    @pytest.mark.parametrize(
+        "code",
+        ["invalid_from", "invalid_name", "invalid_symbol", "missing_required", "invalid_burn"],
+    )
+    def test_ok_false_bad_request_codes(self, svc, monkeypatch, code):
+        monkeypatch.setattr(
+            "clawmes.services.clawnch.http_get",
+            lambda *a, **k: {"ok": False, "error": "boom", "code": code},
+        )
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="X")
+        assert exc_info.value.code == "bad_request"
+
+    def test_ok_false_unknown_code_maps_to_api_error(self, svc, monkeypatch):
+        monkeypatch.setattr(
+            "clawmes.services.clawnch.http_get",
+            lambda *a, **k: {"ok": False, "error": "something", "code": "weird_code"},
+        )
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="X")
+        assert exc_info.value.code == "api_error"
+
+    def test_ok_false_no_code_field(self, svc, monkeypatch):
+        monkeypatch.setattr(
+            "clawmes.services.clawnch.http_get",
+            lambda *a, **k: {"ok": False, "error": "no code"},
+        )
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="X")
+        assert exc_info.value.code == "api_error"
+
+    def test_ok_false_no_error_field(self, svc, monkeypatch):
+        monkeypatch.setattr(
+            "clawmes.services.clawnch.http_get",
+            lambda *a, **k: {"ok": False, "code": "weird_code"},
+        )
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="X")
+        assert "prepare_deploy failed" in exc_info.value.message
+
+
 class TestReads:
     def test_get_my_launches_requires_key(self, svc):
         svc.start()
@@ -530,7 +680,7 @@ class TestReads:
         assert exc_info.value.code == "no_credentials"
 
     def test_get_my_launches_calls_api(self, svc_with_key, monkeypatch):
-        def _get(url, headers, timeout):
+        def _get(url, params=None, headers=None, timeout=None):
             return {"launches": []}
 
         monkeypatch.setattr("clawmes.services.clawnch.http_get", _get)
@@ -545,7 +695,7 @@ class TestReads:
     def test_get_launch_calls_api(self, svc, monkeypatch):
         captured: list[str] = []
 
-        def _get(url, headers, timeout):
+        def _get(url, params=None, headers=None, timeout=None):
             captured.append(url)
             return {"token": "0xabc"}
 
@@ -558,7 +708,7 @@ class TestReads:
     def test_get_launch_unauthed_works_without_key(self, svc, monkeypatch):
         captured: list[dict] = []
 
-        def _get(url, headers, timeout):
+        def _get(url, params=None, headers=None, timeout=None):
             captured.append(headers)
             return {"token": "0xabc"}
 
@@ -714,7 +864,7 @@ class TestErrorReclassify:
     def test_get_reclassifies_too(self, svc_with_key, monkeypatch):
         exc = _HTTPErr(_FakeResponse(404, {"error": "no agent"}))
 
-        def _get(url, headers, timeout):
+        def _get(url, params=None, headers=None, timeout=None):
             raise exc
 
         monkeypatch.setattr("clawmes.services.clawnch.http_get", _get)
@@ -726,7 +876,7 @@ class TestErrorReclassify:
         class _Bare(Exception):
             pass
 
-        def _get(url, headers, timeout):
+        def _get(url, params=None, headers=None, timeout=None):
             raise _Bare("transport down")
 
         monkeypatch.setattr("clawmes.services.clawnch.http_get", _get)


### PR DESCRIPTION
## Summary

Wires the Base MCP backend work (clawnch#2, clawnch#3, clawnch#4) deeply into the clawmes Hermes Agent plugin. Headline change: **`/launch` no longer requires a Clawnch API key** when a wallet is connected — the user's wallet signs and pays gas directly, with the 20% platform fee preserved in the prepared calldata.

## What's in this PR

### Non-custodial `/launch` (new default)

When a wallet is connected, `/launch confirm` now hits `https://www.clawn.ch/api/prepare/deploy` for unsigned Clanker factory calldata and submits via the active wallet mode. **No API key, no `/register_agent` step, no 24h cooldown, no captcha**.

```
/connect_local            # or /connect / /connect_bankr
/launch name MyCoin
/launch symbol MC
/launch confirm           # signs + submits via your wallet
```

Three flags control mode:
- `/launch confirm` → non-custodial default when wallet connected, custodial fallback otherwise
- `/launch confirm --custodial` → forced custodial (legacy path, requires `CLAWNCH_API_KEY`)
- `/launch confirm --noncustodial` → forced non-custodial (errors clearly if no wallet)

### `/launch export` mode

Emit the unsigned calldata as a `{chain, calls}` JSON block for paste into Base MCP / Claude Desktop / Cursor. No wallet operation on the clawmes side — purely a calldata-prep export.

### `/launch alerts [source]`

Subscribe link to the public `@ClawnchAlerts` Telegram channel + client-side filter docs per source.

### `/burn` (new top-level command)

Standalone $CLAWNCH burn, decoupled from `/launch`:

```
/burn 1000000       # signs + submits a 1M CLAWNCH burn = 1% vault
/burn last          # show the last burn tx hash from this session
```

Returns the burn tx hash you can pipe into `/launch burn <tx_hash>`, `/api/prepare/deploy?burnTxHash=...`, or any other surface that takes a burn receipt.

### `/buy` Clawnch attribution

`/buy <token> <eth>` quotes now show a Clawnch-attribution line when the buy token is in the launchpad index:

```
Quote: 0.01 ETH → 1000 MNEME
  Address: 0x...
  Universe: all
  Clawnch: source clawmes · agent Agent42 · launched 2026-05-22T18:36:27.000Z
```

Best-effort — failures (token not in index, upstream down) silently skip the line. Never blocks the swap.

### `ClawnchService.prepare_deploy()`

New service method wrapping `GET /api/prepare/deploy`. Public endpoint, no auth. Returns the envelope shape and maps upstream codes (`rate_limited`, `invalid_burn`, `invalid_from`, etc.) to standard `ClawnchError` classifications. Used by `/launch confirm` (non-custodial) and `/launch export`.

`ClawnchService._get()` gains an optional `params` kwarg for query-string requests.

## Tests

77 new tests across:
- `tests/services/test_clawnch.py` — `prepare_deploy` full error-code coverage
- `tests/commands/test_launch.py` — 19 new cases (non-custodial path, mode resolution, receipt parsing, export, alerts)
- `tests/commands/test_buy.py` — 8 attribution cases + an autouse no-network stub
- `tests/commands/test_burn.py` — 20 cases for the new command

Full suite 2936 passing at **100% coverage**. Ruff clean.

## Version bump

v0.3.0 → v0.4.0 across pyproject.toml, `_version.py`, and both `plugin.yaml` copies.

## Backwards compatibility

Existing custodial flow remains fully supported behind `/launch confirm --custodial`. The `CLAWNCH_API_KEY` env var is still honored. Users on v0.3.0 who relied on the custodial default get a one-line behavior change: passing `--custodial` to confirm now preserves the old path, otherwise the new non-custodial path runs.

## Companion PRs

- clawnch#2 (merged): shipped `/api/prepare/deploy` server-side
- clawnch#3 (merged): source attribution types + getPostUrl fall-through fixes
- clawnch#4 (merged): roadmap items — burn-vault verification, per-wallet rate limit, Telegram alerts via indexer
- base/skills#43 (pending Base review): Clawnch plugin spec with the same launch flow

This PR closes the loop between the chat-platform agent and the Base ecosystem integration server-side.