### PR TITLE
feat(base): deep Base integration — Base Account wallet, clawmes-mcp, builder code, basenames, onramp (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,100 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.5.0 — 2026-05-26
+
+### Added — deep Base ecosystem integration
+
+A second batch of Base-specific surfaces. Most are small additive
+features; the big ones are Base Account wallet mode and shipping
+clawmes itself as an MCP server for desktop AI clients.
+
+- **Base Account wallet mode (`/connect_base`)** — fourth wallet mode
+  alongside WalletConnect / local-key / Bankr. Uses Coinbase's OAuth
+  2.1 + stored-request flow (same as Base MCP) so every Base App user
+  can connect their existing Coinbase Smart Wallet to clawmes without
+  needing to import a mnemonic or set up WalletConnect. Tx + signature
+  requests trigger an approval prompt in the user's Base App. Configure
+  via `CLAWMES_BASE_ACCOUNT_CLIENT_ID` after registering an OAuth client
+  on Coinbase Developer Platform.
+
+- **`clawmes-mcp` — clawmes as an MCP server** — desktop AI clients
+  (Claude Desktop, Cursor, ChatGPT, any MCP-compatible client) can
+  install clawmes directly and use its tools without going through
+  Hermes. Read-only subset for v1: `defi_price`, `defi_balance`,
+  `market_intel`, `clawnch_launch` (info), `clawnch_fees`,
+  `bv7x_oracle`, `bv7x_market`, `nft`, `block_explorer`, `cost_basis`.
+  Install with `pip install clawmes[mcp]`, run with `clawmes-mcp`,
+  configure in Claude Desktop's `claude_desktop_config.json` under
+  `mcpServers`.
+
+- **Coinbase builder code on every Base transaction** — clawmes appends
+  Coinbase's `BASE_BUILDER_CODE` suffix to swap, deploy, and burn
+  calldata on Base mainnet so the plugin earns builder rewards on
+  every on-chain action it drives. The clawnch backend already does
+  this server-side; this commit closes the gap for client-side txs.
+
+- **Basenames (.base.eth) resolution** — `/buy`, `/transfer`, `/send`
+  and any other command that takes an address now resolves
+  `jesse.base.eth`-style names natively against the Base L2 ENS
+  registry. Non-`.base.eth` ENS names continue to resolve against
+  Ethereum mainnet's canonical registry.
+
+- **`/launch check`** — pre-flight validation. Calls `/api/prepare/deploy`
+  to validate every param (name, symbol, burn tx) without committing
+  and shows the user what they'd get on confirm — most useful when
+  a `burn_tx_hash` is in the draft so the vault % gets verified
+  before paying gas.
+
+- **Base App deep links** — `/launch confirm` success messages now
+  include a `Base App: https://base.app/?token=…` link that opens
+  the new token in the user's Base App alongside the existing
+  Basescan + DexScreener URLs. URL pattern overridable via env.
+
+- **`/onramp [usd_amount]`** — generate a Coinbase Onramp link
+  pre-filled with the connected wallet's address. Removes the
+  "need ETH first" friction for new users. Configure via
+  `CLAWMES_COINBASE_ONRAMP_APP_ID` (Coinbase Developer Platform
+  app id); falls back to the generic landing page without it.
+
+- **x402 payment-required helpers (`clawmes.lib.x402`)** — minimal
+  client-side detection of HTTP 402 challenges per the x402 spec
+  (https://www.x402.org). Provides `is_x402_response`,
+  `parse_challenge`, and `format_challenge`. Foundation for future
+  paid-endpoint integrations; not wired into tools yet.
+
+### Changed
+
+- **`/launch confirm` non-custodial deploy** now also appends the
+  Coinbase builder code suffix to the prepared Clanker calldata
+  before submitting via the wallet. Custodial path was already
+  handled server-side.
+- **`/burn` + `/launch burn`** ERC-20 transfers append the builder
+  code suffix on Base. CLAWNCH burn-to-vault txs earn builder
+  rewards too.
+- **`active_mode`** on `WalletService` is consistently used as a
+  property (no parens) across all callers. Three call sites
+  (`/launch`'s non-custodial confirm, `/launch burn`, `/burn`)
+  were incorrectly calling it as a method; now fixed.
+
+### Tests
+
+- 137 new tests covering the new lib helpers, services, wallet
+  mode, commands, and MCP server. Full suite 3073 passing at
+  100% coverage. Ruff clean.
+
+### Notes
+
+- The `mcp` Python package is an optional dependency (`pip install
+  clawmes[mcp]`); the core install is unchanged. Without the extra
+  installed, the `clawmes-mcp` script entry will fail at runtime with
+  an import error pointing at the install command.
+- Base Account, Coinbase Onramp, and Base App deep-link production
+  endpoints can be overridden via env vars (`CLAWMES_BASE_ACCOUNT_*`,
+  `CLAWMES_COINBASE_ONRAMP_*`, `CLAWMES_BASE_APP_*_URL`) — the
+  defaults are best-effort against publicly-documented URLs that may
+  shift as the Base App / Coinbase Developer Platform mature.
+
 ## 0.4.0 — 2026-05-26
 
 ### Added — Base ecosystem integration

--- a/README.md
+++ b/README.md
@@ -68,18 +68,18 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 
 ## Commands
 
-79 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
+81 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
 
 | Category | Commands |
 |---|---|
-| **Wallet** (8) | `/wallet` `/connect` `/connect_local` `/connect_bankr` `/disconnect` `/mode` `/chain` `/address` |
+| **Wallet** (9) | `/wallet` `/connect` `/connect_local` `/connect_bankr` `/connect_base` `/disconnect` `/mode` `/chain` `/address` |
 | **Wallet recovery** (4) | `/create_wallet` `/recover` `/export_wallet` `/wallet_backup` |
 | **Policy & safety** (5) | `/policy` `/policy_clear` `/safemode` `/dangermode` `/audit` |
 | **Transactions** (4) | `/tx` `/tx_search` `/tx_export` `/pending` |
 | **Plans & triggers** (10) | `/plans` `/plan` `/plan_logs` `/interrupt_plan` `/pause_plan` `/resume_plan` `/triggers` `/watch` `/unwatch` `/cron` |
 | **Onboarding** (19) | `/welcome`, 5 personas (`/professional` `/degen` `/chill` `/technical` `/mentor`), 10 capability toggles (`/cap_wallet` `/cap_prices` `/cap_portfolio` `/cap_trading` `/cap_liquidity` `/cap_launchpad` `/cap_bridge` `/cap_routing` `/cap_clawnx` `/cap_hummingbot`), `/skip` `/back` `/reonboard` |
 | **Balance & portfolio** (2) | `/balance` `/portfolio` |
-| **Trading & discovery** (4) | `/buy` `/trending` `/my_launches` `/burn` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault % |
+| **Trading & discovery** (5) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link |
 | **Self-evolution** (3) | `/evolve` `/stable` `/evolution` — gates `agent_memory` and `skill_evolve` write actions; OFF by default |
 | **Endpoint allowlist** (3) | `/allowlist` `/allow` `/disallow` — session-scoped host allowlist + 100-entry block audit ring |
 | **Discoverability** (5) | `/skills` `/persona` `/chains` `/tools_list` `/safety_status` |
@@ -250,6 +250,53 @@ After launching (or any time): three commands cover the basic loop of finding to
 ```
 
 `/buy` uses the existing `defi_swap` tool under the hood — 0x aggregator with Permit2 (single signature, no separate `approve` tx). The quote step always renders the resolved address before signing, so you can verify you're buying the right token. `--all` resolution returns the highest-volume Base pair for the symbol; `--clawnch` additionally verifies the address against the Clawnch launches table.
+
+## Base ecosystem integration
+
+clawmes is built around the Base network. v0.5.0 deepens that integration across four surfaces:
+
+### Coinbase Smart Wallet via `/connect_base`
+
+Connect your existing Base Account (the wallet you use in Base App) to clawmes via OAuth — same flow Base MCP uses:
+
+```
+/connect_base                       # emits an OAuth URL
+# visit the URL, approve in Coinbase, copy the `code` query param from the redirect
+/connect_base <code>                # finalizes the connection
+```
+
+Every tx + signature thereafter triggers an approval in your Base App, same UX as WalletConnect. No mnemonic to manage. Configure via `CLAWMES_BASE_ACCOUNT_CLIENT_ID` after registering an OAuth client on [Coinbase Developer Platform](https://portal.cdp.coinbase.com).
+
+### `clawmes-mcp` — use clawmes from desktop AI
+
+clawmes ships as a Model Context Protocol server in addition to the Hermes Agent plugin, so Claude Desktop / Cursor / ChatGPT / any MCP-compatible client can use its read tools directly:
+
+```
+pip install clawmes[mcp]
+clawmes-mcp                         # runs the stdio MCP server
+```
+
+Configure Claude Desktop's `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{ "mcpServers": { "clawmes": { "command": "clawmes-mcp" } } }
+```
+
+Read tools exposed in v0.5.0: `defi_price`, `defi_balance`, `market_intel`, `clawnch_launch` (info), `clawnch_fees`, `bv7x_oracle`, `bv7x_market`, `nft`, `block_explorer`, `cost_basis`. Write tools (swap / deploy / transfer) require a connected wallet that doesn't transfer cleanly into the MCP context — those land in a follow-up that delegates signing to Base MCP via `send_calls`.
+
+### Builder rewards on every clawmes swap + deploy
+
+Every clawmes-initiated transaction on Base mainnet automatically appends Coinbase's `BASE_BUILDER_CODE` suffix to the calldata, attributing the on-chain activity to Clawnch's builder ID. The EVM ignores trailing calldata beyond the ABI-decoded args, so it's a harmless ~28-byte suffix that earns builder rewards proportional to the volume the plugin drives.
+
+### Coinbase Onramp + Basenames + Base App deep links
+
+```
+/onramp 50                          # Coinbase Onramp link, $50 of ETH to your wallet
+/buy jesse.base.eth 0.01            # Basenames resolve natively against Base L2 ENS
+/launch confirm                     # success output includes a Base App deep link
+```
+
+`CLAWMES_COINBASE_ONRAMP_APP_ID` for production Onramp config; without it the command emits a generic Coinbase landing URL. Basename resolution is automatic — no flag needed. Base App URL pattern is overridable via `CLAWMES_BASE_APP_TOKEN_URL` if Coinbase's URL scheme shifts.
 
 ## Security
 

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -27,6 +27,7 @@ from clawmes.commands import (
     launch,
     my_launches,
     onboarding,
+    onramp,
     plans,
     policy,
     trending,
@@ -67,6 +68,7 @@ def register_all(ctx) -> None:
     trending.register(ctx)
     my_launches.register(ctx)
     burn.register(ctx)
+    onramp.register(ctx)
     # TODO(v0.1.0+): model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
     # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/burn.py
+++ b/clawmes/commands/burn.py
@@ -150,7 +150,7 @@ async def _submit(sender_id: str, whole_tokens: int) -> str:
     state = get_wallet_state()
     if not state.connected:
         return "No wallet connected. Run /connect or /connect_local first."
-    mode = get_wallet_service().active_mode()
+    mode = get_wallet_service().active_mode
     if mode is None:
         return "No active wallet mode. Run /connect."
 
@@ -159,6 +159,11 @@ async def _submit(sender_id: str, whole_tokens: int) -> str:
     burn_addr = cfg["burn_address"]
     amount_wei = whole_tokens * (10**18)
     calldata = encode_transfer(burn_addr, amount_wei)
+
+    # Append Coinbase builder code suffix on Base mainnet.
+    from clawmes.lib.base_builder import append_builder_code
+
+    calldata = append_builder_code(calldata, 8453)
 
     try:
         tx_hash = mode.send_transaction(

--- a/clawmes/commands/launch.py
+++ b/clawmes/commands/launch.py
@@ -207,6 +207,8 @@ async def handle_launch(raw_args: str, **kwargs: Any) -> str:
         out = await _export(sender_id)
     elif action == "alerts":
         out = _render_alerts(rest)
+    elif action == "check":
+        out = await _check(sender_id)
     else:
         out = (
             f"Unknown /launch arg {action!r}. Use:\n"
@@ -227,6 +229,7 @@ async def handle_launch(raw_args: str, **kwargs: Any) -> str:
             "  /launch confirm --custodial   — deploy via Clawnch's custodial deployer\n"
             "  /launch export                — emit unsigned calldata for Base MCP / external signing\n"
             "  /launch alerts [source]       — subscribe to launch alerts (Telegram channel + filter docs)\n"
+            "  /launch check                 — pre-flight: validate params + burn, show vault %\n"
             "  /launch cancel                — clear draft"
         )
     _record("launch", raw_args, out)
@@ -344,7 +347,7 @@ async def _submit_burn(draft: dict[str, Any], whole_tokens: int) -> str:
     state = get_wallet_state()
     if not state.connected:
         return "No wallet connected. Run /connect or /connect_local first."
-    mode = get_wallet_service().active_mode()
+    mode = get_wallet_service().active_mode
     if mode is None:
         return "No active wallet mode. Run /connect."
 
@@ -353,6 +356,11 @@ async def _submit_burn(draft: dict[str, Any], whole_tokens: int) -> str:
     burn_addr = cfg["burn_address"]
     amount_wei = whole_tokens * (10**18)
     calldata = encode_transfer(burn_addr, amount_wei)
+
+    # Append Coinbase builder code suffix on Base mainnet.
+    from clawmes.lib.base_builder import append_builder_code
+
+    calldata = append_builder_code(calldata, 8453)
 
     try:
         tx_hash = mode.send_transaction(
@@ -514,14 +522,21 @@ async def _confirm_noncustodial(
     if not to_addr or not calldata:
         return f"Prepare returned an unexpected shape: {prepared!r}"
 
-    mode = get_wallet_service().active_mode()
+    mode = get_wallet_service().active_mode
     if mode is None:
         return "No active wallet mode. Run /connect."
+
+    # Append Coinbase builder code suffix on Base mainnet so the plugin
+    # earns builder rewards proportional to the deploy activity it drives.
+    from clawmes.lib.base_builder import append_builder_code
+
+    final_data = append_builder_code(calldata, chain_id)
+
     try:
         tx_hash = mode.send_transaction(
             to=to_addr,
             value=0,
-            data=calldata,
+            data=final_data,
             chain_id=chain_id,
         )
     except Exception as exc:  # noqa: BLE001
@@ -545,6 +560,8 @@ async def _confirm_noncustodial(
         pass
 
     _clear_draft(sender_id)
+    from clawmes.lib.base_app import token_url as _base_app_token_url
+
     lines = [
         f"Launched (non-custodial). {meta.get('platformFeeBps', 2000) / 100:.0f}% platform fee preserved.",
         f"  Tx: {tx_hash}",
@@ -553,6 +570,7 @@ async def _confirm_noncustodial(
     if token_address:
         lines.append(f"  Token: {token_address}")
         lines.append(f"  Chart: https://dexscreener.com/base/{token_address}")
+        lines.append(f"  Base App: {_base_app_token_url(token_address)}")
     vault_pct = meta.get("vaultPercentage") or 0
     if vault_pct:
         lines.append(f"  Vault: {vault_pct}% (Clanker lockup applies)")
@@ -602,11 +620,14 @@ async def _confirm_custodial(
         return f"Launch failed: {exc}"
 
     _clear_draft(sender_id)
+    from clawmes.lib.base_app import token_url as _base_app_token_url
+
     tx_hash = result.get("txHash") or result.get("tx_hash")
     token_address = result.get("tokenAddress") or result.get("token_address")
     lines = ["Launched (custodial)."]
     if token_address:
         lines.append(f"  Token: {token_address}")
+        lines.append(f"  Base App: {_base_app_token_url(token_address)}")
     if tx_hash:
         lines.append(f"  Tx: {tx_hash}")
         lines.append(f"  Chart: https://dexscreener.com/base/{token_address or tx_hash}")
@@ -669,6 +690,90 @@ def _render_alerts(rest: str) -> str:
                 "run /launch alerts <source> for client-side filter docs.",
             ]
         )
+    return "\n".join(lines)
+
+
+async def _check(sender_id: str) -> str:
+    """``/launch check`` — pre-flight validation of the current draft.
+
+    Calls ``/api/prepare/deploy`` to validate every parameter (name,
+    symbol, burn tx) without committing — the user sees exactly what
+    they'd get on confirm. Mostly useful when a ``burn_tx_hash`` is in
+    the draft: ``meta.vaultPercentage`` from the response confirms the
+    burn verified and shows the % the deploy will receive.
+
+    Counts against the per-wallet prepare rate limit (10/UTC day) the
+    same way a real confirm does — both endpoints use the same
+    underlying ``/api/prepare/deploy`` call.
+    """
+    draft = _get_draft(sender_id)
+    name = draft.get("name")
+    symbol = draft.get("symbol")
+    if not name or not symbol:
+        return (
+            "Check needs at minimum a name and a symbol. "
+            "Run /launch name <…> and /launch symbol <TICKER> first."
+        )
+
+    from clawmes.services.clawnch import ClawnchError, get_clawnch_service
+    from clawmes.services.wallet import get_wallet_state
+
+    state = get_wallet_state()
+    from_addr = state.address or "0x" + "0" * 40
+    socials = draft.get("socials") or {}
+    burn = draft.get("burn_tx_hash")
+
+    try:
+        prepared = get_clawnch_service().prepare_deploy(
+            from_address=from_addr,
+            name=name,
+            symbol=symbol,
+            description=draft.get("description") or None,
+            image=draft.get("image") or None,
+            twitter=socials.get("twitter"),
+            website=socials.get("website"),
+            telegram=socials.get("telegram"),
+            farcaster=socials.get("farcaster"),
+            discord=socials.get("discord"),
+            burn_tx_hash=burn,
+        )
+    except ClawnchError as exc:
+        # The whole point of `check` is to surface validation failures
+        # cleanly without running a half-baked deploy. Render the error
+        # as a checklist hint rather than a generic failure.
+        if exc.code == "bad_request":
+            hint = "Fix the param flagged below, then re-run /launch check."
+        elif exc.code == "rate_limited":
+            hint = "Per-wallet prepare limit reached (10/day). Try again after 00:00 UTC."
+        else:
+            hint = "Upstream check failed — params look OK on our side."
+        return f"Check failed ({exc.code}): {exc.message}\n\n{hint}"
+    except Exception as exc:  # noqa: BLE001
+        return f"Check failed: {exc}"
+
+    meta = prepared.get("meta") or {}
+    lines = [
+        "Pre-flight OK. This draft will deploy as:",
+        f"  Name:       {name}",
+        f"  Symbol:     {symbol}",
+        f"  Fees:       {meta.get('userFeeBps', 8000) / 100:.0f}% you / "
+        f"{meta.get('platformFeeBps', 2000) / 100:.0f}% Clawnch",
+    ]
+    vault_pct = meta.get("vaultPercentage") or 0
+    if vault_pct:
+        lines.append(f"  Vault:      {vault_pct}% (Clanker 7-day lockup applies)")
+    elif burn:
+        lines.append("  Vault:      0% — burn hash recorded but produced no vault %")
+    else:
+        lines.append("  Vault:      0% (no burn — /burn <amount> to claim)")
+    if not state.address:
+        lines.append("")
+        lines.append(
+            "⚠ No wallet connected — used the zero address for the pre-flight. "
+            "Connect a wallet before /launch confirm or the deploy will fail."
+        )
+    lines.append("")
+    lines.append("Run /launch confirm to deploy with these params, or edit then re-check.")
     return "\n".join(lines)
 
 

--- a/clawmes/commands/onramp.py
+++ b/clawmes/commands/onramp.py
@@ -1,0 +1,134 @@
+"""``/onramp`` slash command — Coinbase Onramp link generator.
+
+Removes the "need ETH first" friction for new users by emitting a
+Coinbase Onramp URL pre-filled with their connected wallet's address.
+The user opens the link in a browser, completes KYC (if not already
+done), and the purchased ETH lands on Base directly.
+
+The URL is a hosted Coinbase widget; clawmes never touches fiat or
+custody. We just construct the deep link and surface it.
+
+Two configuration env vars:
+
+  * ``CLAWMES_COINBASE_ONRAMP_APP_ID`` — Coinbase Developer Platform
+    app ID for clawmes / Clawnch. Required for production use.
+  * ``CLAWMES_COINBASE_ONRAMP_DEFAULT_AMOUNT`` — default USD amount
+    when the user doesn't specify one. Default: ``25``.
+
+When ``APP_ID`` isn't configured, the command still emits a generic
+Coinbase Onramp landing-page URL so the user can fall back manually.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from urllib.parse import urlencode
+
+from clawmes.services.wallet import get_wallet_state
+
+_ONRAMP_BASE_URL = "https://pay.coinbase.com/buy/select-asset"
+_FALLBACK_LANDING = "https://www.coinbase.com/onramp"
+_DEFAULT_AMOUNT_USD = "25"
+
+
+def _record(name: str, args: str, result: str) -> None:
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _parse_amount(raw: str) -> float | str | None:
+    """Return parsed positive float, error string, or ``None`` (no input)."""
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        amount = float(raw)
+    except ValueError:
+        return f"Invalid amount {raw!r}. Expected a positive USD number (e.g. 50)."
+    if amount <= 0:
+        return f"Invalid amount {raw!r}. Must be positive."
+    return amount
+
+
+def _build_onramp_url(*, address: str, amount: str, asset: str = "ETH") -> str:
+    """Build a Coinbase Onramp URL with destination wallet pre-filled.
+
+    Falls back to the generic landing page when ``APP_ID`` env var
+    isn't set so users always get *something* clickable, even on a
+    fresh install without Coinbase Developer Platform setup.
+    """
+    app_id = os.environ.get("CLAWMES_COINBASE_ONRAMP_APP_ID")
+    if not app_id:
+        return _FALLBACK_LANDING
+
+    destination_wallets = (
+        '[{"address":"' + address + '","blockchains":["base"],"assets":["' + asset + '"]}]'
+    )
+    params = {
+        "appId": app_id,
+        "destinationWallets": destination_wallets,
+        "defaultAsset": asset,
+        "defaultNetwork": "base",
+        "presetFiatAmount": amount,
+        "fiatCurrency": "USD",
+    }
+    return f"{_ONRAMP_BASE_URL}?{urlencode(params)}"
+
+
+async def handle_onramp(raw_args: str, **_kwargs: Any) -> str:
+    parsed = _parse_amount(raw_args or "")
+    if isinstance(parsed, str):
+        return parsed
+    amount_usd = (
+        str(parsed)
+        if isinstance(parsed, float)
+        else os.environ.get("CLAWMES_COINBASE_ONRAMP_DEFAULT_AMOUNT", _DEFAULT_AMOUNT_USD)
+    )
+
+    state = get_wallet_state()
+    if not state.connected or not state.address:
+        out = (
+            "No wallet connected — Onramp needs a destination address.\n"
+            "Run /connect / /connect_local / /connect_bankr first.\n"
+            "\n"
+            "Generic Coinbase Onramp (you'll have to enter the address manually):\n"
+            f"  {_FALLBACK_LANDING}"
+        )
+        _record("onramp", raw_args, out)
+        return out
+
+    url = _build_onramp_url(address=state.address, amount=amount_usd)
+    is_fallback = url == _FALLBACK_LANDING
+
+    lines = [
+        f"Coinbase Onramp link for {state.address}:",
+        "",
+        f"  {url}",
+        "",
+        f"Buy ~${amount_usd} of ETH on Base via Coinbase. Opens a hosted widget — "
+        "KYC + payment happen on Coinbase's side, clawmes doesn't touch fiat. "
+        "ETH lands on Base directly to your connected wallet.",
+    ]
+    if is_fallback:
+        lines.append("")
+        lines.append(
+            "⚠ CLAWMES_COINBASE_ONRAMP_APP_ID not configured — using the generic Coinbase "
+            "Onramp landing page. Set the env var to get pre-filled destination + amount."
+        )
+    out = "\n".join(lines)
+    _record("onramp", raw_args, out)
+    return out
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="onramp",
+        handler=handle_onramp,
+        description="Generate a Coinbase Onramp link pre-filled with your wallet address",
+        args_hint="[usd_amount]",
+    )

--- a/clawmes/commands/wallet.py
+++ b/clawmes/commands/wallet.py
@@ -106,6 +106,61 @@ async def handle_connect_bankr(raw_args: str) -> str:
     )
 
 
+async def handle_connect_base(raw_args: str) -> str:
+    """``/connect_base [code]`` — connect a Coinbase Smart Wallet / Base Account.
+
+    Two-step flow:
+
+      1. ``/connect_base`` (no args) — clawmes returns an OAuth
+         authorize URL. User visits it in a browser, completes
+         Coinbase OAuth, and copies the ``code`` query param from
+         the redirect URL.
+      2. ``/connect_base <code>`` — clawmes exchanges the code for
+         access + refresh tokens and finalizes the connection.
+
+    Every tx + signature thereafter triggers a stored-request approval
+    in the user's Base App, same UX as Base MCP.
+    """
+    from clawmes.services.base_account import BaseAccountError
+    from clawmes.services.wallet import get_wallet_service
+
+    svc = get_wallet_service()
+    code = raw_args.strip()
+
+    if not code:
+        try:
+            _state, auth_url = svc.connect_base_account()
+        except BaseAccountError as exc:
+            if exc.code == "not_configured":
+                return (
+                    "Base Account connect requires CLAWMES_BASE_ACCOUNT_CLIENT_ID. "
+                    "Register a Coinbase Developer Platform OAuth client at "
+                    "https://portal.cdp.coinbase.com and export the client id "
+                    "before /connect_base."
+                )
+            return f"Base Account connect failed: {exc.message}"
+        return (
+            "Base Account OAuth started. Open this URL in a browser:\n"
+            f"\n  {auth_url}\n\n"
+            "After approving, copy the `code` query param from the redirect URL "
+            "and run:\n"
+            "  /connect_base <code>"
+        )
+
+    try:
+        state = svc.complete_base_account(code)
+    except BaseAccountError as exc:
+        return f"Base Account code exchange failed ({exc.code}): {exc.message}"
+    return (
+        f"Base Account connected.\n"
+        f"  Address: {state.address}\n"
+        f"  Chain:   {state.chain_name}\n"
+        f"  Mode:    base_account (Coinbase Smart Wallet)\n"
+        "\n"
+        "Tx + signature requests will prompt for approval in your Base App."
+    )
+
+
 async def handle_disconnect(raw_args: str) -> str:
     from clawmes.services.wallet import get_wallet_service
 
@@ -120,6 +175,7 @@ async def handle_disconnect(raw_args: str) -> str:
         "walletconnect": "WalletConnect session",
         "local": "local-key session",
         "bankr": "Bankr session",
+        "base_account": "Base Account session",
     }.get(previous.mode or "", "wallet session")
     return f"Disconnected {mode_label} ({addr_short} on {chain})."
 
@@ -202,6 +258,12 @@ def register(ctx) -> None:
         name="connect_bankr",
         handler=handle_connect_bankr,
         description="Connect a Bankr custodial wallet",
+    )
+    ctx.register_command(
+        name="connect_base",
+        handler=handle_connect_base,
+        description="Connect a Coinbase Smart Wallet / Base Account via OAuth",
+        args_hint="[code]",
     )
     ctx.register_command(
         name="disconnect",

--- a/clawmes/lib/base_app.py
+++ b/clawmes/lib/base_app.py
@@ -1,0 +1,50 @@
+"""Base App deep links.
+
+Coinbase's Base App (https://base.app) is the consumer wallet + mini-app
+shell most Base users live in day-to-day. Whenever clawmes returns a
+"here's the thing you just did on-chain" message, surfacing a Base App
+link lets the user jump straight to the token / tx in their wallet
+without having to copy the address into a separate browser.
+
+Two URL patterns:
+
+  * ``token_url(address)`` — opens the token's page in Base App's
+    Wallet tab (balance, swap, send).
+  * ``tx_url(tx_hash)`` — opens the tx details in the Base App
+    transactions view.
+
+These are best-effort renderings of public URLs. The exact patterns
+can shift as Base App's URL scheme evolves; override via env vars
+(``CLAWMES_BASE_APP_TOKEN_URL``, ``CLAWMES_BASE_APP_TX_URL``) if the
+defaults stop working.
+"""
+
+from __future__ import annotations
+
+import os
+
+_DEFAULT_TOKEN_URL_TEMPLATE = "https://base.app/?token={address}"
+_DEFAULT_TX_URL_TEMPLATE = "https://base.app/?tx={tx_hash}"
+
+
+def token_url(address: str) -> str:
+    """Return a Base App URL that opens ``address`` in the Wallet tab.
+
+    Empty / falsy inputs return an empty string so callers can chain
+    this into renderers without null-checking.
+    """
+    if not address:
+        return ""
+    template = os.environ.get("CLAWMES_BASE_APP_TOKEN_URL", _DEFAULT_TOKEN_URL_TEMPLATE)
+    return template.format(address=address)
+
+
+def tx_url(tx_hash: str) -> str:
+    """Return a Base App URL that opens ``tx_hash`` in the tx detail view.
+
+    Empty / falsy inputs return an empty string.
+    """
+    if not tx_hash:
+        return ""
+    template = os.environ.get("CLAWMES_BASE_APP_TX_URL", _DEFAULT_TX_URL_TEMPLATE)
+    return template.format(tx_hash=tx_hash)

--- a/clawmes/lib/base_builder.py
+++ b/clawmes/lib/base_builder.py
@@ -1,0 +1,54 @@
+"""Base builder code — on-chain attribution for Coinbase builder rewards.
+
+Coinbase rewards builders for on-chain activity attributable to their
+builder ID. Attribution works by appending a known sentinel suffix to
+every transaction's ``data`` field. The EVM ignores trailing calldata
+beyond the ABI-decoded args, so the suffix is harmless to the
+transaction's actual execution.
+
+clawmes appends the suffix to every Base mainnet tx it broadcasts —
+swaps, non-custodial deploys, $CLAWNCH burns — so the plugin earns
+Coinbase builder rewards proportional to the on-chain activity it
+drives. The clawnch backend's custodial deploy flow already appends
+this in ``api/lib/clanker-backend.ts``; this module is the
+client-side mirror.
+
+The exact 28-byte suffix is the public Coinbase-issued code for
+Clawnch's builder ID (``bc_z92vaimh``); kept identical to the
+server-side constant in ``clawnch/api/lib/constants.ts``.
+"""
+
+from __future__ import annotations
+
+#: Coinbase builder code suffix appended to Base mainnet calldata.
+#: 28 bytes, public on-chain marker. Identical to the server-side
+#: ``BASE_BUILDER_CODE`` in ``clawnch/api/lib/constants.ts``.
+BASE_BUILDER_CODE = "0x62635f7a39327661696d680b0080218021802180218021802180218021"
+
+
+#: Base mainnet chain ID. Only chain where the builder code applies.
+_BASE_CHAIN_ID = 8453
+
+
+def append_builder_code(data: str, chain_id: int | None) -> str:
+    """Return ``data`` with the builder-code suffix appended on Base mainnet.
+
+    Pass-through on non-Base chains so the same wrapper can be applied
+    universally without hand-checking the chain id at every call site.
+
+    Args:
+      data: Hex calldata string (``0x``-prefixed) to append to.
+      chain_id: Network chain id. Only ``8453`` triggers the append.
+
+    Returns:
+      The original calldata on non-Base chains. On Base, the original
+      calldata concatenated with the builder-code suffix (without the
+      ``0x`` prefix of the suffix, since the suffix only carries one
+      hex prefix at the front of the combined value).
+    """
+    if chain_id != _BASE_CHAIN_ID:
+        return data
+    if not data.startswith("0x"):
+        # Defensive: build a clean prefix if the caller fed in raw hex.
+        data = "0x" + data
+    return data + BASE_BUILDER_CODE[2:]

--- a/clawmes/lib/ens.py
+++ b/clawmes/lib/ens.py
@@ -31,6 +31,12 @@ _log = logger_for("lib.ens")
 # https://docs.ens.domains/contract-api-reference/ens — never moved.
 ENS_REGISTRY = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
 
+#: Base ENS L2 Registry (Coinbase's L2 ENS deployment). Resolves
+#: ``*.base.eth`` names natively on Base L2 — bypasses the CCIP-Read
+#: hop that ``base.eth`` parent resolution on mainnet would require.
+#: Doc: https://docs.base.org/basenames
+BASE_ENS_REGISTRY = "0xB94704422c2A1E396835A571837Aa5AE53285a95"
+
 # Function selectors (first 4 bytes of keccak256 of the function signature).
 _SELECTOR_RESOLVER = bytes.fromhex("0178b8bf")  # resolver(bytes32)
 _SELECTOR_ADDR = bytes.fromhex("3b3b57de")  # addr(bytes32)
@@ -42,6 +48,9 @@ _ZERO_BYTES32 = "0x" + "0" * 64
 # wallet is currently on. Bridged ENS variants (e.g. on Base) exist but
 # the canonical resolver lives on mainnet.
 _ENS_CHAIN_ID = 1
+
+#: Base mainnet chain id for ``*.base.eth`` lookups.
+_BASE_CHAIN_ID = 8453
 
 
 class EnsError(RuntimeError):
@@ -88,8 +97,25 @@ def namehash(name: str) -> bytes:
     return keccak(namehash(rest) + keccak(label.encode("utf-8")))
 
 
+def is_basename(value: str) -> bool:
+    """Return True if ``value`` looks like a Coinbase Basename.
+
+    Basenames are subdomains of ``.base.eth`` (e.g. ``jesse.base.eth``).
+    They live on the Base L2 ENS registry rather than the Ethereum
+    mainnet registry; ``resolve()`` routes them automatically so most
+    callers don't need to branch on this.
+    """
+    return bool(value) and value.lower().endswith(".base.eth")
+
+
 def resolve(name: str) -> str:
-    """Resolve an ENS name to a checksummed 0x address on mainnet.
+    """Resolve an ENS name (or Basename) to a checksummed 0x address.
+
+    Detects ``*.base.eth`` names and routes the lookup to the Base L2
+    ENS registry. All other names go to Ethereum mainnet's canonical
+    ENS registry. The two registries share the same ABI so the
+    resolution algorithm is identical — only the registry contract
+    address and RPC chain id differ.
 
     Raises :class:`EnsError` with one of these codes:
 
@@ -97,15 +123,22 @@ def resolve(name: str) -> str:
       * ``no_address``     — the resolver returned the zero address.
       * ``rpc_error``      — the underlying RPC call failed.
     """
+    if is_basename(name):
+        registry = BASE_ENS_REGISTRY
+        chain_id = _BASE_CHAIN_ID
+    else:
+        registry = ENS_REGISTRY
+        chain_id = _ENS_CHAIN_ID
+
     rpc = get_rpc_service()
     node = namehash(name)
     node_hex = "0x" + node.hex()
 
     try:
         resolver_result = rpc.eth_call(
-            to=ENS_REGISTRY,
+            to=registry,
             data="0x" + (_SELECTOR_RESOLVER + node).hex(),
-            chain_id=_ENS_CHAIN_ID,
+            chain_id=chain_id,
         )
     except RpcError as exc:
         raise EnsError("rpc_error", f"ENS resolver lookup failed: {exc.message}") from exc
@@ -121,7 +154,7 @@ def resolve(name: str) -> str:
         addr_result = rpc.eth_call(
             to=resolver_addr,
             data="0x" + (_SELECTOR_ADDR + node).hex(),
-            chain_id=_ENS_CHAIN_ID,
+            chain_id=chain_id,
         )
     except RpcError as exc:
         raise EnsError("rpc_error", f"ENS addr lookup failed: {exc.message}") from exc

--- a/clawmes/lib/x402.py
+++ b/clawmes/lib/x402.py
@@ -1,0 +1,106 @@
+"""x402 payment-required HTTP detection helpers.
+
+x402 (https://www.x402.org) is Coinbase's machine-payment protocol
+built on HTTP 402 Payment Required. A server that wants payment for
+an endpoint responds with status 402 + a JSON body describing what
+to pay (amount, recipient, currency, network). Clients pay on-chain
+and retry with proof.
+
+This module is a minimal client-side detector — it parses x402
+challenges out of HTTP responses so other clawmes tools can opt into
+paying for premium endpoints. We don't yet wire payment auto-handling
+into the request pipeline; that's a follow-up that involves wallet
+signing + retry-with-proof.
+
+Server-side x402 (the Clawnch backend exposing paid endpoints) is a
+separate, downstream concern.
+
+Spec reference: https://www.x402.org/
+
+Why ship this as a helper module before wiring it into the request
+pipeline: gives downstream tools (premium /api/bv7x_oracle, premium
+yield aggregators, paid analytics) a clean way to surface payment
+requirements to the user without needing each one to re-parse the
+challenge shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class X402Challenge:
+    """Structured representation of an x402 payment challenge.
+
+    The spec lets servers describe multiple acceptable payment options;
+    we expose them via :attr:`accepts`. ``primary()`` picks the first
+    Base-mainnet USDC option (the most common) or the first option if
+    none match.
+    """
+
+    accepts: tuple[dict[str, Any], ...]
+    raw: dict[str, Any]
+
+    def primary(self) -> dict[str, Any] | None:
+        """Return the most likely payment option (Base USDC > first)."""
+        if not self.accepts:
+            return None
+        for option in self.accepts:
+            network = (option.get("network") or "").lower()
+            asset = (option.get("asset") or "").upper()
+            if network == "base" and asset == "USDC":
+                return option
+        return self.accepts[0]
+
+
+def is_x402_response(body: Any, status_code: int | None = None) -> bool:
+    """Return True if ``body`` (parsed JSON or dict) looks like an x402 challenge.
+
+    The x402 spec keys responses with an ``"accepts"`` array describing
+    payment options. We accept either ``status_code == 402`` OR the
+    body shape — some implementations return 200 with the challenge in
+    the body to dodge proxies that swallow 4xx.
+    """
+    if status_code == 402:
+        return True
+    if not isinstance(body, dict):
+        return False
+    accepts = body.get("accepts")
+    return isinstance(accepts, list) and len(accepts) > 0
+
+
+def parse_challenge(body: dict[str, Any]) -> X402Challenge:
+    """Parse the body of an x402 response into a structured challenge."""
+    accepts = body.get("accepts") or []
+    options: tuple[dict[str, Any], ...] = tuple(opt for opt in accepts if isinstance(opt, dict))
+    return X402Challenge(accepts=options, raw=body)
+
+
+def format_challenge(challenge: X402Challenge) -> str:
+    """Render a challenge as a short user-facing message.
+
+    Tools that hit an x402-protected endpoint can use this to surface
+    the payment requirement to the user without inventing their own
+    format.
+    """
+    primary = challenge.primary()
+    if not primary:
+        return "Payment required but no acceptable payment options were offered."
+
+    network = primary.get("network") or "?"
+    asset = primary.get("asset") or "?"
+    amount = primary.get("maxAmountRequired") or primary.get("amount") or "?"
+    recipient = primary.get("payTo") or primary.get("recipient") or "?"
+    description = primary.get("description") or ""
+
+    lines = [
+        f"Payment required: {amount} {asset} on {network}",
+        f"  Pay to: {recipient}",
+    ]
+    if description:
+        lines.append(f"  For: {description}")
+    if len(challenge.accepts) > 1:
+        lines.append(f"  (+ {len(challenge.accepts) - 1} alternate payment option(s))")
+    return "\n".join(lines)

--- a/clawmes/mcp_server/__init__.py
+++ b/clawmes/mcp_server/__init__.py
@@ -49,6 +49,17 @@ Configure Claude Desktop's ``~/Library/Application Support/Claude/claude_desktop
 
 from __future__ import annotations
 
-from clawmes.mcp_server.server import main
-
 __all__ = ["main"]
+
+
+def main() -> None:
+    """Lazy-loading entrypoint — defers the ``mcp`` import to runtime.
+
+    Lets ``clawmes.mcp_server`` be importable without the optional
+    ``[mcp]`` extra installed (so tests / linters / introspection
+    don't need the SDK), while preserving the ``clawmes-mcp`` script
+    entry's behavior for production use.
+    """
+    from clawmes.mcp_server.server import main as _real_main
+
+    _real_main()

--- a/clawmes/mcp_server/__init__.py
+++ b/clawmes/mcp_server/__init__.py
@@ -1,0 +1,54 @@
+"""``clawmes-mcp`` — exposes clawmes read tools as an MCP server.
+
+Distribution surface in addition to the Hermes Agent plugin:
+
+  * Chat platforms (Telegram / Discord / Slack via Hermes) — the
+    historical clawmes surface, full read + write tools available.
+  * **Desktop AI clients** (Claude Desktop, Cursor, ChatGPT, any other
+    MCP-compatible client) — install ``clawmes-mcp`` as an MCP server
+    to get clawmes' read tools available as MCP tools.
+
+Why read-only first: write tools (swap, deploy, transfer) need a
+connected wallet, and clawmes' wallet modes (WalletConnect, local-key,
+Bankr, Base Account) all assume a stateful clawmes session managing
+the wallet. MCP clients are stateless from the wallet perspective —
+they delegate signing to a sibling MCP server like Base MCP.
+
+For writes through MCP, users should:
+
+  1. Install ``clawmes-mcp`` for read / discovery
+  2. Install Base MCP for signing
+  3. Use clawmes-mcp to gather context, then Base MCP's
+     ``send_calls`` to execute
+
+A future iteration will expose write tools that return unsigned
+calldata + delegate to Base MCP's ``send_calls`` for execution.
+
+Optional install:
+
+  .. code-block:: bash
+
+     pip install clawmes[mcp]
+
+Run via stdio (the standard MCP transport):
+
+  .. code-block:: bash
+
+     clawmes-mcp
+
+Configure Claude Desktop's ``~/Library/Application Support/Claude/claude_desktop_config.json``:
+
+  .. code-block:: json
+
+     {
+       "mcpServers": {
+         "clawmes": { "command": "clawmes-mcp" }
+       }
+     }
+"""
+
+from __future__ import annotations
+
+from clawmes.mcp_server.server import main
+
+__all__ = ["main"]

--- a/clawmes/mcp_server/server.py
+++ b/clawmes/mcp_server/server.py
@@ -29,7 +29,8 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from clawmes import __version__
 
@@ -115,7 +116,7 @@ _TOOL_FACTORIES: dict[str, Callable[[], Callable[..., str]]] = {
 }
 
 
-def _build_tool_list() -> list["Tool"]:
+def _build_tool_list() -> list[Tool]:
     """Reflect each exposed clawmes tool into an MCP ``Tool`` definition."""
     from mcp.types import Tool
 
@@ -163,7 +164,7 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> str:
         )
 
 
-def _wrap_call_tool_result(result: str) -> list["TextContent"]:
+def _wrap_call_tool_result(result: str) -> list[TextContent]:
     """Wrap a clawmes tool's JSON-string output as MCP TextContent.
 
     Split out from the decorator-wrapped closure inside ``build_server``
@@ -175,25 +176,26 @@ def _wrap_call_tool_result(result: str) -> list["TextContent"]:
     return [TextContent(type="text", text=result)]
 
 
-def build_server() -> "Server":
+def build_server() -> Server:
     """Build the MCP Server object with clawmes tool handlers registered.
 
     Split out from :func:`main` so tests can drive the server in-process
     without running the stdio loop.
     """
-    from mcp.server.lowlevel import Server
-    from mcp.types import TextContent, Tool
+    from mcp.server.lowlevel import Server as _Server
+    from mcp.types import TextContent as _TextContent
+    from mcp.types import Tool as _Tool
 
-    server: Server = Server(name="clawmes", version=__version__)
+    server: _Server = _Server(name="clawmes", version=__version__)
 
     @server.list_tools()
-    async def _list_tools() -> list[Tool]:
+    async def _list_tools() -> list[_Tool]:
         return _build_tool_list()
 
     @server.call_tool()
     async def _call(  # pragma: no cover — exercised via stdio integration smoke test
         name: str, arguments: dict[str, Any] | None = None
-    ) -> list[TextContent]:
+    ) -> list[_TextContent]:
         return _wrap_call_tool_result(_call_tool(name, arguments))
 
     return server

--- a/clawmes/mcp_server/server.py
+++ b/clawmes/mcp_server/server.py
@@ -29,14 +29,13 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
-from collections.abc import Callable
-from typing import Any
-
-import mcp.server.stdio
-from mcp.server.lowlevel import Server
-from mcp.types import TextContent, Tool
+from typing import TYPE_CHECKING, Any, Callable
 
 from clawmes import __version__
+
+if TYPE_CHECKING:  # pragma: no cover — type-check-only imports
+    from mcp.server.lowlevel import Server
+    from mcp.types import TextContent, Tool
 
 
 def _import_defi_price() -> Callable[..., str]:
@@ -116,8 +115,10 @@ _TOOL_FACTORIES: dict[str, Callable[[], Callable[..., str]]] = {
 }
 
 
-def _build_tool_list() -> list[Tool]:
+def _build_tool_list() -> list["Tool"]:
     """Reflect each exposed clawmes tool into an MCP ``Tool`` definition."""
+    from mcp.types import Tool
+
     tools: list[Tool] = []
     for name, factory in _TOOL_FACTORIES.items():
         fn = factory()
@@ -162,22 +163,27 @@ def _call_tool(name: str, arguments: dict[str, Any] | None) -> str:
         )
 
 
-def _wrap_call_tool_result(result: str) -> list[TextContent]:
+def _wrap_call_tool_result(result: str) -> list["TextContent"]:
     """Wrap a clawmes tool's JSON-string output as MCP TextContent.
 
     Split out from the decorator-wrapped closure inside ``build_server``
     so tests can verify the wrapping shape directly without going through
     the MCP SDK's request-dispatch plumbing.
     """
+    from mcp.types import TextContent
+
     return [TextContent(type="text", text=result)]
 
 
-def build_server() -> Server:
+def build_server() -> "Server":
     """Build the MCP Server object with clawmes tool handlers registered.
 
     Split out from :func:`main` so tests can drive the server in-process
     without running the stdio loop.
     """
+    from mcp.server.lowlevel import Server
+    from mcp.types import TextContent, Tool
+
     server: Server = Server(name="clawmes", version=__version__)
 
     @server.list_tools()
@@ -194,6 +200,8 @@ def build_server() -> Server:
 
 
 async def _run() -> None:
+    import mcp.server.stdio
+
     server = build_server()
     async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
         await server.run(

--- a/clawmes/mcp_server/server.py
+++ b/clawmes/mcp_server/server.py
@@ -1,0 +1,215 @@
+"""MCP server that exposes a curated set of clawmes read tools.
+
+Architecture:
+
+  * The official ``mcp`` Python SDK (Anthropic) provides the stdio
+    transport + JSON-RPC plumbing. We just register handlers for
+    ``tools/list`` and ``tools/call``.
+  * Each exposed clawmes tool gets wrapped into the MCP shape: name,
+    description, input JSON schema, and a sync handler.
+  * Tools execute the underlying clawmes function — same registry as
+    the Hermes Agent path — and return the JSON envelope as MCP text
+    content.
+
+The tool selection is intentionally read-only for v1: every exposed
+tool either reads on-chain data, queries external APIs, or surfaces
+clawnch index records. None requires a connected wallet on the
+clawmes side. Writes (swap / deploy / transfer) need wallet state
+that doesn't transfer cleanly into an MCP context — those land in a
+follow-up that delegates signing to Base MCP via ``send_calls``.
+
+Adding a new tool to the exposed set: append its module + factory to
+``_TOOL_FACTORIES``. Each factory returns the decorated clawmes
+function (the one with the ``_clawmes_meta`` attribute set by
+``@read_tool``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from collections.abc import Callable
+from typing import Any
+
+import mcp.server.stdio
+from mcp.server.lowlevel import Server
+from mcp.types import TextContent, Tool
+
+from clawmes import __version__
+
+
+def _import_defi_price() -> Callable[..., str]:
+    from clawmes.tools.defi_price import defi_price
+
+    return defi_price
+
+
+def _import_defi_balance() -> Callable[..., str]:
+    from clawmes.tools.defi_balance import defi_balance
+
+    return defi_balance
+
+
+def _import_market_intel() -> Callable[..., str]:
+    from clawmes.tools.market_intel import market_intel
+
+    return market_intel
+
+
+def _import_clawnch_launch() -> Callable[..., str]:
+    from clawmes.tools.clawnch_launch import clawnch_launch
+
+    return clawnch_launch
+
+
+def _import_clawnch_fees() -> Callable[..., str]:
+    from clawmes.tools.clawnch_fees import clawnch_fees
+
+    return clawnch_fees
+
+
+def _import_bv7x_oracle() -> Callable[..., str]:
+    from clawmes.tools.bv7x_oracle import bv7x_oracle
+
+    return bv7x_oracle
+
+
+def _import_bv7x_market() -> Callable[..., str]:
+    from clawmes.tools.bv7x_market import bv7x_market
+
+    return bv7x_market
+
+
+def _import_nft() -> Callable[..., str]:
+    from clawmes.tools.nft import nft
+
+    return nft
+
+
+def _import_block_explorer() -> Callable[..., str]:
+    from clawmes.tools.block_explorer import block_explorer
+
+    return block_explorer
+
+
+def _import_cost_basis() -> Callable[..., str]:
+    from clawmes.tools.cost_basis import cost_basis
+
+    return cost_basis
+
+
+#: Lazy importers — keep startup fast (no full plugin discovery just
+#: to ship the MCP server). Each entry maps the MCP-side name to a
+#: zero-arg factory that returns the decorated clawmes function.
+_TOOL_FACTORIES: dict[str, Callable[[], Callable[..., str]]] = {
+    "defi_price": _import_defi_price,
+    "defi_balance": _import_defi_balance,
+    "market_intel": _import_market_intel,
+    "clawnch_launch": _import_clawnch_launch,
+    "clawnch_fees": _import_clawnch_fees,
+    "bv7x_oracle": _import_bv7x_oracle,
+    "bv7x_market": _import_bv7x_market,
+    "nft": _import_nft,
+    "block_explorer": _import_block_explorer,
+    "cost_basis": _import_cost_basis,
+}
+
+
+def _build_tool_list() -> list[Tool]:
+    """Reflect each exposed clawmes tool into an MCP ``Tool`` definition."""
+    tools: list[Tool] = []
+    for name, factory in _TOOL_FACTORIES.items():
+        fn = factory()
+        meta = getattr(fn, "_clawmes_meta", None)
+        if meta is None:
+            # Defensive — every @read_tool / @write_tool sets this.
+            # Skip rather than crash if a clawmes refactor breaks the
+            # invariant; the server stays useful for the rest of the set.
+            continue
+        tools.append(
+            Tool(
+                name=name,
+                description=meta.get("description") or "",
+                inputSchema=meta.get("schema") or {"type": "object", "properties": {}},
+            )
+        )
+    return tools
+
+
+def _call_tool(name: str, arguments: dict[str, Any] | None) -> str:
+    """Dispatch an MCP ``tools/call`` to the underlying clawmes function."""
+    factory = _TOOL_FACTORIES.get(name)
+    if factory is None:
+        return json.dumps(
+            {
+                "isError": True,
+                "content": [{"type": "text", "text": f"Unknown clawmes tool: {name}"}],
+            }
+        )
+    fn = factory()
+    args_dict: dict[str, Any] = dict(arguments or {})
+    try:
+        return fn(args_dict)
+    except Exception as exc:  # noqa: BLE001 — surface to MCP client
+        return json.dumps(
+            {
+                "isError": True,
+                "content": [
+                    {"type": "text", "text": f"Tool {name} raised {type(exc).__name__}: {exc}"}
+                ],
+            }
+        )
+
+
+def _wrap_call_tool_result(result: str) -> list[TextContent]:
+    """Wrap a clawmes tool's JSON-string output as MCP TextContent.
+
+    Split out from the decorator-wrapped closure inside ``build_server``
+    so tests can verify the wrapping shape directly without going through
+    the MCP SDK's request-dispatch plumbing.
+    """
+    return [TextContent(type="text", text=result)]
+
+
+def build_server() -> Server:
+    """Build the MCP Server object with clawmes tool handlers registered.
+
+    Split out from :func:`main` so tests can drive the server in-process
+    without running the stdio loop.
+    """
+    server: Server = Server(name="clawmes", version=__version__)
+
+    @server.list_tools()
+    async def _list_tools() -> list[Tool]:
+        return _build_tool_list()
+
+    @server.call_tool()
+    async def _call(  # pragma: no cover — exercised via stdio integration smoke test
+        name: str, arguments: dict[str, Any] | None = None
+    ) -> list[TextContent]:
+        return _wrap_call_tool_result(_call_tool(name, arguments))
+
+    return server
+
+
+async def _run() -> None:
+    server = build_server()
+    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+def main() -> None:
+    """CLI entrypoint — ``clawmes-mcp`` from pyproject.toml [scripts]."""
+    try:
+        asyncio.run(_run())
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+if __name__ == "__main__":  # pragma: no cover — script entry
+    main()

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.4.0
+version: 0.5.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/services/base_account.py
+++ b/clawmes/services/base_account.py
@@ -1,0 +1,316 @@
+"""Base Account / Coinbase Smart Wallet — OAuth + stored-request client.
+
+Base App's wallet (Coinbase Smart Wallet, sometimes referenced as
+"Base Account") is the wallet most Base ecosystem users live in
+day-to-day. It exposes:
+
+  * **OAuth 2.1** for authentication — same flow Base MCP uses to
+    pair an external agent with a user's Base Account.
+  * **Stored-request endpoint** for tx / signature requests — the
+    agent constructs the request, the wallet returns a request id
+    plus an approval URL, and the user opens the URL in their Base
+    App to approve / cancel.
+
+This service is the clawmes-side client for that surface. It backs
+:class:`clawmes.wallet.base_account.BaseAccountMode`, which presents
+the same wallet-mode interface as Bankr / WalletConnect / local-key
+so the rest of clawmes can treat it as just another mode.
+
+Configuration:
+
+  * ``CLAWMES_BASE_ACCOUNT_CLIENT_ID`` — OAuth client id registered
+    with Coinbase Developer Platform. Required for ``connect``.
+  * ``CLAWMES_BASE_ACCOUNT_REDIRECT_URI`` — OAuth redirect URI
+    (defaults to ``http://localhost:8765/oauth/base_account/callback``
+    — only used by local CLI flows; production users should override).
+  * ``CLAWMES_BASE_ACCOUNT_AUTH_URL`` — OAuth authorize endpoint
+    (defaults to Coinbase's public endpoint; overridable for staging).
+  * ``CLAWMES_BASE_ACCOUNT_TOKEN_URL`` — OAuth token-exchange endpoint.
+  * ``CLAWMES_BASE_ACCOUNT_API_URL`` — Base Account API root for
+    wallet-request submission / polling.
+
+Why ship this even when the real Coinbase endpoints might shift: the
+*shape* of the integration is stable (OAuth code flow, stored-request
+pattern matches Base MCP), and the env-var overrides let the user
+point clawmes at the right URLs without code changes when Base App's
+production endpoints stabilize.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Any
+from urllib.parse import urlencode
+
+from clawmes.lib.http import http_get, http_post
+from clawmes.lib.logger import logger_for
+from clawmes.services._base import Service
+
+_log = logger_for("services.base_account")
+
+# Defaults — production users should override via env if Coinbase ships
+# different endpoints. Path conventions match Coinbase's OAuth 2.1 +
+# Base Account "wallet/requests" patterns described in the Base MCP
+# spec; treat as best-effort until publicly documented.
+_DEFAULT_AUTH_URL = "https://auth.coinbase.com/oauth2/authorize"
+_DEFAULT_TOKEN_URL = "https://auth.coinbase.com/oauth2/token"
+_DEFAULT_API_URL = "https://api.base.app"
+_DEFAULT_REDIRECT_URI = "http://localhost:8765/oauth/base_account/callback"
+_DEFAULT_SCOPE = "wallet:read wallet:sign"
+
+# How long to poll a stored request before giving up. Approvals are
+# user-paced; 5 minutes is the right ceiling for chat-platform UX.
+_DEFAULT_POLL_TIMEOUT_S = 300.0
+_DEFAULT_POLL_INTERVAL_S = 2.0
+
+
+class BaseAccountError(RuntimeError):
+    """Raised on Base Account API failures.
+
+    ``code`` classification:
+      * ``not_configured``  — required env var missing.
+      * ``not_connected``   — operation needs an access token but none set.
+      * ``oauth_error``     — OAuth flow failure (auth code / token exchange).
+      * ``request_failed``  — stored-request submission rejected by the API.
+      * ``approval_timeout``— user didn't approve within the polling window.
+      * ``api_error``       — generic upstream failure.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class BaseAccountService(Service):
+    """Singleton OAuth + stored-request client for Base Account."""
+
+    id = "clawmes.base_account"
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._token_expires_at: float | None = None
+        self._user_address: str | None = None
+        self._auth_url: str = _DEFAULT_AUTH_URL
+        self._token_url: str = _DEFAULT_TOKEN_URL
+        self._api_url: str = _DEFAULT_API_URL
+        self._client_id: str | None = None
+        self._redirect_uri: str = _DEFAULT_REDIRECT_URI
+
+    # ── lifecycle ───────────────────────────────────────────────────
+
+    def start(self) -> None:
+        with self._lock:
+            self._auth_url = os.environ.get("CLAWMES_BASE_ACCOUNT_AUTH_URL", _DEFAULT_AUTH_URL)
+            self._token_url = os.environ.get("CLAWMES_BASE_ACCOUNT_TOKEN_URL", _DEFAULT_TOKEN_URL)
+            self._api_url = os.environ.get("CLAWMES_BASE_ACCOUNT_API_URL", _DEFAULT_API_URL)
+            self._client_id = os.environ.get("CLAWMES_BASE_ACCOUNT_CLIENT_ID") or None
+            self._redirect_uri = os.environ.get(
+                "CLAWMES_BASE_ACCOUNT_REDIRECT_URI", _DEFAULT_REDIRECT_URI
+            )
+        if self._client_id:
+            _log.info("base_account service started (client=%s)", self._client_id[:8] + "…")
+        else:
+            _log.info(
+                "base_account service started without CLAWMES_BASE_ACCOUNT_CLIENT_ID — "
+                "connect will fail until configured"
+            )
+
+    def stop(self) -> None:
+        with self._lock:
+            self._access_token = None
+            self._refresh_token = None
+            self._token_expires_at = None
+            self._user_address = None
+
+    # ── OAuth ───────────────────────────────────────────────────────
+
+    def get_auth_url(self, *, state: str | None = None) -> str:
+        """Return the OAuth authorize URL for the user to visit.
+
+        Raises :class:`BaseAccountError` with code ``not_configured``
+        when ``CLAWMES_BASE_ACCOUNT_CLIENT_ID`` is not set.
+        """
+        if not self._client_id:
+            raise BaseAccountError(
+                "not_configured",
+                "CLAWMES_BASE_ACCOUNT_CLIENT_ID env var not set. Register a Coinbase "
+                "Developer Platform OAuth client and export the id before /connect_base.",
+            )
+        params = {
+            "client_id": self._client_id,
+            "redirect_uri": self._redirect_uri,
+            "response_type": "code",
+            "scope": _DEFAULT_SCOPE,
+        }
+        if state:
+            params["state"] = state
+        return f"{self._auth_url}?{urlencode(params)}"
+
+    def exchange_code(self, code: str) -> dict[str, Any]:
+        """Exchange an authorization ``code`` for access + refresh tokens.
+
+        Stores the tokens on the service singleton and returns the raw
+        upstream response (useful for callers that want to inspect
+        ``expires_in`` directly).
+        """
+        if not self._client_id:
+            raise BaseAccountError(
+                "not_configured", "CLAWMES_BASE_ACCOUNT_CLIENT_ID env var not set"
+            )
+        if not code:
+            raise BaseAccountError("oauth_error", "authorization code is required")
+        body = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": self._client_id,
+            "redirect_uri": self._redirect_uri,
+        }
+        try:
+            resp = http_post(
+                self._token_url,
+                json=body,
+                headers={"Content-Type": "application/json"},
+                timeout=30.0,
+            )
+        except Exception as exc:  # noqa: BLE001 — classified below
+            raise BaseAccountError("oauth_error", f"token exchange failed: {exc}") from exc
+        if not isinstance(resp, dict) or not resp.get("access_token"):
+            raise BaseAccountError(
+                "oauth_error", f"token exchange returned no access token: {resp!r}"
+            )
+        with self._lock:
+            self._access_token = str(resp["access_token"])
+            self._refresh_token = (
+                str(resp.get("refresh_token")) if resp.get("refresh_token") else None
+            )
+            expires_in = resp.get("expires_in")
+            if isinstance(expires_in, (int, float)):
+                self._token_expires_at = time.time() + float(expires_in)
+            self._user_address = resp.get("address") or resp.get("wallet_address") or None
+        _log.info("base_account oauth code exchanged successfully")
+        return resp
+
+    # ── account ─────────────────────────────────────────────────────
+
+    def get_user_address(self) -> str:
+        """Return the connected Base Account's primary address.
+
+        If the token-exchange response didn't include the address, we
+        hit the API's ``/v1/wallet`` endpoint to fetch it. Cached
+        thereafter for the lifetime of the connection.
+        """
+        with self._lock:
+            cached = self._user_address
+        if cached:
+            return cached
+        token = self._require_token()
+        try:
+            resp = http_get(
+                f"{self._api_url}/v1/wallet",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=15.0,
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise BaseAccountError("api_error", f"wallet lookup failed: {exc}") from exc
+        addr = (resp or {}).get("address") or (resp or {}).get("primary_address")
+        if not isinstance(addr, str) or not addr:
+            raise BaseAccountError("api_error", f"wallet API returned no address: {resp!r}")
+        with self._lock:
+            self._user_address = addr
+        return addr
+
+    # ── stored-request ──────────────────────────────────────────────
+
+    def submit_request(self, *, method: str, params: list[Any]) -> dict[str, Any]:
+        """Submit a wallet JSON-RPC request to Base Account.
+
+        Returns ``{request_id, approval_url, status}``. The user opens
+        ``approval_url`` in their Base App to approve. Caller should
+        poll :meth:`poll_request` until status is ``confirmed`` or
+        ``rejected``.
+        """
+        token = self._require_token()
+        body = {"method": method, "params": params}
+        try:
+            resp = http_post(
+                f"{self._api_url}/v1/wallet/requests",
+                json=body,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                timeout=30.0,
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise BaseAccountError("request_failed", f"wallet/requests POST failed: {exc}") from exc
+        if not isinstance(resp, dict) or not resp.get("request_id"):
+            raise BaseAccountError(
+                "request_failed", f"wallet/requests returned bad shape: {resp!r}"
+            )
+        return resp
+
+    def poll_request(
+        self,
+        request_id: str,
+        *,
+        timeout: float = _DEFAULT_POLL_TIMEOUT_S,
+        interval: float = _DEFAULT_POLL_INTERVAL_S,
+    ) -> dict[str, Any]:
+        """Poll until ``request_id`` is approved / rejected / expires."""
+        token = self._require_token()
+        deadline = time.monotonic() + timeout
+        url = f"{self._api_url}/v1/wallet/requests/{request_id}"
+        while True:
+            try:
+                resp = http_get(
+                    url,
+                    headers={"Authorization": f"Bearer {token}"},
+                    timeout=15.0,
+                )
+            except Exception as exc:  # noqa: BLE001
+                raise BaseAccountError("api_error", f"wallet/requests poll failed: {exc}") from exc
+            status = (resp or {}).get("status") or ""
+            if status in ("confirmed", "rejected", "expired", "failed"):
+                if status != "confirmed":
+                    raise BaseAccountError(
+                        "request_failed", f"request {request_id} {status}: {resp!r}"
+                    )
+                return resp
+            if time.monotonic() >= deadline:
+                raise BaseAccountError(
+                    "approval_timeout",
+                    f"timed out waiting for user approval of {request_id} (status={status})",
+                )
+            time.sleep(interval)
+
+    # ── helpers ─────────────────────────────────────────────────────
+
+    def is_connected(self) -> bool:
+        with self._lock:
+            return self._access_token is not None
+
+    def _require_token(self) -> str:
+        with self._lock:
+            tok = self._access_token
+        if not tok:
+            raise BaseAccountError(
+                "not_connected",
+                "Base Account not connected. Run /connect_base to authenticate.",
+            )
+        return tok
+
+
+_instance: BaseAccountService | None = None
+
+
+def get_base_account_service() -> BaseAccountService:
+    global _instance
+    if _instance is None:
+        _instance = BaseAccountService()
+        _instance.start()
+    return _instance

--- a/clawmes/services/wallet.py
+++ b/clawmes/services/wallet.py
@@ -203,6 +203,47 @@ class WalletService(Service):
             account_index=account_index,
         )
 
+    # --- Base Account convenience ---------------------------------------
+
+    def connect_base_account(self, *, chain_id: int = 8453) -> tuple[WalletState, str | None]:
+        """Materialize a :class:`BaseAccountMode` and start its OAuth flow.
+
+        Returns a ``(state, auth_url)`` tuple:
+
+          * ``state`` is the post-``connect()`` state — still
+            ``disconnected`` because OAuth runs out-of-band; the user
+            visits the URL, completes auth, and a follow-up call to
+            :meth:`complete_base_account` finalizes the connection.
+          * ``auth_url`` is the URL the user must visit. ``None`` if
+            the OAuth client isn't configured (the underlying service
+            raises ``BaseAccountError`` in that case).
+        """
+        from clawmes.wallet.base_account import BaseAccountMode
+
+        mode = BaseAccountMode()
+        self.set_mode(mode)
+        state = mode.connect(chain_id=chain_id)
+        return state, mode.get_pending_auth_url()
+
+    def complete_base_account(self, code: str, *, chain_id: int = 8453) -> WalletState:
+        """Finish the OAuth code exchange for an in-flight Base Account connect.
+
+        Raises if there's no in-flight Base Account mode (caller didn't
+        run :meth:`connect_base_account` first) or if the code is
+        invalid.
+        """
+        from clawmes.wallet.base_account import BaseAccountMode
+
+        active = self.active_mode
+        if not isinstance(active, BaseAccountMode):
+            from clawmes.services.base_account import BaseAccountError
+
+            raise BaseAccountError(
+                "not_connected",
+                "No in-flight Base Account session. Run /connect_base first to get an auth URL.",
+            )
+        return active.connect_with_code(code, chain_id=chain_id)
+
     # --- WalletConnect convenience --------------------------------------
 
     def connect_walletconnect(self) -> WalletState:

--- a/clawmes/tools/defi_swap.py
+++ b/clawmes/tools/defi_swap.py
@@ -324,11 +324,18 @@ def _handle_swap(
             code="wallet_not_connected",
         )
 
+    # Append Coinbase builder code suffix on Base mainnet so the plugin
+    # earns builder rewards proportional to the swap volume it drives.
+    # No-op on other chains; safe to apply universally.
+    from clawmes.lib.base_builder import append_builder_code
+
+    final_data = append_builder_code(data, chain_id)
+
     try:
         tx_hash = mode.send_transaction(
             to=to,
             value=value,
-            data=data,
+            data=final_data,
             gas=gas if gas > 0 else None,
             chain_id=chain_id,
         )

--- a/clawmes/wallet/base_account.py
+++ b/clawmes/wallet/base_account.py
@@ -1,0 +1,217 @@
+"""Base Account / Coinbase Smart Wallet — wallet mode.
+
+Wraps :class:`clawmes.services.base_account.BaseAccountService` in
+the standard :class:`clawmes.wallet._base.WalletMode` shape so every
+clawmes tool can treat Base Account as just another wallet mode
+alongside WalletConnect, local-key, and Bankr.
+
+Flow:
+
+  1. ``connect`` returns immediately with an authorization URL the
+     user should visit. The actual access token isn't set until the
+     user completes OAuth and the caller invokes ``connect_with_code``.
+  2. ``send_transaction`` / signing operations POST to Base Account's
+     stored-request endpoint. The user approves in Base App.
+
+Approval UX: every tx + signature triggers a Base App approval. Same
+shape as WalletConnect's "tx goes to your phone" model — clawmes
+never holds the user's private key.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from clawmes.lib.logger import logger_for
+from clawmes.services.base_account import BaseAccountError, get_base_account_service
+from clawmes.wallet._base import WalletMode
+from clawmes.wallet.state import WalletState
+
+_log = logger_for("wallet.base_account")
+
+#: Default chain for Base Account. The wallet is Base-native; cross-chain
+#: support is gated on Coinbase exposing it server-side.
+_DEFAULT_CHAIN_ID = 8453
+
+
+class BaseAccountMode(WalletMode):
+    name = "base_account"
+
+    def __init__(self) -> None:
+        self._state = WalletState.disconnected()
+        self._pending_auth_url: str | None = None
+
+    # ── lifecycle ───────────────────────────────────────────────────
+
+    def connect(self, **kwargs: Any) -> WalletState:
+        """Start the OAuth flow.
+
+        Returns a ``disconnected`` :class:`WalletState` (since OAuth
+        is async / out-of-band) but stashes the authorize URL on the
+        mode so the caller can read it via :meth:`get_pending_auth_url`.
+        """
+        del kwargs
+        svc = get_base_account_service()
+        self._pending_auth_url = svc.get_auth_url()
+        _log.info("base_account oauth pending; user must visit auth URL")
+        return self._state
+
+    def connect_with_code(self, code: str, *, chain_id: int | None = None) -> WalletState:
+        """Complete the OAuth code exchange and materialize wallet state.
+
+        Called after the user visits ``get_pending_auth_url()`` and
+        retrieves the ``code`` query param from the redirect.
+        """
+        svc = get_base_account_service()
+        svc.exchange_code(code)
+        address = svc.get_user_address()
+
+        target_chain = int(chain_id or _DEFAULT_CHAIN_ID)
+        from clawmes.lib.chains import get_chain
+
+        try:
+            chain_name = get_chain(target_chain).name
+        except KeyError:
+            chain_name = f"chain {target_chain}"
+
+        self._state = WalletState(
+            connected=True,
+            mode="base_account",
+            address=address,
+            chain_id=target_chain,
+            chain_name=chain_name,
+        )
+        self._pending_auth_url = None
+        _log.info("base_account connected: %s on %s", address, chain_name)
+        return self._state
+
+    def disconnect(self) -> None:
+        get_base_account_service().stop()
+        self._state = WalletState.disconnected()
+        self._pending_auth_url = None
+
+    def state(self) -> WalletState:
+        return self._state
+
+    def get_pending_auth_url(self) -> str | None:
+        """Return the OAuth URL the user needs to visit, if any."""
+        return self._pending_auth_url
+
+    # ── signing / sending ───────────────────────────────────────────
+
+    def send_transaction(
+        self,
+        *,
+        to: str,
+        value: int,
+        data: bytes | str = b"",
+        chain_id: int | None = None,
+        gas: int | None = None,
+        max_fee_per_gas: int | None = None,
+        max_priority_fee_per_gas: int | None = None,
+    ) -> str:
+        if not self._state.connected:
+            raise BaseAccountError(
+                "not_connected", "Base Account not connected. Run /connect_base."
+            )
+        del max_fee_per_gas, max_priority_fee_per_gas  # Base Account manages gas
+        target_chain = chain_id or self._state.chain_id or _DEFAULT_CHAIN_ID
+
+        # Normalize calldata for JSON-RPC: hex string with 0x prefix.
+        if isinstance(data, bytes):
+            data_hex = "0x" + data.hex()
+        else:
+            data_hex = data if data.startswith("0x") else "0x" + data
+
+        # eth_sendTransaction shape — most common request method for
+        # Base Account's stored-request flow per the Base MCP spec.
+        params: list[Any] = [
+            {
+                "from": self._state.address,
+                "to": to,
+                "value": hex(value) if value else "0x0",
+                "data": data_hex,
+                "chainId": hex(target_chain),
+            }
+        ]
+        if gas is not None:
+            params[0]["gas"] = hex(gas)
+
+        svc = get_base_account_service()
+        submitted = svc.submit_request(method="eth_sendTransaction", params=params)
+        approval_url = submitted.get("approval_url")
+        request_id = submitted["request_id"]
+        if approval_url:
+            _log.info("base_account approval required for %s: %s", request_id, approval_url)
+        confirmed = svc.poll_request(request_id)
+        tx_hash = confirmed.get("result") or confirmed.get("tx_hash")
+        if not isinstance(tx_hash, str) or not tx_hash:
+            raise BaseAccountError(
+                "request_failed",
+                f"approved request returned no tx hash: {confirmed!r}",
+            )
+        return tx_hash
+
+    def sign_typed_data_v4(self, typed_data: dict[str, Any]) -> str:
+        if not self._state.connected:
+            raise BaseAccountError("not_connected", "Base Account not connected")
+        svc = get_base_account_service()
+        submitted = svc.submit_request(
+            method="eth_signTypedData_v4",
+            params=[self._state.address, json.dumps(typed_data)],
+        )
+        confirmed = svc.poll_request(submitted["request_id"])
+        sig = confirmed.get("result") or confirmed.get("signature")
+        if not isinstance(sig, str) or not sig:
+            raise BaseAccountError(
+                "request_failed", f"signTypedData returned no signature: {confirmed!r}"
+            )
+        return sig
+
+    def sign_personal_message(self, message: bytes | str) -> str:
+        if not self._state.connected:
+            raise BaseAccountError("not_connected", "Base Account not connected")
+        # personal_sign expects (message_hex, address) in JSON-RPC.
+        if isinstance(message, bytes):
+            message_hex = "0x" + message.hex()
+        else:
+            message_hex = message if message.startswith("0x") else "0x" + message.encode().hex()
+        svc = get_base_account_service()
+        submitted = svc.submit_request(
+            method="personal_sign",
+            params=[message_hex, self._state.address],
+        )
+        confirmed = svc.poll_request(submitted["request_id"])
+        sig = confirmed.get("result") or confirmed.get("signature")
+        if not isinstance(sig, str) or not sig:
+            raise BaseAccountError(
+                "request_failed", f"personal_sign returned no signature: {confirmed!r}"
+            )
+        return sig
+
+    def switch_chain(self, chain_id: int) -> WalletState:
+        """Switch the active chain — pure metadata update.
+
+        Base Account exposes the same wallet address across every chain
+        it supports; switching is just changing what chain id we hand
+        to subsequent JSON-RPC requests.
+        """
+        if not self._state.connected:
+            raise BaseAccountError("not_connected", "Base Account not connected")
+        from clawmes.lib.chains import get_chain
+
+        try:
+            chain_name = get_chain(chain_id).name
+        except KeyError:
+            chain_name = f"chain {chain_id}"
+        self._state = WalletState(
+            connected=True,
+            mode="base_account",
+            address=self._state.address,
+            chain_id=chain_id,
+            chain_name=chain_name,
+            balances=self._state.balances,
+            policy_names=self._state.policy_names,
+        )
+        return self._state

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.4.0
+version: 0.5.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ dev = [
     "pytest-cov>=5.0",
     "ruff>=0.5",
     "mypy>=1.10",
+    # MCP SDK is in dev so tests/mcp_server/* can import it; the same
+    # SDK ships under the [mcp] extra for production use of the
+    # clawmes-mcp script entry.
+    "mcp>=1.0",
 ]
 test-network = [
     "responses>=0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.4.0"
+version = "0.5.0"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }
@@ -64,12 +64,27 @@ test-network = [
     "responses>=0.25",
     "vcrpy>=6.0",
 ]
+# Optional: expose clawmes' read tools as an MCP server for desktop AI
+# clients (Claude Desktop, Cursor, ChatGPT). Install with:
+#   pip install clawmes[mcp]
+# Run with:
+#   clawmes-mcp
+mcp = [
+    "mcp>=1.0",
+]
 all = [
-    "clawmes[dev,test-network]",
+    "clawmes[dev,test-network,mcp]",
 ]
 
 [project.entry-points."hermes_agent.plugins"]
 clawmes = "clawmes"
+
+[project.scripts]
+# `clawmes-mcp` exposes clawmes' read tools to MCP-compatible clients
+# (Claude Desktop, Cursor, ChatGPT). Requires the [mcp] extra to be
+# installed; otherwise the import fails at runtime with a clear message
+# pointing the user at the install command.
+clawmes-mcp = "clawmes.mcp_server:main"
 
 [project.urls]
 Homepage = "https://clawnch.dev"

--- a/tests/commands/test_burn.py
+++ b/tests/commands/test_burn.py
@@ -40,6 +40,7 @@ def fake_wallet(monkeypatch):
         def __init__(self, mode):
             self._mode = mode
 
+        @property
         def active_mode(self):
             return self._mode
 
@@ -145,6 +146,7 @@ class TestSubmit:
             return WalletState.for_chain(mode="local", address="0x" + "1" * 40, chain_id=8453)
 
         class _Svc:
+            @property
             def active_mode(self):
                 return None
 

--- a/tests/commands/test_launch.py
+++ b/tests/commands/test_launch.py
@@ -379,6 +379,7 @@ class TestBurn:
 
         def _get_svc():
             class _S:
+                @property
                 def active_mode(self_inner):  # noqa: ARG002, N805
                     return _FakeMode()
 
@@ -418,6 +419,7 @@ class TestBurn:
             return WalletState.for_chain(mode="local", address="0x" + "1" * 40, chain_id=8453)
 
         class _Svc:
+            @property
             def active_mode(self):
                 return None
 
@@ -439,6 +441,7 @@ class TestBurn:
                 raise RuntimeError("rpc down")
 
         class _Svc:
+            @property
             def active_mode(self):
                 return _FakeMode()
 
@@ -580,6 +583,7 @@ class TestNonCustodialConfirm:
                 return state["tx_hash"]
 
         class _Svc:
+            @property
             def active_mode(self_inner):  # noqa: ARG002, N805
                 return _FakeMode() if not state.get("none_mode") else None
 
@@ -858,6 +862,128 @@ class TestExport:
 
 
 # ── /launch alerts ─────────────────────────────────────────────────
+
+
+class TestCheck:
+    """`/launch check` — pre-flight validation."""
+
+    @pytest.fixture
+    def fake_wallet_optional(self, monkeypatch):
+        from clawmes.services import wallet as ws_mod
+        from clawmes.wallet.state import WalletState
+
+        state: dict = {"connected": False, "address": "0x" + "1" * 40}
+
+        def _state():
+            if state["connected"]:
+                return WalletState.for_chain(mode="local", address=state["address"], chain_id=8453)
+            return WalletState.disconnected()
+
+        monkeypatch.setattr(ws_mod, "get_wallet_state", _state)
+        return state
+
+    @pytest.fixture
+    def fake_prepare_for_check(self, monkeypatch):
+        state: dict = {"raise": None, "return": None}
+
+        class _Svc:
+            def prepare_deploy(self_inner, **kwargs):  # noqa: ARG002, N805
+                if state["raise"]:
+                    raise state["raise"]
+                return state["return"] or {
+                    "ok": True,
+                    "data": {"to": "0xE85A", "data": "0xdf40", "value": "0x0", "chainId": 8453},
+                    "meta": {
+                        "platformFeeBps": 2000,
+                        "userFeeBps": 8000,
+                        "vaultPercentage": 0,
+                    },
+                }
+
+        import clawmes.services.clawnch as cl_mod
+
+        monkeypatch.setattr(cl_mod, "get_clawnch_service", lambda: _Svc())
+        return state
+
+    async def test_no_draft(self):
+        out = await launch_mod.handle_launch("check", sender_id="alice")
+        assert "Check needs at minimum" in out
+
+    async def test_basic_check(self, fake_wallet_optional, fake_prepare_for_check):
+        fake_wallet_optional["connected"] = True
+        await launch_mod.handle_launch("name MyCoin", sender_id="alice")
+        await launch_mod.handle_launch("symbol MC", sender_id="alice")
+        out = await launch_mod.handle_launch("check", sender_id="alice")
+        assert "Pre-flight OK" in out
+        assert "MyCoin" in out
+        assert "80% you / 20% Clawnch" in out
+        assert "Vault:      0%" in out
+
+    async def test_with_vault_percentage(self, fake_wallet_optional, fake_prepare_for_check):
+        fake_wallet_optional["connected"] = True
+        fake_prepare_for_check["return"] = {
+            "ok": True,
+            "data": {"to": "0xE85A", "data": "0xdf40", "value": "0x0", "chainId": 8453},
+            "meta": {
+                "platformFeeBps": 2000,
+                "userFeeBps": 8000,
+                "vaultPercentage": 5,
+            },
+        }
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("check", sender_id="alice")
+        assert "Vault:      5%" in out
+
+    async def test_burn_no_vault(self, fake_wallet_optional, fake_prepare_for_check):
+        # burn tx recorded on the draft but the meta returns 0% (e.g. burn was too small)
+        fake_wallet_optional["connected"] = True
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        launch_mod._log_state["alice"]["burn_tx_hash"] = "0x" + "a" * 64
+        out = await launch_mod.handle_launch("check", sender_id="alice")
+        assert "produced no vault" in out
+
+    async def test_no_wallet_warning(self, fake_wallet_optional, fake_prepare_for_check):
+        fake_wallet_optional["connected"] = False
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("check", sender_id="alice")
+        assert "No wallet connected" in out
+
+    async def test_bad_request(self, fake_wallet_optional, fake_prepare_for_check):
+        fake_wallet_optional["connected"] = True
+        fake_prepare_for_check["raise"] = ClawnchError("bad_request", "bad name")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("check", sender_id="alice")
+        assert "Check failed (bad_request)" in out
+        assert "re-run /launch check" in out
+
+    async def test_rate_limited(self, fake_wallet_optional, fake_prepare_for_check):
+        fake_wallet_optional["connected"] = True
+        fake_prepare_for_check["raise"] = ClawnchError("rate_limited", "cap hit")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("check", sender_id="alice")
+        assert "rate_limited" in out
+        assert "00:00 UTC" in out
+
+    async def test_other_error(self, fake_wallet_optional, fake_prepare_for_check):
+        fake_wallet_optional["connected"] = True
+        fake_prepare_for_check["raise"] = ClawnchError("api_error", "down")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("check", sender_id="alice")
+        assert "params look OK" in out
+
+    async def test_unexpected_error(self, fake_wallet_optional, fake_prepare_for_check):
+        fake_wallet_optional["connected"] = True
+        fake_prepare_for_check["raise"] = RuntimeError("boom")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("check", sender_id="alice")
+        assert "Check failed" in out
 
 
 class TestAlerts:

--- a/tests/commands/test_onramp.py
+++ b/tests/commands/test_onramp.py
@@ -1,0 +1,139 @@
+"""Tests for the /onramp slash command."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.commands import onramp as onramp_mod
+from clawmes.wallet.state import WalletState
+
+
+@pytest.fixture
+def fake_wallet(monkeypatch):
+    state: dict = {"connected": False, "address": "0x" + "1" * 40}
+
+    def _state():
+        if state["connected"]:
+            return WalletState.for_chain(mode="local", address=state["address"], chain_id=8453)
+        return WalletState.disconnected()
+
+    monkeypatch.setattr(onramp_mod, "get_wallet_state", _state)
+    return state
+
+
+# ── parse_amount ───────────────────────────────────────────────────
+
+
+class TestParseAmount:
+    def test_empty(self):
+        assert onramp_mod._parse_amount("") is None
+        assert onramp_mod._parse_amount("   ") is None
+
+    def test_valid(self):
+        assert onramp_mod._parse_amount("25") == 25.0
+        assert onramp_mod._parse_amount("100.50") == 100.50
+
+    def test_invalid_string(self):
+        out = onramp_mod._parse_amount("garbage")
+        assert isinstance(out, str)
+        assert "Invalid amount" in out
+
+    def test_negative(self):
+        out = onramp_mod._parse_amount("-5")
+        assert isinstance(out, str)
+        assert "Must be positive" in out
+
+    def test_zero(self):
+        out = onramp_mod._parse_amount("0")
+        assert isinstance(out, str)
+        assert "Must be positive" in out
+
+
+# ── _build_onramp_url ──────────────────────────────────────────────
+
+
+class TestBuildUrl:
+    def test_no_app_id_returns_fallback(self, monkeypatch):
+        monkeypatch.delenv("CLAWMES_COINBASE_ONRAMP_APP_ID", raising=False)
+        url = onramp_mod._build_onramp_url(address="0xabc", amount="25")
+        assert url == onramp_mod._FALLBACK_LANDING
+
+    def test_with_app_id_includes_params(self, monkeypatch):
+        monkeypatch.setenv("CLAWMES_COINBASE_ONRAMP_APP_ID", "my-app-id")
+        url = onramp_mod._build_onramp_url(address="0xabc", amount="50")
+        assert url.startswith(onramp_mod._ONRAMP_BASE_URL)
+        assert "appId=my-app-id" in url
+        assert "0xabc" in url
+        assert "50" in url
+        assert "base" in url
+
+
+# ── handle_onramp ──────────────────────────────────────────────────
+
+
+class TestHandleOnramp:
+    async def test_invalid_amount(self, fake_wallet):
+        out = await onramp_mod.handle_onramp("garbage")
+        assert "Invalid amount" in out
+
+    async def test_no_wallet_shows_fallback(self, fake_wallet):
+        fake_wallet["connected"] = False
+        out = await onramp_mod.handle_onramp("25")
+        assert "No wallet connected" in out
+        assert onramp_mod._FALLBACK_LANDING in out
+
+    async def test_wallet_connected_no_app_id(self, fake_wallet, monkeypatch):
+        fake_wallet["connected"] = True
+        monkeypatch.delenv("CLAWMES_COINBASE_ONRAMP_APP_ID", raising=False)
+        out = await onramp_mod.handle_onramp("50")
+        assert "Coinbase Onramp link" in out
+        assert "50" in out
+        # Fallback URL because APP_ID isn't configured
+        assert onramp_mod._FALLBACK_LANDING in out
+        assert "CLAWMES_COINBASE_ONRAMP_APP_ID" in out
+
+    async def test_wallet_connected_with_app_id(self, fake_wallet, monkeypatch):
+        fake_wallet["connected"] = True
+        monkeypatch.setenv("CLAWMES_COINBASE_ONRAMP_APP_ID", "test-app")
+        out = await onramp_mod.handle_onramp("100")
+        assert onramp_mod._ONRAMP_BASE_URL in out
+        # No warning about missing APP_ID since it's configured
+        assert "not configured" not in out
+
+    async def test_default_amount_from_env(self, fake_wallet, monkeypatch):
+        fake_wallet["connected"] = True
+        monkeypatch.setenv("CLAWMES_COINBASE_ONRAMP_APP_ID", "test-app")
+        monkeypatch.setenv("CLAWMES_COINBASE_ONRAMP_DEFAULT_AMOUNT", "75")
+        out = await onramp_mod.handle_onramp("")
+        assert "75" in out
+
+    async def test_default_amount_fallback(self, fake_wallet, monkeypatch):
+        fake_wallet["connected"] = True
+        monkeypatch.setenv("CLAWMES_COINBASE_ONRAMP_APP_ID", "test-app")
+        monkeypatch.delenv("CLAWMES_COINBASE_ONRAMP_DEFAULT_AMOUNT", raising=False)
+        out = await onramp_mod.handle_onramp("")
+        assert onramp_mod._DEFAULT_AMOUNT_USD in out
+
+
+class TestRecordingBestEffort:
+    async def test_recording_failure(self, monkeypatch, fake_wallet):
+        from clawmes.services import command_history as ch_mod
+
+        def _boom(*a, **kw):
+            raise RuntimeError("history broken")
+
+        monkeypatch.setattr(ch_mod, "record_command_call", _boom)
+        out = await onramp_mod.handle_onramp("")
+        assert isinstance(out, str)
+
+
+class TestRegister:
+    def test_registers(self):
+        captured = []
+
+        class FakeCtx:
+            def register_command(self, **kw):
+                captured.append(kw["name"])
+
+        onramp_mod.register(FakeCtx())
+        assert captured == ["onramp"]

--- a/tests/commands/test_wallet.py
+++ b/tests/commands/test_wallet.py
@@ -468,7 +468,7 @@ class TestAddress:
 
 
 class TestRegister:
-    def test_registers_eight_commands(self):
+    def test_registers_nine_commands(self):
         recorded = []
 
         class FakeCtx:
@@ -481,6 +481,7 @@ class TestRegister:
             "connect",
             "connect_local",
             "connect_bankr",
+            "connect_base",
             "disconnect",
             "mode",
             "chain",
@@ -533,3 +534,96 @@ class TestConnectLocal:
         out = await wallet_cmd.handle_connect_local("hunter2")
         assert "Local wallet load failed" in out
         assert "no local keystore found" in out
+
+
+class TestConnectBase:
+    """``/connect_base`` — Coinbase Smart Wallet OAuth flow."""
+
+    @pytest.fixture
+    def _isolate_svc(self, monkeypatch):
+        from clawmes.services import base_account as ba_mod
+        from clawmes.services import wallet as wallet_svc
+
+        monkeypatch.setattr(ba_mod, "_instance", None)
+        monkeypatch.setattr(wallet_svc, "_instance", None)
+
+    @pytest.mark.asyncio
+    async def test_no_args_starts_oauth_with_config(self, monkeypatch, _isolate_svc):
+        monkeypatch.setenv("CLAWMES_BASE_ACCOUNT_CLIENT_ID", "my-client")
+        out = await wallet_cmd.handle_connect_base("")
+        assert "Open this URL" in out
+        assert "client_id=my-client" in out
+
+    @pytest.mark.asyncio
+    async def test_no_args_not_configured(self, monkeypatch, _isolate_svc):
+        monkeypatch.delenv("CLAWMES_BASE_ACCOUNT_CLIENT_ID", raising=False)
+        out = await wallet_cmd.handle_connect_base("")
+        assert "CLAWMES_BASE_ACCOUNT_CLIENT_ID" in out
+        assert "Coinbase Developer Platform" in out
+
+    @pytest.mark.asyncio
+    async def test_code_exchange_no_prior_connect(self, monkeypatch, _isolate_svc):
+        monkeypatch.setenv("CLAWMES_BASE_ACCOUNT_CLIENT_ID", "my-client")
+        # Without a prior connect_base_account, the mode isn't active
+        out = await wallet_cmd.handle_connect_base("some_code")
+        assert "Base Account code exchange failed" in out
+
+    @pytest.mark.asyncio
+    async def test_code_exchange_happy_path(self, monkeypatch, _isolate_svc):
+        from clawmes.services import base_account as ba_mod
+
+        monkeypatch.setenv("CLAWMES_BASE_ACCOUNT_CLIENT_ID", "my-client")
+        # Stub the OAuth token exchange
+        monkeypatch.setattr(
+            ba_mod,
+            "http_post",
+            lambda *a, **k: {"access_token": "tok", "address": "0x" + "9" * 40},
+        )
+        # Step 1: initiate OAuth (no args)
+        await wallet_cmd.handle_connect_base("")
+        # Step 2: exchange code
+        out = await wallet_cmd.handle_connect_base("auth-code-from-redirect")
+        assert "Base Account connected" in out
+        assert "0x" + "9" * 40 in out
+        assert "Tx + signature requests" in out
+
+    @pytest.mark.asyncio
+    async def test_other_oauth_error(self, monkeypatch, _isolate_svc):
+        # Configure the env var so the first call succeeds, then inject
+        # an unrelated BaseAccountError on the first call instead of
+        # not_configured to hit the generic "connect failed" branch.
+        monkeypatch.setenv("CLAWMES_BASE_ACCOUNT_CLIENT_ID", "my-client")
+        from clawmes.services import wallet as wallet_svc
+        from clawmes.services.base_account import BaseAccountError
+
+        def _boom(*a, **kw):
+            raise BaseAccountError("api_error", "something else broke")
+
+        # Patch the service convenience method to raise the non-config error
+        svc = wallet_svc.get_wallet_service()
+        monkeypatch.setattr(svc, "connect_base_account", _boom)
+        out = await wallet_cmd.handle_connect_base("")
+        assert "Base Account connect failed" in out
+        assert "something else broke" in out
+
+
+class TestDisconnectBaseAccount:
+    @pytest.mark.asyncio
+    async def test_renders_base_account_label(self, monkeypatch):
+        from clawmes.services import wallet as wallet_svc
+        from clawmes.wallet.state import WalletState
+
+        # Fake an active base_account session that gets disconnected
+        monkeypatch.setattr(wallet_svc, "_instance", None)
+        svc = wallet_svc.get_wallet_service()
+
+        prior = WalletState(
+            connected=True,
+            mode="base_account",
+            address="0x" + "1" * 40,
+            chain_id=8453,
+            chain_name="base",
+        )
+        monkeypatch.setattr(svc, "disconnect", lambda: prior)
+        out = await wallet_cmd.handle_disconnect("")
+        assert "Base Account session" in out

--- a/tests/lib/test_base_app.py
+++ b/tests/lib/test_base_app.py
@@ -1,0 +1,37 @@
+"""Tests for clawmes.lib.base_app."""
+
+from __future__ import annotations
+
+from clawmes.lib import base_app
+
+
+class TestTokenUrl:
+    def test_default_template(self, monkeypatch):
+        monkeypatch.delenv("CLAWMES_BASE_APP_TOKEN_URL", raising=False)
+        url = base_app.token_url("0x" + "a" * 40)
+        assert url == "https://base.app/?token=0x" + "a" * 40
+
+    def test_empty_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("CLAWMES_BASE_APP_TOKEN_URL", raising=False)
+        assert base_app.token_url("") == ""
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("CLAWMES_BASE_APP_TOKEN_URL", "https://staging.base.app/t/{address}")
+        url = base_app.token_url("0xabc")
+        assert url == "https://staging.base.app/t/0xabc"
+
+
+class TestTxUrl:
+    def test_default_template(self, monkeypatch):
+        monkeypatch.delenv("CLAWMES_BASE_APP_TX_URL", raising=False)
+        url = base_app.tx_url("0xtx")
+        assert url == "https://base.app/?tx=0xtx"
+
+    def test_empty_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("CLAWMES_BASE_APP_TX_URL", raising=False)
+        assert base_app.tx_url("") == ""
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("CLAWMES_BASE_APP_TX_URL", "https://staging.base.app/tx/{tx_hash}")
+        url = base_app.tx_url("0xabc")
+        assert url == "https://staging.base.app/tx/0xabc"

--- a/tests/lib/test_base_builder.py
+++ b/tests/lib/test_base_builder.py
@@ -1,0 +1,34 @@
+"""Tests for clawmes.lib.base_builder."""
+
+from __future__ import annotations
+
+from clawmes.lib.base_builder import BASE_BUILDER_CODE, append_builder_code
+
+
+class TestAppendBuilderCode:
+    def test_appends_on_base(self):
+        out = append_builder_code("0xdeadbeef", 8453)
+        assert out.startswith("0xdeadbeef")
+        assert out.endswith(BASE_BUILDER_CODE[2:])
+
+    def test_pass_through_on_other_chains(self):
+        assert append_builder_code("0xdeadbeef", 1) == "0xdeadbeef"
+        assert append_builder_code("0xdeadbeef", 42161) == "0xdeadbeef"
+
+    def test_pass_through_on_none_chain(self):
+        assert append_builder_code("0xdeadbeef", None) == "0xdeadbeef"
+
+    def test_adds_prefix_to_raw_hex(self):
+        # Defensive — if a caller forgets the 0x prefix, we add it
+        # before appending so the output is well-formed.
+        out = append_builder_code("deadbeef", 8453)
+        assert out.startswith("0xdeadbeef")
+        assert out.endswith(BASE_BUILDER_CODE[2:])
+
+    def test_constant_shape(self):
+        # Sanity: the suffix is hex-prefixed and even-length so it slices
+        # cleanly into bytes when appended to other calldata.
+        assert BASE_BUILDER_CODE.startswith("0x")
+        body = BASE_BUILDER_CODE[2:]
+        assert len(body) % 2 == 0
+        assert all(c in "0123456789abcdefABCDEF" for c in body)

--- a/tests/lib/test_ens.py
+++ b/tests/lib/test_ens.py
@@ -186,3 +186,35 @@ class TestResolve:
         monkeypatch.setattr(eth_utils, "to_checksum_address", bad_checksum)
         addr = resolve("vitalik.eth")
         assert addr == "0x" + "b" * 40
+
+    def test_basename_routes_to_base_l2(self, fake_rpc):
+        # .base.eth names should query the BASE_ENS_REGISTRY on chain 8453
+        from clawmes.lib.ens import BASE_ENS_REGISTRY
+
+        resolver = "0x" + "0" * 24 + "f" * 40
+        user_addr = "0x" + "0" * 24 + "c" * 40
+        fake_rpc.responses = [resolver, user_addr]
+        addr = resolve("jesse.base.eth")
+        # eth_utils returns mixed-case checksum — just verify it's the
+        # same underlying address (case-insensitive comparison).
+        assert addr.lower() == "0x" + "c" * 40
+        # Both eth_calls should hit Base mainnet (chain_id=8453) on the
+        # Base ENS Registry, not the Ethereum mainnet registry.
+        assert fake_rpc.calls[0]["chain_id"] == 8453
+        assert fake_rpc.calls[0]["to"] == BASE_ENS_REGISTRY
+        assert fake_rpc.calls[1]["chain_id"] == 8453
+
+
+class TestIsBasename:
+    def test_yes(self):
+        from clawmes.lib.ens import is_basename
+
+        assert is_basename("jesse.base.eth")
+        assert is_basename("JESSE.BASE.ETH")
+
+    def test_no(self):
+        from clawmes.lib.ens import is_basename
+
+        assert not is_basename("vitalik.eth")
+        assert not is_basename("foo.bar")
+        assert not is_basename("")

--- a/tests/lib/test_x402.py
+++ b/tests/lib/test_x402.py
@@ -1,0 +1,123 @@
+"""Tests for clawmes.lib.x402."""
+
+from __future__ import annotations
+
+from clawmes.lib.x402 import (
+    X402Challenge,
+    format_challenge,
+    is_x402_response,
+    parse_challenge,
+)
+
+
+class TestIsX402Response:
+    def test_status_402(self):
+        assert is_x402_response({}, status_code=402)
+
+    def test_accepts_in_body(self):
+        assert is_x402_response({"accepts": [{"network": "base"}]})
+
+    def test_not_a_dict(self):
+        assert not is_x402_response("string", status_code=200)
+        assert not is_x402_response(None, status_code=200)
+
+    def test_no_accepts(self):
+        assert not is_x402_response({"foo": "bar"}, status_code=200)
+
+    def test_empty_accepts(self):
+        assert not is_x402_response({"accepts": []}, status_code=200)
+
+
+class TestParseChallenge:
+    def test_filters_non_dict_options(self):
+        body = {"accepts": [{"network": "base", "asset": "USDC"}, "garbage", None]}
+        challenge = parse_challenge(body)
+        assert len(challenge.accepts) == 1
+
+    def test_preserves_raw(self):
+        body = {"accepts": [], "extra": "field"}
+        challenge = parse_challenge(body)
+        assert challenge.raw is body
+
+
+class TestPrimary:
+    def test_no_options(self):
+        challenge = X402Challenge(accepts=(), raw={})
+        assert challenge.primary() is None
+
+    def test_prefers_base_usdc(self):
+        challenge = X402Challenge(
+            accepts=(
+                {"network": "ethereum", "asset": "ETH"},
+                {"network": "base", "asset": "USDC", "amount": "1"},
+            ),
+            raw={},
+        )
+        primary = challenge.primary()
+        assert primary["asset"] == "USDC"
+
+    def test_falls_back_to_first(self):
+        challenge = X402Challenge(
+            accepts=({"network": "ethereum", "asset": "ETH"},),
+            raw={},
+        )
+        primary = challenge.primary()
+        assert primary["asset"] == "ETH"
+
+
+class TestFormatChallenge:
+    def test_no_options(self):
+        challenge = X402Challenge(accepts=(), raw={})
+        out = format_challenge(challenge)
+        assert "no acceptable payment options" in out
+
+    def test_basic(self):
+        challenge = X402Challenge(
+            accepts=(
+                {
+                    "network": "base",
+                    "asset": "USDC",
+                    "maxAmountRequired": "1.50",
+                    "payTo": "0x" + "a" * 40,
+                },
+            ),
+            raw={},
+        )
+        out = format_challenge(challenge)
+        assert "1.50" in out
+        assert "USDC" in out
+        assert "base" in out
+        assert "0xaaaaaaaa" in out
+
+    def test_with_description_and_alternates(self):
+        challenge = X402Challenge(
+            accepts=(
+                {
+                    "network": "base",
+                    "asset": "USDC",
+                    "amount": "1.00",
+                    "recipient": "0xabc",
+                    "description": "Premium oracle access",
+                },
+                {"network": "ethereum", "asset": "ETH", "amount": "0.001"},
+            ),
+            raw={},
+        )
+        out = format_challenge(challenge)
+        assert "Premium oracle access" in out
+        assert "1 alternate" in out
+
+    def test_missing_fields_render_question_marks(self):
+        # A dict with only a network key still counts as a payment option;
+        # missing fields show up as "?" rather than crashing.
+        challenge = X402Challenge(accepts=({"network": "base"},), raw={})
+        out = format_challenge(challenge)
+        assert "?" in out
+        assert "base" in out
+
+    def test_falsy_primary_renders_no_options(self):
+        # Empty dict is falsy → primary() returns it, the formatter
+        # treats it as "no options."
+        challenge = X402Challenge(accepts=({},), raw={})
+        out = format_challenge(challenge)
+        assert "no acceptable payment options" in out

--- a/tests/mcp_server/test_server.py
+++ b/tests/mcp_server/test_server.py
@@ -1,0 +1,215 @@
+"""Tests for clawmes.mcp.server."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes import mcp_server as mcp_pkg
+from clawmes.mcp_server import server as srv
+
+
+class TestToolList:
+    def test_lists_all_factories(self):
+        tools = srv._build_tool_list()
+        names = [t.name for t in tools]
+        for expected in (
+            "defi_price",
+            "defi_balance",
+            "market_intel",
+            "clawnch_launch",
+            "clawnch_fees",
+            "bv7x_oracle",
+            "bv7x_market",
+            "nft",
+            "block_explorer",
+            "cost_basis",
+        ):
+            assert expected in names
+
+    def test_tool_has_schema(self):
+        tools = srv._build_tool_list()
+        for t in tools:
+            assert isinstance(t.inputSchema, dict)
+            assert t.description  # all tools have descriptions
+
+    def test_skips_tools_without_meta(self, monkeypatch):
+        # Defensive — a factory that returns a non-decorated function
+        # should be silently skipped, not crash the list.
+        def _bad_factory():
+            return lambda args, **kw: '{"ok": true}'
+
+        monkeypatch.setitem(srv._TOOL_FACTORIES, "bogus", _bad_factory)
+        tools = srv._build_tool_list()
+        names = [t.name for t in tools]
+        assert "bogus" not in names
+
+
+class TestCallTool:
+    def test_unknown_tool(self):
+        out = srv._call_tool("not_a_real_tool", {})
+        import json
+
+        body = json.loads(out)
+        assert body["isError"] is True
+        assert "Unknown" in body["content"][0]["text"]
+
+    def test_dispatches_to_real_tool(self):
+        # defi_balance with no args should bounce on schema validation —
+        # but the call should still return a JSON envelope (no exception).
+        out = srv._call_tool("defi_balance", {})
+        import json
+
+        body = json.loads(out)
+        assert isinstance(body, dict)
+        # Either isError true (no wallet etc.) or a valid envelope
+        assert "isError" in body or "content" in body
+
+    def test_handles_runtime_error(self, monkeypatch):
+        def _boom_factory():
+            def _fn(args, **kwargs):
+                raise RuntimeError("kaboom")
+
+            _fn._clawmes_meta = {"description": "boom", "schema": {}}  # type: ignore[attr-defined]
+            return _fn
+
+        monkeypatch.setitem(srv._TOOL_FACTORIES, "_boom_test", _boom_factory)
+        out = srv._call_tool("_boom_test", {})
+        import json
+
+        body = json.loads(out)
+        assert body["isError"] is True
+        assert "kaboom" in body["content"][0]["text"]
+
+
+class TestBuildServer:
+    def test_returns_a_server(self):
+        s = srv.build_server()
+        # Just verify the type — actual stdio plumbing is tested via
+        # the smoke-test in the README. The server lifecycle test
+        # would require running asyncio + faking stdio streams.
+        assert s.name == "clawmes"
+
+    @pytest.mark.asyncio
+    async def test_list_tools_handler(self):
+        # Exercise the registered list_tools handler — the decorator
+        # stores it on the Server's request handlers map; we walk it.
+        s = srv.build_server()
+        # The mcp SDK stores handlers in s.request_handlers keyed by request
+        # type. We pull the list_tools handler and invoke it.
+        from mcp.types import ListToolsRequest
+
+        # Find the ListTools handler the decorator registered
+        handlers = s.request_handlers
+        handler = handlers.get(ListToolsRequest)
+        assert handler is not None
+
+    @pytest.mark.asyncio
+    async def test_call_tool_handler_wraps_text_content(self):
+        s = srv.build_server()
+        from mcp.types import CallToolRequest
+
+        handler = s.request_handlers.get(CallToolRequest)
+        assert handler is not None
+
+
+class TestImporters:
+    """The factories that lazy-import tools shouldn't crash on import."""
+
+    @pytest.mark.parametrize("name", list(srv._TOOL_FACTORIES.keys()))
+    def test_factory_returns_callable(self, name):
+        fn = srv._TOOL_FACTORIES[name]()
+        assert callable(fn)
+        assert hasattr(fn, "_clawmes_meta")
+
+
+class TestWrapCallToolResult:
+    def test_wraps_text(self):
+        out = srv._wrap_call_tool_result('{"ok": true}')
+        assert len(out) == 1
+        assert out[0].type == "text"
+        assert out[0].text == '{"ok": true}'
+
+
+class TestServerHandlers:
+    """Exercise the list_tools and call_tool handlers that the
+    ``build_server`` decorator registers."""
+
+    @pytest.mark.asyncio
+    async def test_list_tools_returns_list(self):
+        s = srv.build_server()
+        from mcp.types import ListToolsRequest
+
+        handler = s.request_handlers[ListToolsRequest]
+        # The decorator wraps the user handler — call it via the
+        # registered handler chain. The handler signature expects a
+        # request object.
+        req = ListToolsRequest(method="tools/list", params=None)
+        resp = await handler(req)
+        # ListToolsResult has a tools field
+        assert len(resp.root.tools) > 0
+
+    @pytest.mark.asyncio
+    async def test_call_tool_returns_text_content(self):
+        s = srv.build_server()
+        from mcp.types import CallToolRequest, CallToolRequestParams
+
+        handler = s.request_handlers[CallToolRequest]
+        req = CallToolRequest(
+            method="tools/call",
+            params=CallToolRequestParams(name="defi_balance", arguments={}),
+        )
+        resp = await handler(req)
+        # Result has content list of TextContent
+        content = resp.root.content
+        assert len(content) > 0
+        assert content[0].type == "text"
+
+
+class TestMainEntrypoint:
+    def test_main_is_callable(self):
+        # Just verify the entry point exists and is callable; running it
+        # for real would block on stdin.
+        assert callable(mcp_pkg.main)
+        assert callable(srv.main)
+
+    def test_main_handles_keyboard_interrupt(self, monkeypatch):
+        async def _raise():
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr(srv, "_run", _raise)
+        # Should sys.exit(0), not propagate
+        with pytest.raises(SystemExit) as exc_info:
+            srv.main()
+        assert exc_info.value.code == 0
+
+    @pytest.mark.asyncio
+    async def test_run_wires_stdio_to_server(self, monkeypatch):
+        """``_run`` should construct the server + plug it into stdio."""
+        from contextlib import asynccontextmanager
+
+        ran: dict = {"server_run_called": False}
+
+        class _FakeServer:
+            name = "clawmes"
+
+            def create_initialization_options(self):
+                return {"opts": True}
+
+            async def run(self, read, write, opts):
+                ran["server_run_called"] = True
+                ran["read"] = read
+                ran["write"] = write
+                ran["opts"] = opts
+
+        @asynccontextmanager
+        async def _fake_stdio():
+            yield ("read_stream", "write_stream")
+
+        monkeypatch.setattr(srv, "build_server", lambda: _FakeServer())
+        import mcp.server.stdio as stdio_mod
+
+        monkeypatch.setattr(stdio_mod, "stdio_server", _fake_stdio)
+        await srv._run()
+        assert ran["server_run_called"]
+        assert ran["read"] == "read_stream"
+        assert ran["opts"] == {"opts": True}

--- a/tests/mcp_server/test_server.py
+++ b/tests/mcp_server/test_server.py
@@ -172,6 +172,19 @@ class TestMainEntrypoint:
         assert callable(mcp_pkg.main)
         assert callable(srv.main)
 
+    def test_package_main_delegates_to_server_main(self, monkeypatch):
+        """``clawmes.mcp_server.main`` is a thin lazy-import wrapper
+        that defers to ``clawmes.mcp_server.server.main``. Verify it
+        actually calls through."""
+        called: dict = {"count": 0}
+
+        def _fake_main():
+            called["count"] += 1
+
+        monkeypatch.setattr(srv, "main", _fake_main)
+        mcp_pkg.main()
+        assert called["count"] == 1
+
     def test_main_handles_keyboard_interrupt(self, monkeypatch):
         async def _raise():
             raise KeyboardInterrupt()

--- a/tests/services/test_base_account.py
+++ b/tests/services/test_base_account.py
@@ -1,0 +1,294 @@
+"""Tests for clawmes.services.base_account."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.services import base_account as ba_mod
+from clawmes.services.base_account import BaseAccountError, BaseAccountService
+
+
+@pytest.fixture
+def svc(monkeypatch):
+    # Fresh singleton per test
+    monkeypatch.setattr(ba_mod, "_instance", None)
+    monkeypatch.delenv("CLAWMES_BASE_ACCOUNT_CLIENT_ID", raising=False)
+    monkeypatch.delenv("CLAWMES_BASE_ACCOUNT_AUTH_URL", raising=False)
+    monkeypatch.delenv("CLAWMES_BASE_ACCOUNT_TOKEN_URL", raising=False)
+    monkeypatch.delenv("CLAWMES_BASE_ACCOUNT_API_URL", raising=False)
+    s = BaseAccountService()
+    s.start()
+    return s
+
+
+@pytest.fixture
+def svc_configured(monkeypatch):
+    monkeypatch.setattr(ba_mod, "_instance", None)
+    monkeypatch.setenv("CLAWMES_BASE_ACCOUNT_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("CLAWMES_BASE_ACCOUNT_AUTH_URL", "https://auth.test/authorize")
+    monkeypatch.setenv("CLAWMES_BASE_ACCOUNT_TOKEN_URL", "https://auth.test/token")
+    monkeypatch.setenv("CLAWMES_BASE_ACCOUNT_API_URL", "https://api.test")
+    s = BaseAccountService()
+    s.start()
+    return s
+
+
+# ── lifecycle ─────────────────────────────────────────────────────
+
+
+class TestLifecycle:
+    def test_start_without_client_id(self, svc):
+        # No client id is fine; just means connect will error later
+        assert svc._client_id is None
+
+    def test_start_with_env_overrides(self, svc_configured):
+        assert svc_configured._client_id == "test-client-id"
+        assert svc_configured._auth_url == "https://auth.test/authorize"
+
+    def test_stop_clears_tokens(self, svc_configured):
+        svc_configured._access_token = "tok"
+        svc_configured._user_address = "0xabc"
+        svc_configured.stop()
+        assert svc_configured._access_token is None
+        assert svc_configured._user_address is None
+
+
+# ── auth URL ──────────────────────────────────────────────────────
+
+
+class TestGetAuthUrl:
+    def test_not_configured(self, svc):
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc.get_auth_url()
+        assert exc_info.value.code == "not_configured"
+
+    def test_basic(self, svc_configured):
+        url = svc_configured.get_auth_url()
+        assert "https://auth.test/authorize" in url
+        assert "client_id=test-client-id" in url
+        assert "response_type=code" in url
+
+    def test_with_state(self, svc_configured):
+        url = svc_configured.get_auth_url(state="abc123")
+        assert "state=abc123" in url
+
+
+# ── exchange_code ─────────────────────────────────────────────────
+
+
+class TestExchangeCode:
+    def test_not_configured(self, svc):
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc.exchange_code("abc")
+        assert exc_info.value.code == "not_configured"
+
+    def test_empty_code(self, svc_configured):
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.exchange_code("")
+        assert exc_info.value.code == "oauth_error"
+
+    def test_http_failure(self, svc_configured, monkeypatch):
+        def _boom(*args, **kwargs):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(ba_mod, "http_post", _boom)
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.exchange_code("code")
+        assert exc_info.value.code == "oauth_error"
+
+    def test_no_access_token_in_response(self, svc_configured, monkeypatch):
+        monkeypatch.setattr(ba_mod, "http_post", lambda *a, **k: {"error": "invalid"})
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.exchange_code("code")
+        assert exc_info.value.code == "oauth_error"
+
+    def test_non_dict_response(self, svc_configured, monkeypatch):
+        monkeypatch.setattr(ba_mod, "http_post", lambda *a, **k: ["not", "a", "dict"])
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.exchange_code("code")
+        assert exc_info.value.code == "oauth_error"
+
+    def test_happy_path_stores_tokens(self, svc_configured, monkeypatch):
+        monkeypatch.setattr(
+            ba_mod,
+            "http_post",
+            lambda *a, **k: {
+                "access_token": "acc",
+                "refresh_token": "ref",
+                "expires_in": 3600,
+                "address": "0x" + "1" * 40,
+            },
+        )
+        out = svc_configured.exchange_code("code")
+        assert out["access_token"] == "acc"
+        assert svc_configured._access_token == "acc"
+        assert svc_configured._refresh_token == "ref"
+        assert svc_configured._user_address == "0x" + "1" * 40
+        assert svc_configured._token_expires_at is not None
+
+    def test_happy_path_without_refresh_token(self, svc_configured, monkeypatch):
+        monkeypatch.setattr(
+            ba_mod,
+            "http_post",
+            lambda *a, **k: {"access_token": "acc"},
+        )
+        svc_configured.exchange_code("code")
+        assert svc_configured._refresh_token is None
+        assert svc_configured._token_expires_at is None
+
+
+# ── get_user_address ──────────────────────────────────────────────
+
+
+class TestGetUserAddress:
+    def test_cached(self, svc_configured):
+        svc_configured._access_token = "tok"
+        svc_configured._user_address = "0xabc"
+        assert svc_configured.get_user_address() == "0xabc"
+
+    def test_no_token(self, svc_configured):
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.get_user_address()
+        assert exc_info.value.code == "not_connected"
+
+    def test_fetches_from_api(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+        monkeypatch.setattr(
+            ba_mod,
+            "http_get",
+            lambda *a, **k: {"address": "0xdef"},
+        )
+        assert svc_configured.get_user_address() == "0xdef"
+        # Cached on subsequent calls
+        assert svc_configured._user_address == "0xdef"
+
+    def test_primary_address_field(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+        monkeypatch.setattr(
+            ba_mod,
+            "http_get",
+            lambda *a, **k: {"primary_address": "0xpri"},
+        )
+        assert svc_configured.get_user_address() == "0xpri"
+
+    def test_api_error(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+
+        def _boom(*a, **k):
+            raise RuntimeError("503")
+
+        monkeypatch.setattr(ba_mod, "http_get", _boom)
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.get_user_address()
+        assert exc_info.value.code == "api_error"
+
+    def test_no_address_field(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+        monkeypatch.setattr(ba_mod, "http_get", lambda *a, **k: {})
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.get_user_address()
+        assert exc_info.value.code == "api_error"
+
+
+# ── submit_request + poll_request ────────────────────────────────
+
+
+class TestSubmitRequest:
+    def test_not_connected(self, svc_configured):
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.submit_request(method="eth_sendTransaction", params=[])
+        assert exc_info.value.code == "not_connected"
+
+    def test_http_failure(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+
+        def _boom(*a, **k):
+            raise RuntimeError("network")
+
+        monkeypatch.setattr(ba_mod, "http_post", _boom)
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.submit_request(method="m", params=[])
+        assert exc_info.value.code == "request_failed"
+
+    def test_bad_response_shape(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+        monkeypatch.setattr(ba_mod, "http_post", lambda *a, **k: {"no_request_id": True})
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.submit_request(method="m", params=[])
+        assert exc_info.value.code == "request_failed"
+
+    def test_happy_path(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+        monkeypatch.setattr(
+            ba_mod,
+            "http_post",
+            lambda *a, **k: {
+                "request_id": "req-123",
+                "approval_url": "https://base.app/approve/req-123",
+            },
+        )
+        out = svc_configured.submit_request(method="eth_sendTransaction", params=[{}])
+        assert out["request_id"] == "req-123"
+        assert "approval_url" in out
+
+
+class TestPollRequest:
+    def test_confirmed(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+        monkeypatch.setattr(
+            ba_mod,
+            "http_get",
+            lambda *a, **k: {"status": "confirmed", "result": "0xtx"},
+        )
+        out = svc_configured.poll_request("req-1", timeout=1.0, interval=0.01)
+        assert out["status"] == "confirmed"
+
+    def test_rejected(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+        monkeypatch.setattr(
+            ba_mod,
+            "http_get",
+            lambda *a, **k: {"status": "rejected"},
+        )
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.poll_request("req-1", timeout=1.0, interval=0.01)
+        assert exc_info.value.code == "request_failed"
+
+    def test_api_error(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+
+        def _boom(*a, **k):
+            raise RuntimeError("503")
+
+        monkeypatch.setattr(ba_mod, "http_get", _boom)
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.poll_request("req-1", timeout=1.0, interval=0.01)
+        assert exc_info.value.code == "api_error"
+
+    def test_timeout(self, svc_configured, monkeypatch):
+        svc_configured._access_token = "tok"
+        # Status keeps returning "pending" — should hit timeout
+        monkeypatch.setattr(ba_mod, "http_get", lambda *a, **k: {"status": "pending"})
+        with pytest.raises(BaseAccountError) as exc_info:
+            svc_configured.poll_request("req-1", timeout=0.05, interval=0.01)
+        assert exc_info.value.code == "approval_timeout"
+
+
+# ── is_connected / _require_token ────────────────────────────────
+
+
+class TestConnectionHelpers:
+    def test_is_connected_false(self, svc):
+        assert not svc.is_connected()
+
+    def test_is_connected_true(self, svc_configured):
+        svc_configured._access_token = "tok"
+        assert svc_configured.is_connected()
+
+
+class TestSingleton:
+    def test_get_returns_singleton(self, monkeypatch):
+        monkeypatch.setattr(ba_mod, "_instance", None)
+        first = ba_mod.get_base_account_service()
+        second = ba_mod.get_base_account_service()
+        assert first is second

--- a/tests/tools/test_defi_swap.py
+++ b/tests/tools/test_defi_swap.py
@@ -334,10 +334,15 @@ class TestSwap:
         details = out["details"]
         assert details["tx_hash"] == "0x" + "f" * 64
         assert details["router"] == "0x" + "1" * 40
-        # Mode received the calldata
+        # Mode received the calldata. On Base mainnet the Coinbase
+        # builder code suffix is appended; the original 0x calldata is
+        # the prefix.
         kwargs = fake_mode.send_transaction.call_args.kwargs
         assert kwargs["to"] == "0x" + "1" * 40
-        assert kwargs["data"] == "0xdeadbeef"
+        assert kwargs["data"].startswith("0xdeadbeef")
+        from clawmes.lib.base_builder import BASE_BUILDER_CODE
+
+        assert kwargs["data"].endswith(BASE_BUILDER_CODE[2:])
         assert kwargs["value"] == 0
 
     def test_swap_with_native_eth_value(self, connected, fake_zerox, fake_decimals, fake_mode):

--- a/tests/wallet/test_base_account.py
+++ b/tests/wallet/test_base_account.py
@@ -1,0 +1,253 @@
+"""Tests for clawmes.wallet.base_account."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.services.base_account import BaseAccountError
+from clawmes.wallet.base_account import BaseAccountMode
+
+
+class _FakeSvc:
+    def __init__(self):
+        self.calls: list = []
+        self.auth_url = "https://auth.test/?client_id=x"
+        self.address = "0x" + "1" * 40
+        self.requests: list[dict] = []
+        self.poll_responses: list[dict] = []
+        self.submit_response = {
+            "request_id": "req-1",
+            "approval_url": "https://base.app/approve",
+        }
+        self.exchange_response = {"access_token": "acc", "address": "0x" + "1" * 40}
+        self.stop_called = False
+
+    def get_auth_url(self, **kwargs):
+        return self.auth_url
+
+    def exchange_code(self, code):
+        self.calls.append(("exchange_code", code))
+        return self.exchange_response
+
+    def get_user_address(self):
+        return self.address
+
+    def submit_request(self, *, method, params):
+        self.requests.append({"method": method, "params": params})
+        return self.submit_response
+
+    def poll_request(self, request_id, **_kw):
+        if self.poll_responses:
+            return self.poll_responses.pop(0)
+        return {"status": "confirmed", "result": "0xtx"}
+
+    def stop(self):
+        self.stop_called = True
+
+
+@pytest.fixture
+def svc(monkeypatch):
+    s = _FakeSvc()
+    import clawmes.services.base_account as ba_mod
+
+    monkeypatch.setattr(ba_mod, "_instance", s)
+    return s
+
+
+# ── lifecycle ─────────────────────────────────────────────────────
+
+
+class TestConnect:
+    def test_returns_disconnected_state_with_auth_url(self, svc):
+        mode = BaseAccountMode()
+        state = mode.connect()
+        assert not state.connected
+        assert mode.get_pending_auth_url() == svc.auth_url
+
+    def test_connect_with_code(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        state = mode.connect_with_code("abc123")
+        assert state.connected
+        assert state.address == "0x" + "1" * 40
+        assert state.chain_id == 8453
+        assert state.mode == "base_account"
+        assert mode.get_pending_auth_url() is None
+
+    def test_connect_with_code_custom_chain(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        state = mode.connect_with_code("abc", chain_id=42161)
+        assert state.chain_id == 42161
+
+    def test_connect_with_code_unknown_chain(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        state = mode.connect_with_code("abc", chain_id=99999999)
+        assert state.chain_id == 99999999
+        assert "99999999" in state.chain_name
+
+    def test_disconnect(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        mode.disconnect()
+        assert not mode.state().connected
+        assert mode.get_pending_auth_url() is None
+        assert svc.stop_called
+
+
+# ── send_transaction ──────────────────────────────────────────────
+
+
+class TestSendTransaction:
+    def test_not_connected(self, svc):
+        mode = BaseAccountMode()
+        with pytest.raises(BaseAccountError) as exc_info:
+            mode.send_transaction(to="0xabc", value=0)
+        assert exc_info.value.code == "not_connected"
+
+    def test_happy_path(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        tx_hash = mode.send_transaction(to="0xtarget", value=1000, data=b"\x12\x34")
+        assert tx_hash == "0xtx"
+        # Request shape
+        req = svc.requests[0]
+        assert req["method"] == "eth_sendTransaction"
+        assert req["params"][0]["to"] == "0xtarget"
+        assert req["params"][0]["value"] == "0x3e8"
+        assert req["params"][0]["data"] == "0x1234"
+
+    def test_bytes_data_encodes(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        mode.send_transaction(to="0xt", value=0, data=b"\xab\xcd")
+        assert svc.requests[0]["params"][0]["data"] == "0xabcd"
+
+    def test_string_data_normalized(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        # Without 0x prefix
+        mode.send_transaction(to="0xt", value=0, data="deadbeef")
+        assert svc.requests[0]["params"][0]["data"] == "0xdeadbeef"
+
+    def test_chain_override(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        mode.send_transaction(to="0xt", value=0, chain_id=42161)
+        assert svc.requests[0]["params"][0]["chainId"] == hex(42161)
+
+    def test_gas_passed_through(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        mode.send_transaction(to="0xt", value=0, gas=200000)
+        assert svc.requests[0]["params"][0]["gas"] == hex(200000)
+
+    def test_no_tx_hash_in_confirmed_response(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        svc.poll_responses = [{"status": "confirmed"}]  # No result/tx_hash
+        with pytest.raises(BaseAccountError) as exc_info:
+            mode.send_transaction(to="0xt", value=0)
+        assert exc_info.value.code == "request_failed"
+
+
+# ── signing ──────────────────────────────────────────────────────
+
+
+class TestSignTypedData:
+    def test_not_connected(self, svc):
+        mode = BaseAccountMode()
+        with pytest.raises(BaseAccountError):
+            mode.sign_typed_data_v4({})
+
+    def test_happy_path(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        svc.poll_responses = [{"status": "confirmed", "result": "0xsig"}]
+        sig = mode.sign_typed_data_v4({"types": {}, "primaryType": "X"})
+        assert sig == "0xsig"
+        assert svc.requests[0]["method"] == "eth_signTypedData_v4"
+
+    def test_no_signature(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        svc.poll_responses = [{"status": "confirmed"}]
+        with pytest.raises(BaseAccountError):
+            mode.sign_typed_data_v4({})
+
+
+class TestSignPersonalMessage:
+    def test_not_connected(self, svc):
+        mode = BaseAccountMode()
+        with pytest.raises(BaseAccountError):
+            mode.sign_personal_message("hi")
+
+    def test_bytes_message(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        svc.poll_responses = [{"status": "confirmed", "signature": "0xsig"}]
+        sig = mode.sign_personal_message(b"hello")
+        assert sig == "0xsig"
+        # First param is the message hex
+        assert svc.requests[0]["params"][0] == "0x" + b"hello".hex()
+
+    def test_hex_string_message(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        svc.poll_responses = [{"status": "confirmed", "result": "0xsig"}]
+        mode.sign_personal_message("0xabcd")
+        assert svc.requests[0]["params"][0] == "0xabcd"
+
+    def test_plain_string_message(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        svc.poll_responses = [{"status": "confirmed", "result": "0xsig"}]
+        mode.sign_personal_message("hello")
+        # Plain string gets hex-encoded
+        assert svc.requests[0]["params"][0].startswith("0x")
+
+    def test_no_signature_in_response(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        svc.poll_responses = [{"status": "confirmed"}]
+        with pytest.raises(BaseAccountError):
+            mode.sign_personal_message("hi")
+
+
+# ── switch_chain ─────────────────────────────────────────────────
+
+
+class TestSwitchChain:
+    def test_not_connected(self, svc):
+        mode = BaseAccountMode()
+        with pytest.raises(BaseAccountError):
+            mode.switch_chain(1)
+
+    def test_switches(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        new_state = mode.switch_chain(1)
+        assert new_state.chain_id == 1
+
+    def test_unknown_chain_gracefully(self, svc):
+        mode = BaseAccountMode()
+        mode.connect()
+        mode.connect_with_code("abc")
+        new_state = mode.switch_chain(99999999)
+        assert new_state.chain_id == 99999999
+        assert "99999999" in new_state.chain_name


### PR DESCRIPTION
## Summary

Eight integrations that put clawmes deeper into the Base ecosystem on every surface — wallet connection, transaction calldata, name resolution, fiat onramp, and distribution to desktop AI clients.

## What's in this PR

### Big unlocks

- **`/connect_base` — Base Account / Coinbase Smart Wallet wallet mode**
  Fourth wallet mode alongside WalletConnect, local-key, Bankr. Uses Coinbase's OAuth 2.1 + stored-request flow (same as Base MCP) so every Base App user can connect their existing Base Account to clawmes without importing a mnemonic. Every tx + signature triggers an approval prompt in the user's Base App. Configure via `CLAWMES_BASE_ACCOUNT_CLIENT_ID`.

- **`clawmes-mcp` — clawmes as an MCP server**
  Desktop AI clients (Claude Desktop, Cursor, ChatGPT) can now install clawmes directly without going through Hermes. Read-only subset for v1 (10 tools: `defi_price`, `defi_balance`, `market_intel`, `clawnch_launch`, `clawnch_fees`, `bv7x_oracle`, `bv7x_market`, `nft`, `block_explorer`, `cost_basis`). Install with `pip install clawmes[mcp]`, run with `clawmes-mcp`.

### Smaller wins

- **`BASE_BUILDER_CODE` on every Base tx** — clawmes appends Coinbase's builder code suffix to swap, deploy, and burn calldata so the plugin earns builder rewards on every on-chain action it drives. Closes the gap with the clawnch backend's server-side `appendBuilderCode`.

- **Basenames (`*.base.eth`) resolution** — extends the existing ENS resolver to route `.base.eth` names to the Base L2 ENS registry natively. Auto-detected, no flag needed. `/buy jesse.base.eth 0.01` now works.

- **`/launch check`** — pre-flight validation that calls `/api/prepare/deploy` without committing. Verifies the burn tx + shows vault % before paying gas. Hugely useful when a burn hash is in the draft and the user wants to verify the math before signing.

- **Base App deep links on launch success** — `/launch confirm` success messages now emit `Base App: https://base.app/?token=…` alongside Basescan + DexScreener URLs.

- **`/onramp [usd_amount]`** — Coinbase Onramp deep link pre-filled with the connected wallet's address. Removes the "need ETH first" friction for new users.

- **x402 payment-required detection helpers** (`clawmes.lib.x402`) — minimal client-side detection of HTTP 402 challenges per the [x402 spec](https://www.x402.org). Foundation for future paid-endpoint integrations.

## Bug fix surfaced during testing

Three call sites in v0.4.0 (`/launch confirm` non-custodial path, `/launch burn`, `/burn`) were calling `WalletService.active_mode()` as a method when it's actually a `@property`. The test fakes had `active_mode` as a method, which hid the bug. Now all callers use property access; fakes updated to `@property` decorators.

## Testing

- 137 new tests across `tests/lib/test_base_builder.py`, `tests/lib/test_base_app.py`, `tests/lib/test_x402.py`, `tests/lib/test_ens.py`, `tests/commands/test_onramp.py`, `tests/commands/test_burn.py` (active_mode property fix), `tests/commands/test_launch.py` (check + non-custodial fix), `tests/commands/test_wallet.py` (connect_base + Base Account label), `tests/services/test_base_account.py`, `tests/wallet/test_base_account.py`, `tests/mcp_server/test_server.py`.
- Full suite **3073 passing at 100% coverage**. Ruff clean.

## Version bump

v0.4.0 → v0.5.0 across `pyproject.toml`, `_version.py`, and both `plugin.yaml` copies. `mcp` package added as an optional `[mcp]` extra (core install unchanged).

## Production config

Most new surfaces work with sensible defaults but production deployments should configure:

| Env var | Purpose |
|---|---|
| `CLAWMES_BASE_ACCOUNT_CLIENT_ID` | OAuth client ID registered on Coinbase Developer Platform. Required for `/connect_base`. |
| `CLAWMES_COINBASE_ONRAMP_APP_ID` | Coinbase Onramp app id. Required for pre-filled Onramp URLs (falls back to generic landing page). |
| `CLAWMES_BASE_APP_TOKEN_URL` / `CLAWMES_BASE_APP_TX_URL` | Override Base App deep link patterns if Coinbase's URL scheme shifts. |
| `CLAWMES_BASE_ACCOUNT_AUTH_URL` / `_TOKEN_URL` / `_API_URL` | Override Coinbase endpoints for staging or if production URLs shift. |

## Why this is the right next batch

Base's MCP launch + Coinbase Smart Wallet's ecosystem-wide rollout means every Base user is one wallet-mode-connect away from a clawmes session. Shipping both `/connect_base` (Base App users come to clawmes) and `clawmes-mcp` (desktop AI users come to clawmes) closes the loop on Base ecosystem distribution. The smaller items (builder code, basenames, onramp, deep links) are incremental UX wins that make clawmes feel native to the Base ecosystem rather than just running on it.

This is the deepest Base integration any chat-platform agent ships today.