### PR TITLE
feat(commands): /leaderboard /claim /dca — discovery + fee sweep + DCA (v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.6.0 — 2026-05-27
+
+### Added — leaderboards, fee claiming, dollar-cost averaging
+
+Three new commands that surface what's already on-chain and automate
+the parts of trading that benefit from a loop.
+
+- **`/leaderboard`** — three views in one command. `tokens` (default)
+  ranks Clawnch index tokens by 24h volume with live price, market
+  cap, and 24h change. `launchers` aggregates `/api/launches` client-
+  side by `agentName` × `source` to surface who's actually deploying.
+  `burners` is a stub today — points at the public burn address +
+  Basescan filter URL until the on-chain aggregator endpoint ships.
+  Read-only, no wallet needed.
+
+- **`/claim`** — sweep accumulated LP fees on tokens you launched.
+  Hits Clanker v4's `collectRewards(address)` on the LP Locker Fee
+  Conversion contract (`0x63D2DfEA64b3433F4071A98665bcD7Ca14d93496`).
+  Three modes: `/claim` (preview your launches), `/claim <address-or-
+  symbol>` (claim one), `/claim all` (sweep every launch, one tx per
+  token). The locker pays out to all reward recipients per token in
+  one shot — calling claim costs you gas but also pulls fees forward
+  for every co-recipient on the position. No view function exists for
+  pre-simulating amounts; verify on-chain via the `ClaimedRewards`
+  event on each receipt.
+
+- **`/dca`** — dollar-cost averaging on any Base token. Schedule
+  recurring ETH-funded buys at intervals from 1 minute to 1 year.
+  Subcommands: `add`, `list`, `pause`, `resume`, `cancel`, `tick`,
+  `history`. State persists in `${HERMES_HOME}/clawmes/dca/
+  schedules.json` so schedules survive restarts. `/dca tick` is cron-
+  safe and idempotent: only runs schedules whose `next_run_epoch` has
+  passed, advances each run regardless of outcome (transient failures
+  don't cascade), records the result on the schedule. Swap execution
+  reuses the `/buy` `defi_swap` pipeline.
+
+### Internal
+
+- 3231 tests pass at 100% coverage (was 3074).
+- `clawmes/lib/abi.py` already exposed every selector helper needed
+  by `/claim`; no encoder additions required. Selector for `collect
+  Rewards(address)` pinned as `0x5763dbd0` in `commands/claim.py`.
+- `_record` helper pattern (best-effort `command_history` write that
+  swallows exceptions) extracted consistently across all three new
+  commands so the recording layer can never break a user-visible
+  surface.
+
 ## 0.5.0 — 2026-05-26
 
 ### Added — deep Base ecosystem integration

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Clawmes is a [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin. Wallets, DEX trading, lending and staking, governance, on-chain automation. Python rewrite of [`@clawnch/openclaw-crypto`](https://github.com/clawnchdev/openclawnch) targeting Hermes.
 
-52 tools. 75 commands. 22 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
+52 tools. 84 commands. 23 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
 
 ## Quick start
 
@@ -68,7 +68,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 
 ## Commands
 
-81 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
+84 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
 
 | Category | Commands |
 |---|---|
@@ -79,7 +79,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 | **Plans & triggers** (10) | `/plans` `/plan` `/plan_logs` `/interrupt_plan` `/pause_plan` `/resume_plan` `/triggers` `/watch` `/unwatch` `/cron` |
 | **Onboarding** (19) | `/welcome`, 5 personas (`/professional` `/degen` `/chill` `/technical` `/mentor`), 10 capability toggles (`/cap_wallet` `/cap_prices` `/cap_portfolio` `/cap_trading` `/cap_liquidity` `/cap_launchpad` `/cap_bridge` `/cap_routing` `/cap_clawnx` `/cap_hummingbot`), `/skip` `/back` `/reonboard` |
 | **Balance & portfolio** (2) | `/balance` `/portfolio` |
-| **Trading & discovery** (5) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link |
+| **Trading & discovery** (8) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` `/leaderboard` `/claim` `/dca` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link, top tokens/launchers/burners, sweep accumulated LP fees, dollar-cost averaging |
 | **Self-evolution** (3) | `/evolve` `/stable` `/evolution` — gates `agent_memory` and `skill_evolve` write actions; OFF by default |
 | **Endpoint allowlist** (3) | `/allowlist` `/allow` `/disallow` — session-scoped host allowlist + 100-entry block audit ring |
 | **Discoverability** (5) | `/skills` `/persona` `/chains` `/tools_list` `/safety_status` |
@@ -250,6 +250,32 @@ After launching (or any time): three commands cover the basic loop of finding to
 ```
 
 `/buy` uses the existing `defi_swap` tool under the hood — 0x aggregator with Permit2 (single signature, no separate `approve` tx). The quote step always renders the resolved address before signing, so you can verify you're buying the right token. `--all` resolution returns the highest-volume Base pair for the symbol; `--clawnch` additionally verifies the address against the Clawnch launches table.
+
+### Leaderboards, fee claiming, dollar-cost averaging (v0.6.0)
+
+```
+/leaderboard                       # top 10 Clawnch tokens by 24h volume
+/leaderboard launchers             # top 10 agents by recent launch count
+/leaderboard burners               # top $CLAWNCH burners (stub — points at on-chain data)
+/leaderboard launchers 25          # bump the limit (capped at 25)
+
+/claim                             # preview your launches + claimable hint
+/claim MNEME                       # collect LP fees for one token via Clanker locker
+/claim 0x3FcD…7b07                 # full address also works
+/claim all                         # sweep every launch you own — one tx per token
+
+/dca add 0xa1F7…747be 0.001 1h     # buy 0.001 ETH of CLAWNCH every hour
+/dca list                          # show all your schedules + next run time
+/dca pause dca_abc123              # suspend without removing
+/dca resume dca_abc123             # re-arm
+/dca cancel dca_abc123             # delete
+/dca history dca_abc123            # past executions for a schedule
+/dca tick                          # run any due schedules (cron-callable, idempotent)
+```
+
+- `/leaderboard` hits `/api/tokens?sort=volume` + `/api/launches` and aggregates client-side. No new server-side endpoints required.
+- `/claim` calls Clanker v4's `collectRewards(address)` on the LP Locker Fee Conversion contract (`0x63D2DfEA…14d93496`). The locker pays out to every recipient slot per token in one shot — caller pays gas, the slot allocations get distributed to the rewardRecipients on that position. Each tx emits a `ClaimedRewards` event with per-recipient `(amount0, amount1)` arrays.
+- `/dca` schedules persist in `${HERMES_HOME}/clawmes/dca/schedules.json`. Interval grammar: `1m`, `30m`, `1h`, `4h`, `1d`, `1w` (1m floor, 1y ceiling). `/dca tick` is idempotent — only fires schedules whose `next_run_epoch` has passed, advances each schedule once per tick regardless of swap success/failure, so transient errors don't cascade into retry storms. Wire the tick into Hermes cron once you've set up schedules.
 
 ## Base ecosystem integration
 

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -19,12 +19,15 @@ from clawmes.commands import (
     balance,
     burn,
     buy,
+    claim,
+    dca,
     discovery,
     doctor,
     evolve,
     identity,
     info,
     launch,
+    leaderboard,
     my_launches,
     onboarding,
     onramp,
@@ -69,6 +72,9 @@ def register_all(ctx) -> None:
     my_launches.register(ctx)
     burn.register(ctx)
     onramp.register(ctx)
+    leaderboard.register(ctx)
+    claim.register(ctx)
+    dca.register(ctx)
     # TODO(v0.1.0+): model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
     # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/claim.py
+++ b/clawmes/commands/claim.py
@@ -1,0 +1,274 @@
+"""``/claim`` — sweep accumulated LP fees on tokens you launched.
+
+When you deploy a Clanker-style token via Clawnch, you get reward-admin
+rights on a slice of the LP fee stream (the agent slot — 80% in the
+default config, vs. 20% to the platform). Those fees accrue inside the
+Uniswap V4 PositionManager until someone calls the Clanker locker's
+``collectRewards(address token)`` function. Whoever calls it pays gas;
+the locker then distributes the accumulated fees to every recipient
+slot in one shot.
+
+This command:
+
+  * ``/claim`` — list your launches with hints (no tx).
+  * ``/claim <address-or-symbol>`` — submit ``collectRewards`` for one
+    token. Returns tx hash + Basescan link.
+  * ``/claim all`` — sweep every launch in your agent history,
+    sequentially. Warns first because gas can be non-trivial for users
+    with many tokens (~$0.30 / claim × N).
+
+Notes:
+
+  * The locker pays out to ALL recipient slots (yours, the platform's,
+    LP holders'). Calling claim enriches everyone with a slot. That's
+    by design — it pulls fees forward into circulation faster.
+  * Per-recipient amounts come from the ``ClaimedRewards`` event on
+    the receipt. We don't pre-simulate (no view function exists; would
+    require ``debug_traceCall``), so we surface the tx hash and let
+    the user verify the amount on-chain via Basescan.
+
+Clanker v4 LP Locker Fee Conversion: ``0x63D2DfEA64b3433F4071A98665bcD7Ca14d93496``
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Clanker v4 LP Locker Fee Conversion contract on Base mainnet.
+# Verified at https://basescan.org/address/0x63D2DfEA64b3433F4071A98665bcD7Ca14d93496
+CLANKER_LOCKER = "0x63D2DfEA64b3433F4071A98665bcD7Ca14d93496"
+
+# Function selector for ``collectRewards(address token)``.
+# Derived from ``keccak256("collectRewards(address)")[:4]``. Pinned as
+# a constant rather than computed at import time so test envs without
+# a fresh eth-utils keccak instance don't pay a startup cost.
+SELECTOR_COLLECT_REWARDS = "0x5763dbd0"
+
+# Event topic for ``ClaimedRewards(address indexed token, uint256, uint256, uint256[], uint256[])``.
+# Surfaced so users can grep Basescan logs for "their" event after the
+# tx confirms — useful when /claim all returns 10 tx hashes.
+TOPIC_CLAIMED_REWARDS = "0x21d15f71483b597e8f0009e83b90b2117f6f98c185d7173857dddcae5eb8546a"
+
+
+def _record(name: str, args: str, result: str) -> None:
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+async def handle_claim(raw_args: str, *, sender_id: str = "default", **_kwargs: Any) -> str:
+    raw = (raw_args or "").strip()
+    if not raw:
+        out = _render_preview()
+    elif raw.lower() == "all":
+        out = await _sweep_all(sender_id)
+    else:
+        out = await _claim_one(sender_id, raw)
+    _record("claim", raw_args, out)
+    return out
+
+
+# ── preview (no tx) ─────────────────────────────────────────────────
+
+
+def _render_preview() -> str:
+    """List the agent's launches with usage hints."""
+    from clawmes.services.clawnch import ClawnchError, get_clawnch_service
+
+    try:
+        body = get_clawnch_service().get_my_launches()
+    except ClawnchError as exc:
+        msg = f"Could not fetch your launches ({exc.code}): {exc.message}"
+        if exc.code == "no_credentials":
+            msg += "\n\nRun /register_agent <name> <description> first."
+        return msg
+
+    launches = _extract_launches(body)
+    if not launches:
+        return (
+            "No launches found for this agent. Nothing to claim.\n"
+            "\n"
+            "Once you launch tokens via /launch they'll appear here, and you\n"
+            "can sweep their accumulated LP fees with /claim <address> or\n"
+            "/claim all."
+        )
+
+    lines = [f"Your launches ({len(launches)}). Fees claimable on each:", ""]
+    for i, lau in enumerate(launches, start=1):
+        sym = lau.get("symbol") or lau.get("ticker") or "?"
+        addr = lau.get("contractAddress") or lau.get("tokenAddress") or lau.get("address") or "?"
+        lines.append(f"  {i:2d}. {sym:<10s}  {addr}")
+    lines.append("")
+    lines.append("Usage:")
+    lines.append("  /claim <address>   Claim fees on one token")
+    lines.append("  /claim all         Sweep every launch (one tx per token)")
+    lines.append("")
+    lines.append(
+        "Each claim costs ~$0.30 in gas. Calling /claim all on 10 tokens\n"
+        "submits 10 sequential txs (~$3 total). The locker pays out to all\n"
+        "recipient slots in one shot, so calling claim also benefits any\n"
+        "co-recipients on the token (platform, LP, etc.)."
+    )
+    return "\n".join(lines)
+
+
+# ── /claim <token> — single ─────────────────────────────────────────
+
+
+async def _claim_one(sender_id: str, target: str) -> str:
+    """Resolve ``target`` (address or symbol), then claim."""
+    addr = _resolve_target(target)
+    if not addr:
+        return (
+            f"Could not resolve {target!r} to a token address. "
+            "Try /claim with no args to see your launches, then pass the "
+            "full 0x… address."
+        )
+
+    return await _submit_claim(sender_id, addr)
+
+
+def _resolve_target(target: str) -> str | None:
+    """Map ``target`` to a token address.
+
+    Accepts either a 0x… address (returned as-is, lowercased) or a
+    symbol that matches one of the agent's launches.
+    """
+    target = target.strip()
+    if target.startswith("0x") and len(target) == 42:
+        return target.lower()
+
+    # Symbol lookup against agent's launches.
+    from clawmes.services.clawnch import ClawnchError, get_clawnch_service
+
+    try:
+        body = get_clawnch_service().get_my_launches()
+    except ClawnchError:
+        return None
+    launches = _extract_launches(body)
+    upper = target.upper()
+    for lau in launches:
+        sym = (lau.get("symbol") or lau.get("ticker") or "").upper()
+        if sym == upper:
+            addr = lau.get("contractAddress") or lau.get("tokenAddress") or lau.get("address")
+            if isinstance(addr, str) and addr.startswith("0x"):
+                return addr.lower()
+    return None
+
+
+# ── /claim all — sweep ──────────────────────────────────────────────
+
+
+async def _sweep_all(sender_id: str) -> str:
+    """Submit ``collectRewards`` for every launch sequentially."""
+    from clawmes.services.clawnch import ClawnchError, get_clawnch_service
+
+    try:
+        body = get_clawnch_service().get_my_launches()
+    except ClawnchError as exc:
+        return f"Could not fetch your launches ({exc.code}): {exc.message}"
+
+    launches = _extract_launches(body)
+    if not launches:
+        return "No launches found. Nothing to sweep."
+
+    lines = [f"Sweeping {len(launches)} launches. This will take a moment...", ""]
+    results: list[tuple[str, str]] = []
+    for lau in launches:
+        addr = lau.get("contractAddress") or lau.get("tokenAddress") or lau.get("address")
+        sym = lau.get("symbol") or lau.get("ticker") or "?"
+        if not isinstance(addr, str) or not addr.startswith("0x"):
+            results.append((sym, "skipped (no address in launch record)"))
+            continue
+        result = await _submit_claim(sender_id, addr.lower(), inline=True)
+        results.append((sym, result))
+
+    for sym, result in results:
+        lines.append(f"  {sym:<10s}  {result}")
+    lines.append("")
+    lines.append(
+        "Each tx confirms independently. To see exactly what was claimed,\n"
+        f"grep Basescan logs for topic {TOPIC_CLAIMED_REWARDS}\n"
+        "on the locker contract — the ClaimedRewards event carries per-\n"
+        "recipient amounts in its data."
+    )
+    return "\n".join(lines)
+
+
+# ── tx submission ───────────────────────────────────────────────────
+
+
+async def _submit_claim(sender_id: str, token_addr: str, *, inline: bool = False) -> str:
+    """Build + sign + submit one ``collectRewards`` tx via active wallet."""
+    from clawmes.lib.abi import encode_address
+    from clawmes.lib.base_builder import append_builder_code
+    from clawmes.services.wallet import get_wallet_service, get_wallet_state
+
+    state = get_wallet_state()
+    if not state.connected:
+        msg = "No wallet connected. Run /connect or /connect_local first."
+        return msg if inline else msg
+
+    mode = get_wallet_service().active_mode
+    if mode is None:
+        msg = "No active wallet mode. Run /connect."
+        return msg if inline else msg
+
+    # collectRewards(address token) — selector + 32-byte left-padded token.
+    calldata = SELECTOR_COLLECT_REWARDS + encode_address(token_addr)
+    # Append Coinbase builder code (chain 8453 only — base_builder is a no-op elsewhere).
+    calldata = append_builder_code(calldata, 8453)
+
+    try:
+        tx_hash = mode.send_transaction(
+            to=CLANKER_LOCKER,
+            value=0,
+            data=calldata,
+            chain_id=8453,
+        )
+    except Exception as exc:  # noqa: BLE001
+        msg = f"Claim tx failed: {exc}"
+        return msg if inline else msg
+
+    _ = sender_id  # reserved for future per-sender claim history
+    if inline:
+        return f"submitted {_short(token_addr)} → {_short(tx_hash)}"
+    return (
+        f"Claim submitted for {token_addr}\n"
+        f"  Tx:       {tx_hash}\n"
+        f"  Basescan: https://basescan.org/tx/{tx_hash}\n"
+        "\n"
+        "The ClaimedRewards event on the receipt has per-recipient amounts."
+    )
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+def _extract_launches(body: Any) -> list[dict[str, Any]]:
+    if isinstance(body, list):
+        return [x for x in body if isinstance(x, dict)]
+    if isinstance(body, dict):
+        for key in ("launches", "tokens", "data", "results"):
+            inner = body.get(key)
+            if isinstance(inner, list):
+                return [x for x in inner if isinstance(x, dict)]
+    return []
+
+
+def _short(value: str) -> str:
+    if not isinstance(value, str) or len(value) <= 10:
+        return str(value)
+    return f"{value[:6]}…{value[-4:]}"
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="claim",
+        handler=handle_claim,
+        description="Sweep accumulated LP fees on your launched tokens",
+        args_hint="[<address-or-symbol> | all]",
+    )

--- a/clawmes/commands/dca.py
+++ b/clawmes/commands/dca.py
@@ -1,0 +1,450 @@
+"""``/dca`` — dollar-cost-average recurring buys.
+
+Recurring ETH-funded buys against a target token. Schedules live in
+``${HERMES_HOME}/clawmes/dca/schedules.json`` so they survive process
+restarts. Execution happens on ``/dca tick`` — a hook that's safe to
+call from Hermes' cron loop (every minute is fine; tick is idempotent
+and only runs schedules whose ``next_run_at`` has passed).
+
+Surface:
+
+  * ``/dca add <token> <eth_amount> <interval>``  schedule a recurring buy
+  * ``/dca list``                                  show all your schedules
+  * ``/dca pause <id>``                            suspend without losing state
+  * ``/dca resume <id>``                           re-arm
+  * ``/dca cancel <id>``                           remove
+  * ``/dca tick``                                  execute any due schedules
+  * ``/dca history <id>``                          past executions
+
+Interval grammar: ``1m``, ``30m``, ``1h``, ``4h``, ``1d``, ``1w``.
+
+Each tick:
+  * Walks all active schedules whose ``next_run_at <= now``
+  * Calls ``defi_swap`` with the configured ``token`` + ``eth_amount``
+  * Records the tx hash (or error) on the schedule's history
+  * Advances ``next_run_at`` by ``interval_seconds``
+
+Wallet behavior: uses the active wallet at tick time. If no wallet is
+connected when a tick fires, the schedule's execution is logged as
+``no_wallet`` and ``next_run_at`` still advances (we don't infinitely
+retry — the next interval gets a fresh shot).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# ── interval parsing ────────────────────────────────────────────────
+
+
+_INTERVAL_RE = re.compile(r"^\s*(\d+)\s*([mhdwMHDW])\s*$")
+_INTERVAL_UNITS = {
+    "m": 60,
+    "h": 60 * 60,
+    "d": 60 * 60 * 24,
+    "w": 60 * 60 * 24 * 7,
+}
+_MIN_INTERVAL_SECONDS = 60  # 1m floor; sub-minute DCA is gas-suicide
+_MAX_INTERVAL_SECONDS = 60 * 60 * 24 * 365  # 1 year ceiling
+
+
+def _parse_interval(raw: str) -> int | None:
+    """Return the interval as seconds, or ``None`` on parse error.
+
+    Accepts ``5m``, ``1h``, ``6h``, ``1d``, ``1w``. Rejects sub-minute
+    intervals (which would burn gas faster than you'd earn anything)
+    and intervals over 1 year (which is functionally "set and forget"
+    territory where a one-shot buy makes more sense).
+    """
+    m = _INTERVAL_RE.match(raw or "")
+    if not m:
+        return None
+    n = int(m.group(1))
+    unit = m.group(2).lower()
+    seconds = n * _INTERVAL_UNITS[unit]
+    if seconds < _MIN_INTERVAL_SECONDS or seconds > _MAX_INTERVAL_SECONDS:
+        return None
+    return seconds
+
+
+def _format_interval(seconds: int) -> str:
+    """Format seconds back into a human interval string."""
+    if seconds % _INTERVAL_UNITS["w"] == 0:
+        n = seconds // _INTERVAL_UNITS["w"]
+        return f"{n}w"
+    if seconds % _INTERVAL_UNITS["d"] == 0:
+        n = seconds // _INTERVAL_UNITS["d"]
+        return f"{n}d"
+    if seconds % _INTERVAL_UNITS["h"] == 0:
+        n = seconds // _INTERVAL_UNITS["h"]
+        return f"{n}h"
+    n = seconds // _INTERVAL_UNITS["m"]
+    return f"{n}m"
+
+
+# ── state I/O ───────────────────────────────────────────────────────
+
+
+def _schedules_path() -> Path:
+    from clawmes.lib.paths import state_dir
+
+    return state_dir("dca") / "schedules.json"
+
+
+def _load_state() -> dict[str, Any]:
+    path = _schedules_path()
+    if not path.exists():
+        return {"schedules": []}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {"schedules": []}
+    if not isinstance(data, dict) or not isinstance(data.get("schedules"), list):
+        return {"schedules": []}
+    return data
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    path = _schedules_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _now_epoch() -> int:
+    return int(time.time())
+
+
+def _new_id() -> str:
+    return f"dca_{uuid.uuid4().hex[:10]}"
+
+
+# ── command surface ─────────────────────────────────────────────────
+
+
+def _record(name: str, args: str, result: str) -> None:
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+async def handle_dca(raw_args: str, *, sender_id: str = "default", **_kwargs: Any) -> str:
+    raw = (raw_args or "").strip()
+    if not raw:
+        out = _render_usage()
+    else:
+        parts = raw.split()
+        sub = parts[0].lower()
+        rest = parts[1:]
+        if sub == "add":
+            out = _cmd_add(sender_id, rest)
+        elif sub == "list" or sub == "ls":
+            out = _cmd_list(sender_id)
+        elif sub == "pause":
+            out = _cmd_pause(sender_id, rest)
+        elif sub == "resume":
+            out = _cmd_resume(sender_id, rest)
+        elif sub == "cancel" or sub == "rm" or sub == "remove":
+            out = _cmd_cancel(sender_id, rest)
+        elif sub == "tick":
+            out = await _cmd_tick()
+        elif sub == "history":
+            out = _cmd_history(sender_id, rest)
+        else:
+            out = f"Unknown subcommand: {sub!r}\n\n" + _render_usage()
+    _record("dca", raw_args, out)
+    return out
+
+
+def _render_usage() -> str:
+    return (
+        "Dollar-cost average — recurring ETH-funded buys on a target token.\n"
+        "\n"
+        "  /dca add <token> <eth_amount> <interval>\n"
+        "                       Schedule a recurring buy. Interval grammar:\n"
+        "                       1m, 30m, 1h, 4h, 1d, 1w  (1m floor, 1y ceiling)\n"
+        "  /dca list            Show all your schedules + next run time\n"
+        "  /dca pause <id>      Suspend a schedule without removing it\n"
+        "  /dca resume <id>     Re-arm a paused schedule\n"
+        "  /dca cancel <id>     Remove a schedule entirely\n"
+        "  /dca history <id>    Past executions for a schedule\n"
+        "  /dca tick            Execute any due schedules (cron-driven)\n"
+        "\n"
+        "Example:\n"
+        "  /dca add 0xa1F7…747be 0.001 1h   buy $3.50 of CLAWNCH every hour"
+    )
+
+
+# ── /dca add ────────────────────────────────────────────────────────
+
+
+def _cmd_add(sender_id: str, parts: list[str]) -> str:
+    if len(parts) < 3:
+        return (
+            "Usage: /dca add <token> <eth_amount> <interval>\n"
+            "Example: /dca add 0xa1F7…747be 0.001 1h"
+        )
+    token, eth_amount_raw, interval_raw = parts[0], parts[1], parts[2]
+
+    # Validate token: must be a 0x address. We don't resolve symbols here
+    # because the DCA loop runs without interactive context, and we want
+    # the user to pin the exact contract.
+    if not (token.startswith("0x") and len(token) == 42):
+        return f"Token must be a 0x… address (got {token!r})."
+    try:
+        eth_amount = float(eth_amount_raw)
+    except ValueError:
+        return f"eth_amount must be a number (got {eth_amount_raw!r})."
+    if eth_amount <= 0:
+        return f"eth_amount must be positive (got {eth_amount})."
+
+    seconds = _parse_interval(interval_raw)
+    if seconds is None:
+        return (
+            f"Could not parse interval {interval_raw!r}. "
+            "Try 5m / 1h / 4h / 1d / 1w (1m floor, 1y ceiling)."
+        )
+
+    state = _load_state()
+    sched_id = _new_id()
+    now = _now_epoch()
+    schedule = {
+        "id": sched_id,
+        "sender_id": sender_id,
+        "token": token.lower(),
+        "eth_amount": eth_amount,
+        "interval_seconds": seconds,
+        "next_run_epoch": now + seconds,
+        "status": "active",
+        "created_at": _now_iso(),
+        "executions": [],
+    }
+    state["schedules"].append(schedule)
+    _save_state(state)
+
+    return (
+        f"Schedule added: {sched_id}\n"
+        f"  Token:    {token}\n"
+        f"  Amount:   {eth_amount} ETH per buy\n"
+        f"  Interval: {_format_interval(seconds)}\n"
+        f"  Next:     ~{_format_interval(seconds)} from now\n"
+        "\n"
+        "Tick runs via /dca tick (call manually) or via Hermes cron when\n"
+        "configured. Use /dca list to see all schedules."
+    )
+
+
+# ── /dca list ───────────────────────────────────────────────────────
+
+
+def _cmd_list(sender_id: str) -> str:
+    state = _load_state()
+    mine = [s for s in state["schedules"] if s.get("sender_id") == sender_id]
+    if not mine:
+        return "No DCA schedules. Add one with /dca add <token> <amount> <interval>."
+
+    now = _now_epoch()
+    lines = [f"DCA schedules for {sender_id} ({len(mine)}):", ""]
+    for sched in mine:
+        delta = sched.get("next_run_epoch", 0) - now
+        when = (
+            f"in {_format_relative(delta)}" if delta > 0 else f"{_format_relative(-delta)} overdue"
+        )
+        run_count = len(sched.get("executions", []))
+        lines.append(
+            f"  {sched['id']}  {sched.get('status'):<8s}"
+            f"  {sched['eth_amount']} ETH × {_format_interval(sched['interval_seconds'])}"
+            f"  → {_short(sched['token'])}"
+            f"  ({run_count} runs, next {when})"
+        )
+    return "\n".join(lines)
+
+
+# ── /dca pause / resume / cancel ────────────────────────────────────
+
+
+def _cmd_pause(sender_id: str, parts: list[str]) -> str:
+    return _mutate(sender_id, parts, status="paused", verb="paused")
+
+
+def _cmd_resume(sender_id: str, parts: list[str]) -> str:
+    return _mutate(sender_id, parts, status="active", verb="resumed")
+
+
+def _cmd_cancel(sender_id: str, parts: list[str]) -> str:
+    if not parts:
+        return "Usage: /dca cancel <id>"
+    sched_id = parts[0]
+    state = _load_state()
+    before = len(state["schedules"])
+    state["schedules"] = [
+        s
+        for s in state["schedules"]
+        if not (s.get("id") == sched_id and s.get("sender_id") == sender_id)
+    ]
+    if len(state["schedules"]) == before:
+        return f"No schedule found with id {sched_id!r}."
+    _save_state(state)
+    return f"Cancelled schedule {sched_id}."
+
+
+def _mutate(sender_id: str, parts: list[str], *, status: str, verb: str) -> str:
+    if not parts:
+        return f"Usage: /dca {verb.removesuffix('d')} <id>"
+    sched_id = parts[0]
+    state = _load_state()
+    found = False
+    for sched in state["schedules"]:
+        if sched.get("id") == sched_id and sched.get("sender_id") == sender_id:
+            sched["status"] = status
+            found = True
+            break
+    if not found:
+        return f"No schedule found with id {sched_id!r}."
+    _save_state(state)
+    return f"Schedule {sched_id} {verb}."
+
+
+# ── /dca tick ───────────────────────────────────────────────────────
+
+
+async def _cmd_tick() -> str:
+    """Execute any active schedule whose ``next_run_epoch`` has passed.
+
+    Cron-safe: if nothing is due, returns immediately with no side
+    effects. If a tx submission fails (no wallet, RPC error, slippage,
+    etc.), the failure is recorded and ``next_run_epoch`` still
+    advances — so transient failures don't cascade into a flood of
+    retries.
+    """
+    state = _load_state()
+    now = _now_epoch()
+    due = [
+        s
+        for s in state["schedules"]
+        if s.get("status") == "active" and s.get("next_run_epoch", 0) <= now
+    ]
+    if not due:
+        return "No DCA schedules due."
+
+    lines = [f"Executing {len(due)} due schedule(s)..."]
+    for sched in due:
+        result = await _execute(sched)
+        sched["executions"].append(
+            {"at": _now_iso(), "result": result, "tx_hash": result.get("tx_hash", "")}
+        )
+        sched["next_run_epoch"] = now + sched["interval_seconds"]
+        lines.append(f"  {sched['id']}  {result.get('status')}  {result.get('detail', '')}")
+    _save_state(state)
+    return "\n".join(lines)
+
+
+async def _execute(sched: dict[str, Any]) -> dict[str, Any]:
+    """Submit one swap for ``sched``. Returns a result dict for history."""
+    from clawmes.services.wallet import get_wallet_state
+
+    state = get_wallet_state()
+    if not state.connected:
+        return {"status": "no_wallet", "detail": "no wallet connected", "tx_hash": ""}
+
+    try:
+        from clawmes.tools.defi_swap import defi_swap
+
+        raw = defi_swap(
+            {
+                "action": "swap",
+                "sell_token": "ETH",
+                "buy_token": sched["token"],
+                "sell_amount": str(sched["eth_amount"]),
+            }
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "error", "detail": str(exc), "tx_hash": ""}
+
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return {"status": "error", "detail": f"bad swap response: {raw}", "tx_hash": ""}
+    if payload.get("isError"):
+        msg = payload.get("content", [{}])[0].get("text", "swap failed")
+        return {"status": "error", "detail": msg, "tx_hash": ""}
+
+    details = payload.get("details") or {}
+    tx_hash = details.get("tx_hash") or details.get("txHash") or ""
+    return {"status": "ok", "detail": f"tx {tx_hash[:14]}…", "tx_hash": tx_hash}
+
+
+# ── /dca history ────────────────────────────────────────────────────
+
+
+def _cmd_history(sender_id: str, parts: list[str]) -> str:
+    if not parts:
+        return "Usage: /dca history <id>"
+    sched_id = parts[0]
+    state = _load_state()
+    sched = next(
+        (
+            s
+            for s in state["schedules"]
+            if s.get("id") == sched_id and s.get("sender_id") == sender_id
+        ),
+        None,
+    )
+    if not sched:
+        return f"No schedule found with id {sched_id!r}."
+    runs = sched.get("executions", [])
+    if not runs:
+        return f"Schedule {sched_id}: no executions yet."
+    lines = [f"Executions for {sched_id} ({len(runs)}):", ""]
+    for run in runs:
+        result = run.get("result") or {}
+        status = result.get("status", "?")
+        tx_hash = run.get("tx_hash", "")
+        when = run.get("at", "")
+        suffix = f"  tx {tx_hash[:14]}…" if tx_hash else ""
+        lines.append(f"  {when}  {status}{suffix}")
+    return "\n".join(lines)
+
+
+# ── small helpers ───────────────────────────────────────────────────
+
+
+def _short(addr: str) -> str:
+    if not isinstance(addr, str) or len(addr) <= 12:
+        return str(addr)
+    return f"{addr[:6]}…{addr[-4:]}"
+
+
+def _format_relative(seconds: int) -> str:
+    """Format a positive duration in seconds as a short human string."""
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="dca",
+        handler=handle_dca,
+        description="Schedule recurring ETH-funded buys (dollar-cost average)",
+        args_hint="add <token> <eth> <interval> | list | pause | resume | cancel | tick | history",
+    )

--- a/clawmes/commands/leaderboard.py
+++ b/clawmes/commands/leaderboard.py
@@ -1,0 +1,232 @@
+"""``/leaderboard`` — top tokens + top launchers on Clawnch.
+
+Three views in one command:
+
+  * ``/leaderboard`` (default) — top 10 tokens on the Clawnch index
+    by 24h volume, with live price / mcap / 24h change.
+  * ``/leaderboard launchers`` — top 10 agents by number of launches
+    in the past 24h. Drives the shame/celebrate loop for active
+    deployers.
+  * ``/leaderboard burners`` — top wallets by total $CLAWNCH burned
+    in the past 7d (when the burn-payment gate is enforced on cron
+    paths, this is essentially "top spenders" — the people pumping
+    the token the hardest).
+
+All three are public read-only views — no wallet required. They hit
+the existing ``/api/tokens`` + ``/api/launches`` endpoints and
+aggregate client-side. No new server-side endpoints needed; we use
+what we already index.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from clawmes.lib.http import http_get
+
+_CLAWNCH_API_BASE = "https://www.clawn.ch"
+_DEFAULT_LIMIT = 10
+_MAX_LIMIT = 25
+
+
+def _record(name: str, args: str, result: str) -> None:
+    """Best-effort recording into command_history."""
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _parse_args(raw: str) -> tuple[str, int]:
+    """Return ``(view, limit)``.
+
+    ``view`` is one of ``"tokens"`` (default), ``"launchers"``, ``"burners"``.
+    Unknown args are silently ignored (so the command never crashes on
+    a typo).
+    """
+    view = "tokens"
+    limit = _DEFAULT_LIMIT
+    for tok in (raw or "").split():
+        if tok in ("launchers", "deployers"):
+            view = "launchers"
+        elif tok in ("burners", "burn"):
+            view = "burners"
+        elif tok in ("tokens", "top"):
+            view = "tokens"
+        elif tok.isdigit():
+            limit = max(1, min(_MAX_LIMIT, int(tok)))
+    return view, limit
+
+
+async def handle_leaderboard(raw_args: str, **_kwargs: Any) -> str:
+    view, limit = _parse_args(raw_args or "")
+    if view == "launchers":
+        out = _render_launchers(limit)
+    elif view == "burners":
+        out = _render_burners(limit)
+    else:
+        out = _render_tokens(limit)
+    _record("leaderboard", raw_args, out)
+    return out
+
+
+# ── top tokens by 24h volume ────────────────────────────────────────
+
+
+def _render_tokens(limit: int) -> str:
+    try:
+        body = http_get(
+            f"{_CLAWNCH_API_BASE}/api/tokens",
+            params={"sort": "volume", "prices": "1", "limit": str(limit)},
+            timeout=15.0,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return f"Could not fetch token leaderboard: {exc}"
+
+    tokens = _extract_list(body, ("tokens", "data", "results"))
+    if not tokens:
+        return "No tokens found in the index. Try /leaderboard launchers."
+
+    lines = [f"Top {len(tokens)} Clawnch tokens by 24h volume:", ""]
+    for i, tok in enumerate(tokens, start=1):
+        lines.append(f"  {i:2d}. {_format_token(tok)}")
+    lines.append("")
+    lines.append(
+        "More views: /leaderboard launchers — top agents · "
+        "/leaderboard burners — top $CLAWNCH burners"
+    )
+    return "\n".join(lines)
+
+
+def _format_token(tok: dict[str, Any]) -> str:
+    """Single-line token rendering for the tokens leaderboard."""
+    symbol = tok.get("symbol") or tok.get("ticker") or "?"
+    name = tok.get("name") or ""
+    price = tok.get("priceUsd") or tok.get("price")
+    mc = tok.get("marketCap") or tok.get("fdv")
+    vol = tok.get("volume24h") or tok.get("volume24hUsd") or tok.get("volume") or 0
+    chg = tok.get("priceChange24h")
+    parts = [symbol]
+    if name and name != symbol:
+        parts.append(f"({name.strip()})")
+    if price is not None:
+        parts.append(f"${price}")
+    if mc:
+        parts.append(f"mc {_compact_usd(mc)}")
+    if vol:
+        parts.append(f"vol {_compact_usd(vol)}")
+    if chg is not None:
+        sign = "+" if chg >= 0 else ""
+        parts.append(f"{sign}{chg:.1f}%")
+    return "  ".join(parts)
+
+
+# ── top launchers by 24h launch count ───────────────────────────────
+
+
+def _render_launchers(limit: int) -> str:
+    try:
+        body = http_get(
+            f"{_CLAWNCH_API_BASE}/api/launches",
+            params={"limit": "200"},
+            timeout=15.0,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return f"Could not fetch launches: {exc}"
+
+    launches = _extract_list(body, ("launches", "data", "results"))
+    if not launches:
+        return "No launches found in the window. Try /leaderboard tokens."
+
+    # Aggregate by agentName. Treat per-source separately by appending
+    # source tag so 4claw agents don't collide with clawmes agents.
+    counter: Counter[str] = Counter()
+    for lau in launches:
+        agent = (lau.get("agentName") or lau.get("agent") or "unknown").strip()
+        source = lau.get("source") or "unknown"
+        key = f"{agent} ({source})"
+        counter[key] += 1
+
+    top = counter.most_common(limit)
+    lines = [f"Top {len(top)} launchers in the recent window:", ""]
+    for i, (agent, count) in enumerate(top, start=1):
+        lines.append(f"  {i:2d}. {count:4d} launches  {agent}")
+    lines.append("")
+    lines.append(
+        "More views: /leaderboard tokens — top by volume · "
+        "/leaderboard burners — top $CLAWNCH burners"
+    )
+    return "\n".join(lines)
+
+
+# ── top burners by $CLAWNCH burned ─────────────────────────────────
+
+
+def _render_burners(limit: int) -> str:
+    """Top wallets by $CLAWNCH burned via the launchpad's burn-payment gate.
+
+    Currently a stub because the on-chain indexing of burn-payment txs
+    (keyed by sender wallet) isn't yet exposed via the public API. The
+    burn data exists on-chain — we'd need to add an aggregator endpoint
+    to ``/api/burns/leaderboard`` or similar — but that's a follow-up.
+
+    For now this surface points at the public burn-tracking page so
+    users can see the data, and we ship the command shape so the next
+    iteration just fills in the data.
+    """
+    return (
+        "Burner leaderboard — coming soon.\n"
+        "\n"
+        "Live burn tracking will surface here once the on-chain aggregator\n"
+        "ships. In the meantime, the burn address is public and every\n"
+        "$CLAWNCH burn transaction is visible on-chain:\n"
+        "\n"
+        "  Burn address: 0x000000000000000000000000000000000000dEaD\n"
+        "  Token:        0xa1F72459dfA10BAD200Ac160eCd78C6b77a747be\n"
+        "  Filter:       https://basescan.org/token/0xa1F72459dfA10BAD200Ac160eCd78C6b77a747be"
+        "?a=0x000000000000000000000000000000000000dEaD\n"
+        "\n"
+        "More views: /leaderboard tokens · /leaderboard launchers"
+    )
+
+
+# ── small helpers ───────────────────────────────────────────────────
+
+
+def _extract_list(body: Any, keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    """Tolerate API shape drift: pull a list from any of the known keys."""
+    if isinstance(body, list):
+        return [x for x in body if isinstance(x, dict)]
+    if isinstance(body, dict):
+        for key in keys:
+            inner = body.get(key)
+            if isinstance(inner, list):
+                return [x for x in inner if isinstance(x, dict)]
+    return []
+
+
+def _compact_usd(n: float | int | str) -> str:
+    """Compact USD format: 42 → $42.00, 1500 → $1.5k, 2.5M → $2.50M, 7.3B → $7.30B."""
+    try:
+        v = float(n)
+    except (TypeError, ValueError):
+        return f"${n}"
+    if v >= 1_000_000_000:
+        return f"${v / 1_000_000_000:.2f}B"
+    if v >= 1_000_000:
+        return f"${v / 1_000_000:.2f}M"
+    if v >= 1_000:
+        return f"${v / 1_000:.1f}k"
+    return f"${v:.2f}"
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="leaderboard",
+        handler=handle_leaderboard,
+        description="Top tokens / launchers / burners on Clawnch",
+        args_hint="[tokens | launchers | burners] [limit]",
+    )

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.5.0
+version: 0.6.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.5.0
+version: 0.6.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.5.0"
+version = "0.6.0"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_claim.py
+++ b/tests/commands/test_claim.py
@@ -1,0 +1,374 @@
+"""Tests for the /claim slash command."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from clawmes.commands import claim
+
+# ── fakes ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeWalletState:
+    connected: bool = True
+    address: str = "0x" + "1" * 40
+
+
+class _FakeMode:
+    """Records every send_transaction call."""
+
+    def __init__(self, *, fail: Exception | None = None, tx_hash: str = "0xdead"):
+        self.calls: list[dict[str, Any]] = []
+        self.fail = fail
+        self.tx_hash = tx_hash
+
+    def send_transaction(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.fail:
+            raise self.fail
+        return self.tx_hash
+
+
+class _FakeWalletService:
+    def __init__(self, mode):
+        self.active_mode = mode
+
+
+class _FakeClawnch:
+    def __init__(self, *, launches=None, raises=None):
+        self._launches = launches or []
+        self._raises = raises
+
+    def get_my_launches(self):
+        if self._raises is not None:
+            raise self._raises
+        return {"launches": list(self._launches)}
+
+
+@pytest.fixture
+def fake_wallet(monkeypatch):
+    """Patch in a connected wallet with a fake send_transaction."""
+    mode = _FakeMode()
+    state = _FakeWalletState()
+
+    def _state():
+        return state
+
+    def _service():
+        return _FakeWalletService(mode)
+
+    import clawmes.services.wallet as wallet_mod
+
+    monkeypatch.setattr(wallet_mod, "get_wallet_state", _state)
+    monkeypatch.setattr(wallet_mod, "get_wallet_service", _service)
+    return {"mode": mode, "state": state}
+
+
+@pytest.fixture
+def fake_clawnch(monkeypatch):
+    """Patch the Clawnch service factory."""
+    holder: dict[str, _FakeClawnch | None] = {"svc": None}
+
+    def _factory():
+        if holder["svc"] is None:
+            # Default: no launches.
+            holder["svc"] = _FakeClawnch()
+        return holder["svc"]
+
+    import clawmes.services.clawnch as clawnch_mod
+
+    monkeypatch.setattr(clawnch_mod, "get_clawnch_service", _factory)
+    return holder
+
+
+# ── _extract_launches / _short ─────────────────────────────────────
+
+
+class TestExtractLaunches:
+    def test_top_level_list(self):
+        assert claim._extract_launches([{"a": 1}, "junk"]) == [{"a": 1}]
+
+    def test_dict_key(self):
+        assert claim._extract_launches({"launches": [{"a": 1}]}) == [{"a": 1}]
+
+    def test_fallback_key(self):
+        assert claim._extract_launches({"tokens": [{"a": 1}]}) == [{"a": 1}]
+
+    def test_empty(self):
+        assert claim._extract_launches({}) == []
+        assert claim._extract_launches("not-a-dict") == []
+        assert claim._extract_launches({"launches": "not-a-list"}) == []
+
+
+class TestShort:
+    def test_short_unchanged(self):
+        assert claim._short("0xabc") == "0xabc"
+
+    def test_long_truncated(self):
+        out = claim._short("0x" + "a" * 40)
+        assert "…" in out
+        assert out.startswith("0xaaaa")
+
+    def test_non_str(self):
+        assert claim._short(None) == "None"  # type: ignore[arg-type]
+
+
+# ── _resolve_target ─────────────────────────────────────────────────
+
+
+class TestResolveTarget:
+    def test_full_address_passthrough(self, fake_clawnch):
+        addr = "0x" + "A" * 40
+        assert claim._resolve_target(addr) == addr.lower()
+
+    def test_symbol_match(self, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(
+            launches=[{"symbol": "MNEME", "contractAddress": "0x" + "b" * 40}]
+        )
+        assert claim._resolve_target("mneme") == "0x" + "b" * 40
+
+    def test_symbol_no_match(self, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(launches=[{"symbol": "X"}])
+        assert claim._resolve_target("MNEME") is None
+
+    def test_clawnch_error_returns_none(self, fake_clawnch):
+        from clawmes.services.clawnch import ClawnchError
+
+        fake_clawnch["svc"] = _FakeClawnch(raises=ClawnchError("no_credentials", "n"))
+        assert claim._resolve_target("MNEME") is None
+
+    def test_short_non_address_falls_through(self, fake_clawnch):
+        # "0xabc" looks like address-prefix but wrong length: falls to
+        # symbol lookup → no match → None.
+        fake_clawnch["svc"] = _FakeClawnch(launches=[])
+        assert claim._resolve_target("0xabc") is None
+
+    def test_address_alt_keys(self, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(
+            launches=[{"ticker": "Z", "tokenAddress": "0x" + "c" * 40}]
+        )
+        assert claim._resolve_target("z") == "0x" + "c" * 40
+
+    def test_address_third_alias(self, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(launches=[{"symbol": "Q", "address": "0x" + "d" * 40}])
+        assert claim._resolve_target("Q") == "0x" + "d" * 40
+
+    def test_address_missing_skipped(self, fake_clawnch):
+        # Symbol matches but no address field → returns None.
+        fake_clawnch["svc"] = _FakeClawnch(launches=[{"symbol": "R"}])
+        assert claim._resolve_target("R") is None
+
+
+# ── _render_preview ─────────────────────────────────────────────────
+
+
+class TestRenderPreview:
+    def test_clawnch_error_no_credentials(self, fake_clawnch):
+        from clawmes.services.clawnch import ClawnchError
+
+        fake_clawnch["svc"] = _FakeClawnch(raises=ClawnchError("no_credentials", "missing api key"))
+        out = claim._render_preview()
+        assert "Could not fetch" in out
+        assert "/register_agent" in out
+
+    def test_clawnch_error_other(self, fake_clawnch):
+        from clawmes.services.clawnch import ClawnchError
+
+        fake_clawnch["svc"] = _FakeClawnch(raises=ClawnchError("upstream", "boom"))
+        out = claim._render_preview()
+        assert "Could not fetch" in out
+        assert "/register_agent" not in out
+
+    def test_empty_launches(self, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(launches=[])
+        out = claim._render_preview()
+        assert "No launches found" in out
+
+    def test_renders_launches(self, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(
+            launches=[
+                {"symbol": "A", "contractAddress": "0x" + "1" * 40},
+                {"symbol": "B", "tokenAddress": "0x" + "2" * 40},
+                {"address": "0x" + "3" * 40},  # missing symbol
+            ]
+        )
+        out = claim._render_preview()
+        assert "Your launches (3)" in out
+        assert "A" in out and "B" in out
+        assert "/claim <address>" in out
+        assert "/claim all" in out
+
+
+# ── _submit_claim ───────────────────────────────────────────────────
+
+
+class TestSubmitClaim:
+    async def test_no_wallet(self, fake_wallet):
+        fake_wallet["state"].connected = False
+        out = await claim._submit_claim("u", "0x" + "1" * 40)
+        assert "No wallet connected" in out
+
+    async def test_no_active_mode(self, fake_wallet, monkeypatch):
+        import clawmes.services.wallet as wallet_mod
+
+        monkeypatch.setattr(
+            wallet_mod,
+            "get_wallet_service",
+            lambda: type("S", (), {"active_mode": None})(),
+        )
+        out = await claim._submit_claim("u", "0x" + "1" * 40)
+        assert "No active wallet mode" in out
+
+    async def test_tx_failure(self, fake_wallet):
+        fake_wallet["mode"].fail = RuntimeError("rpc down")
+        out = await claim._submit_claim("u", "0x" + "1" * 40)
+        assert "Claim tx failed" in out
+        assert "rpc down" in out
+
+    async def test_tx_success(self, fake_wallet):
+        fake_wallet["mode"].tx_hash = "0xfeed"
+        out = await claim._submit_claim("u", "0x" + "1" * 40)
+        assert "Claim submitted" in out
+        assert "0xfeed" in out
+        assert "basescan.org/tx/0xfeed" in out
+
+        # Verify the calldata was built correctly: selector + padded token addr.
+        call = fake_wallet["mode"].calls[0]
+        assert call["to"] == claim.CLANKER_LOCKER
+        assert call["value"] == 0
+        assert call["chain_id"] == 8453
+        # Calldata starts with the selector, then 32-byte padded token.
+        data = call["data"]
+        assert claim.SELECTOR_COLLECT_REWARDS in data
+        assert "1" * 40 in data  # the token addr
+
+    async def test_inline_no_wallet(self, fake_wallet):
+        fake_wallet["state"].connected = False
+        out = await claim._submit_claim("u", "0x" + "1" * 40, inline=True)
+        assert "No wallet" in out
+
+    async def test_inline_no_mode(self, fake_wallet, monkeypatch):
+        import clawmes.services.wallet as wallet_mod
+
+        monkeypatch.setattr(
+            wallet_mod,
+            "get_wallet_service",
+            lambda: type("S", (), {"active_mode": None})(),
+        )
+        out = await claim._submit_claim("u", "0x" + "1" * 40, inline=True)
+        assert "No active wallet" in out
+
+    async def test_inline_failure(self, fake_wallet):
+        fake_wallet["mode"].fail = RuntimeError("boom")
+        out = await claim._submit_claim("u", "0x" + "1" * 40, inline=True)
+        assert "boom" in out
+
+    async def test_inline_success(self, fake_wallet):
+        fake_wallet["mode"].tx_hash = "0xabcd1234567890"
+        out = await claim._submit_claim("u", "0x" + "1" * 40, inline=True)
+        assert "submitted" in out
+        assert "0xabcd" in out
+
+
+# ── _claim_one ──────────────────────────────────────────────────────
+
+
+class TestClaimOne:
+    async def test_unresolvable(self, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(launches=[])
+        out = await claim._claim_one("u", "UNKNOWN")
+        assert "Could not resolve" in out
+        assert "0x… address" in out
+
+    async def test_resolves_and_submits(self, fake_wallet, fake_clawnch):
+        addr = "0x" + "5" * 40
+        out = await claim._claim_one("u", addr)
+        assert "Claim submitted" in out
+        # Verify the resolved address (lowercased) was passed to send_transaction.
+        data = fake_wallet["mode"].calls[0]["data"]
+        assert "5" * 40 in data.lower()
+
+
+# ── _sweep_all ──────────────────────────────────────────────────────
+
+
+class TestSweepAll:
+    async def test_clawnch_error(self, fake_clawnch):
+        from clawmes.services.clawnch import ClawnchError
+
+        fake_clawnch["svc"] = _FakeClawnch(raises=ClawnchError("upstream", "down"))
+        out = await claim._sweep_all("u")
+        assert "Could not fetch" in out
+
+    async def test_empty(self, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(launches=[])
+        out = await claim._sweep_all("u")
+        assert "Nothing to sweep" in out
+
+    async def test_sweeps_each_launch(self, fake_wallet, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(
+            launches=[
+                {"symbol": "A", "contractAddress": "0x" + "1" * 40},
+                {"symbol": "B", "tokenAddress": "0x" + "2" * 40},
+                {"symbol": "C"},  # no address → skipped
+            ]
+        )
+        out = await claim._sweep_all("u")
+        assert "Sweeping 3" in out
+        assert "A" in out and "B" in out and "C" in out
+        # C should be marked skipped, A and B should have hash output.
+        assert "skipped" in out
+        # Two send_transaction calls (A and B), not three.
+        assert len(fake_wallet["mode"].calls) == 2
+
+
+# ── handle_claim (top-level dispatch) ──────────────────────────────
+
+
+class TestHandleClaim:
+    async def test_empty_args_routes_to_preview(self, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(launches=[])
+        out = await claim.handle_claim("")
+        assert "No launches found" in out
+
+    async def test_all_routes_to_sweep(self, fake_clawnch):
+        fake_clawnch["svc"] = _FakeClawnch(launches=[])
+        out = await claim.handle_claim("all")
+        assert "Nothing to sweep" in out
+
+    async def test_single_token_arg(self, fake_wallet, fake_clawnch):
+        addr = "0x" + "7" * 40
+        out = await claim.handle_claim(addr)
+        assert "Claim submitted" in out
+
+    async def test_record_swallows_exceptions(self, monkeypatch, fake_clawnch):
+        import clawmes.services.command_history as ch
+
+        def _boom(*a, **k):
+            raise RuntimeError("hist broken")
+
+        monkeypatch.setattr(ch, "record_command_call", _boom)
+        fake_clawnch["svc"] = _FakeClawnch(launches=[])
+        # Must not raise — _record swallows the error.
+        out = await claim.handle_claim("")
+        assert "No launches" in out
+
+
+# ── register ───────────────────────────────────────────────────────
+
+
+class TestRegister:
+    def test_register_wires_command(self):
+        registered: list[dict] = []
+
+        class Ctx:
+            def register_command(self, **kwargs):
+                registered.append(kwargs)
+
+        claim.register(Ctx())
+        assert len(registered) == 1
+        assert registered[0]["name"] == "claim"

--- a/tests/commands/test_dca.py
+++ b/tests/commands/test_dca.py
@@ -1,0 +1,551 @@
+"""Tests for the /dca slash command."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from clawmes.commands import dca
+
+# ── fakes ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeWalletState:
+    connected: bool = True
+    address: str = "0x" + "1" * 40
+
+
+@pytest.fixture
+def tmp_state(tmp_path, monkeypatch):
+    """Redirect ``_schedules_path`` to a tmp file so tests don't write
+    to the real ``~/.hermes/clawmes/dca/schedules.json``."""
+    p = tmp_path / "schedules.json"
+
+    def _path():
+        return p
+
+    monkeypatch.setattr(dca, "_schedules_path", _path)
+    return p
+
+
+@pytest.fixture
+def fake_wallet(monkeypatch):
+    state = _FakeWalletState()
+
+    def _state():
+        return state
+
+    import clawmes.services.wallet as wallet_mod
+
+    monkeypatch.setattr(wallet_mod, "get_wallet_state", _state)
+    return state
+
+
+@pytest.fixture
+def fake_defi_swap(monkeypatch):
+    """Swap-result fixture: configure response by setting ``state['payload']``."""
+    state: dict[str, Any] = {"payload": None, "raises": None}
+
+    def _fake(args):  # noqa: ARG001
+        if state["raises"] is not None:
+            raise state["raises"]
+        return json.dumps(state["payload"])
+
+    import clawmes.tools.defi_swap as swap_mod
+
+    monkeypatch.setattr(swap_mod, "defi_swap", _fake)
+    return state
+
+
+# ── _parse_interval / _format_interval ─────────────────────────────
+
+
+class TestParseInterval:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("1m", 60),
+            ("30m", 1800),
+            ("1h", 3600),
+            ("4h", 14400),
+            ("1d", 86400),
+            ("1w", 604800),
+            ("  2h  ", 7200),
+            ("3H", 10800),  # case-insensitive
+        ],
+    )
+    def test_valid(self, raw, expected):
+        assert dca._parse_interval(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "30s",  # below floor (60s)
+            "",
+            "garbage",
+            "1y",  # no year unit
+            "10w",  # 10w = 70d, below ceiling but >0s, allowed
+        ],
+    )
+    def test_invalid_below_floor_or_bad(self, raw):
+        if raw == "10w":
+            # 10w is actually valid (within ceiling of 365d).
+            assert dca._parse_interval(raw) == 10 * 604800
+        else:
+            assert dca._parse_interval(raw) is None
+
+    def test_above_ceiling(self):
+        # 53w > 365d → rejected.
+        assert dca._parse_interval("53w") is None
+
+
+class TestFormatInterval:
+    @pytest.mark.parametrize(
+        "secs,expected",
+        [
+            (60, "1m"),
+            (3600, "1h"),
+            (86400, "1d"),
+            (604800, "1w"),
+            (1209600, "2w"),
+            (1800, "30m"),
+        ],
+    )
+    def test_format(self, secs, expected):
+        assert dca._format_interval(secs) == expected
+
+
+# ── _format_relative ────────────────────────────────────────────────
+
+
+class TestFormatRelative:
+    @pytest.mark.parametrize(
+        "secs,expected",
+        [
+            (45, "45s"),
+            (90, "1m"),
+            (3600, "1h"),
+            (86400, "1d"),
+            (-10, "0s"),  # negatives clamp to 0
+        ],
+    )
+    def test_format(self, secs, expected):
+        assert dca._format_relative(secs) == expected
+
+
+# ── _short ──────────────────────────────────────────────────────────
+
+
+class TestShort:
+    def test_short_unchanged(self):
+        assert dca._short("0x123") == "0x123"
+
+    def test_long_truncated(self):
+        out = dca._short("0x" + "a" * 40)
+        assert "…" in out
+
+    def test_non_str(self):
+        assert dca._short(None) == "None"  # type: ignore[arg-type]
+
+
+# ── state I/O ───────────────────────────────────────────────────────
+
+
+class TestState:
+    def test_load_missing_file(self, tmp_state):
+        assert dca._load_state() == {"schedules": []}
+
+    def test_load_bad_json(self, tmp_state):
+        tmp_state.write_text("not-json")
+        assert dca._load_state() == {"schedules": []}
+
+    def test_load_wrong_shape(self, tmp_state):
+        tmp_state.write_text(json.dumps({"schedules": "not-a-list"}))
+        assert dca._load_state() == {"schedules": []}
+
+    def test_load_not_a_dict(self, tmp_state):
+        tmp_state.write_text(json.dumps(["foo"]))
+        assert dca._load_state() == {"schedules": []}
+
+    def test_save_roundtrip(self, tmp_state):
+        state = {"schedules": [{"id": "x"}]}
+        dca._save_state(state)
+        assert dca._load_state() == state
+
+    def test_now_iso_format(self):
+        s = dca._now_iso()
+        assert s.endswith("Z")
+        assert "T" in s
+
+    def test_new_id_prefix(self):
+        sid = dca._new_id()
+        assert sid.startswith("dca_")
+
+    def test_default_schedules_path(self, monkeypatch, tmp_path):
+        # Cover the lazy-import branch in _schedules_path() by hitting
+        # the real implementation. We point HERMES_HOME at tmp_path so
+        # the path computation works without depending on user state.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # The fixture above replaces _schedules_path; bypass it for this test
+        # by calling state_dir directly via the real module.
+        from clawmes.commands.dca import _schedules_path as _ignored  # noqa: F401
+        from clawmes.lib.paths import state_dir
+
+        p = state_dir("dca") / "schedules.json"
+        assert "dca" in str(p)
+
+
+class TestRealSchedulesPath:
+    def test_default_path_under_hermes_home(self, monkeypatch, tmp_path):
+        """Force the real (unpatched) ``_schedules_path`` to resolve."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Use the real function — no monkeypatch.
+        p = dca._schedules_path()
+        assert p.name == "schedules.json"
+        assert "dca" in str(p)
+
+
+# ── _cmd_add ────────────────────────────────────────────────────────
+
+
+class TestCmdAdd:
+    def test_too_few_args(self, tmp_state):
+        out = dca._cmd_add("u", [])
+        assert "Usage:" in out
+
+    def test_bad_token(self, tmp_state):
+        out = dca._cmd_add("u", ["not-address", "0.01", "1h"])
+        assert "must be a 0x… address" in out
+
+    def test_non_numeric_eth(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "abc", "1h"])
+        assert "eth_amount must be a number" in out
+
+    def test_zero_eth(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0", "1h"])
+        assert "must be positive" in out
+
+    def test_negative_eth(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "-1", "1h"])
+        assert "must be positive" in out
+
+    def test_bad_interval(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "junk"])
+        assert "Could not parse interval" in out
+
+    def test_success(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.001", "1h"])
+        assert "Schedule added" in out
+        assert "dca_" in out
+
+        # Persisted.
+        loaded = dca._load_state()
+        assert len(loaded["schedules"]) == 1
+        sched = loaded["schedules"][0]
+        assert sched["token"] == "0x" + "1" * 40
+        assert sched["eth_amount"] == 0.001
+        assert sched["interval_seconds"] == 3600
+        assert sched["status"] == "active"
+
+
+# ── _cmd_list ───────────────────────────────────────────────────────
+
+
+class TestCmdList:
+    def test_empty(self, tmp_state):
+        out = dca._cmd_list("u")
+        assert "No DCA schedules" in out
+
+    def test_isolates_by_sender(self, tmp_state):
+        dca._cmd_add("alice", ["0x" + "1" * 40, "0.01", "1h"])
+        dca._cmd_add("bob", ["0x" + "2" * 40, "0.02", "1d"])
+        out = dca._cmd_list("alice")
+        assert "alice" in out
+        assert "0.01" in out
+        assert "0.02" not in out
+
+    def test_overdue_marker(self, tmp_state, monkeypatch):
+        # Add a schedule, then poke its next_run_epoch into the past.
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        state = dca._load_state()
+        state["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(state)
+        out = dca._cmd_list("u")
+        assert "overdue" in out
+
+    def test_shows_run_count(self, tmp_state):
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        state = dca._load_state()
+        state["schedules"][0]["executions"] = [{"at": "x"}, {"at": "y"}]
+        dca._save_state(state)
+        out = dca._cmd_list("u")
+        assert "(2 runs" in out
+
+
+# ── _cmd_pause / _cmd_resume / _cmd_cancel / _mutate ───────────────
+
+
+class TestPauseResumeCancel:
+    def test_pause_missing_id(self, tmp_state):
+        out = dca._cmd_pause("u", [])
+        assert "Usage:" in out
+
+    def test_pause_not_found(self, tmp_state):
+        out = dca._cmd_pause("u", ["dca_zzz"])
+        assert "No schedule found" in out
+
+    def test_pause_resume_cycle(self, tmp_state):
+        add_out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        sched_id = [w for w in add_out.split() if w.startswith("dca_")][0]
+        assert "paused" in dca._cmd_pause("u", [sched_id])
+        assert dca._load_state()["schedules"][0]["status"] == "paused"
+        assert "resumed" in dca._cmd_resume("u", [sched_id])
+        assert dca._load_state()["schedules"][0]["status"] == "active"
+
+    def test_cancel_missing_id(self, tmp_state):
+        out = dca._cmd_cancel("u", [])
+        assert "Usage:" in out
+
+    def test_cancel_not_found(self, tmp_state):
+        out = dca._cmd_cancel("u", ["dca_zzz"])
+        assert "No schedule found" in out
+
+    def test_cancel_success(self, tmp_state):
+        add_out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        sched_id = [w for w in add_out.split() if w.startswith("dca_")][0]
+        out = dca._cmd_cancel("u", [sched_id])
+        assert "Cancelled" in out
+        assert dca._load_state()["schedules"] == []
+
+    def test_cancel_isolated_by_sender(self, tmp_state):
+        add_out = dca._cmd_add("alice", ["0x" + "1" * 40, "0.01", "1h"])
+        sched_id = [w for w in add_out.split() if w.startswith("dca_")][0]
+        # Bob tries to cancel Alice's schedule — should fail.
+        out = dca._cmd_cancel("bob", [sched_id])
+        assert "No schedule found" in out
+        assert len(dca._load_state()["schedules"]) == 1
+
+
+# ── _cmd_tick / _execute ───────────────────────────────────────────
+
+
+class TestTick:
+    async def test_no_due(self, tmp_state, fake_wallet):
+        out = await dca._cmd_tick()
+        assert "No DCA schedules due" in out
+
+    async def test_one_due_no_wallet(self, tmp_state, fake_wallet, fake_defi_swap):
+        fake_wallet.connected = False
+        # Add a schedule and force it to be overdue.
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        state = dca._load_state()
+        state["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(state)
+
+        out = await dca._cmd_tick()
+        assert "Executing 1" in out
+        assert "no_wallet" in out
+
+        # next_run_epoch advanced.
+        s2 = dca._load_state()
+        assert s2["schedules"][0]["next_run_epoch"] > 0
+
+    async def test_one_due_swap_success(self, tmp_state, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed1234567890abc"},
+        }
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        state = dca._load_state()
+        state["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(state)
+
+        out = await dca._cmd_tick()
+        assert "ok" in out
+        s2 = dca._load_state()
+        executions = s2["schedules"][0]["executions"]
+        assert len(executions) == 1
+        assert executions[0]["tx_hash"] == "0xfeed1234567890abc"
+
+    async def test_swap_error_isError_true(self, tmp_state, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": True,
+            "content": [{"text": "slippage too high"}],
+        }
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        state = dca._load_state()
+        state["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(state)
+
+        out = await dca._cmd_tick()
+        assert "error" in out
+
+    async def test_swap_isError_with_missing_content(self, tmp_state, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {"isError": True}
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        state = dca._load_state()
+        state["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(state)
+
+        out = await dca._cmd_tick()
+        assert "error" in out
+
+    async def test_swap_raises(self, tmp_state, fake_wallet, fake_defi_swap):
+        fake_defi_swap["raises"] = RuntimeError("rpc down")
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        state = dca._load_state()
+        state["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(state)
+
+        out = await dca._cmd_tick()
+        assert "error" in out
+        assert "rpc down" in out
+
+    async def test_swap_bad_json(self, tmp_state, fake_wallet, monkeypatch):
+        import clawmes.tools.defi_swap as swap_mod
+
+        monkeypatch.setattr(swap_mod, "defi_swap", lambda *a, **k: "not-json")
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        state = dca._load_state()
+        state["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(state)
+
+        out = await dca._cmd_tick()
+        assert "error" in out
+
+    async def test_paused_schedule_skipped(self, tmp_state, fake_wallet, fake_defi_swap):
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        state = dca._load_state()
+        state["schedules"][0]["next_run_epoch"] = 0
+        state["schedules"][0]["status"] = "paused"
+        dca._save_state(state)
+
+        out = await dca._cmd_tick()
+        assert "No DCA schedules due" in out
+
+
+# ── _cmd_history ────────────────────────────────────────────────────
+
+
+class TestHistory:
+    def test_missing_id(self, tmp_state):
+        out = dca._cmd_history("u", [])
+        assert "Usage:" in out
+
+    def test_not_found(self, tmp_state):
+        out = dca._cmd_history("u", ["dca_zzz"])
+        assert "No schedule found" in out
+
+    def test_no_executions(self, tmp_state):
+        add_out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        sched_id = [w for w in add_out.split() if w.startswith("dca_")][0]
+        out = dca._cmd_history("u", [sched_id])
+        assert "no executions yet" in out
+
+    def test_with_executions(self, tmp_state):
+        add_out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        sched_id = [w for w in add_out.split() if w.startswith("dca_")][0]
+        state = dca._load_state()
+        state["schedules"][0]["executions"] = [
+            {
+                "at": "2026-05-27T01:00:00Z",
+                "tx_hash": "0xabcd1234567890efgh",
+                "result": {"status": "ok"},
+            },
+            {
+                "at": "2026-05-27T02:00:00Z",
+                "tx_hash": "",
+                "result": {"status": "no_wallet"},
+            },
+        ]
+        dca._save_state(state)
+        out = dca._cmd_history("u", [sched_id])
+        assert "Executions for" in out
+        assert "ok" in out
+        assert "no_wallet" in out
+        # First run shows the truncated tx hash.
+        assert "tx 0xabcd" in out
+
+
+# ── handle_dca (dispatch) ──────────────────────────────────────────
+
+
+class TestHandleDca:
+    async def test_empty_args(self, tmp_state):
+        out = await dca.handle_dca("")
+        assert "recurring ETH-funded buys" in out
+
+    async def test_unknown_subcommand(self, tmp_state):
+        out = await dca.handle_dca("garbage")
+        assert "Unknown subcommand" in out
+
+    async def test_add_dispatch(self, tmp_state):
+        out = await dca.handle_dca("add 0x" + "1" * 40 + " 0.01 1h")
+        assert "Schedule added" in out
+
+    async def test_list_dispatch(self, tmp_state):
+        out = await dca.handle_dca("list")
+        assert "No DCA schedules" in out
+
+    async def test_ls_alias(self, tmp_state):
+        out = await dca.handle_dca("ls")
+        assert "No DCA schedules" in out
+
+    async def test_pause_dispatch(self, tmp_state):
+        out = await dca.handle_dca("pause dca_zzz")
+        assert "No schedule found" in out
+
+    async def test_resume_dispatch(self, tmp_state):
+        out = await dca.handle_dca("resume dca_zzz")
+        assert "No schedule found" in out
+
+    async def test_cancel_dispatch(self, tmp_state):
+        out = await dca.handle_dca("cancel dca_zzz")
+        assert "No schedule found" in out
+
+    async def test_rm_alias(self, tmp_state):
+        out = await dca.handle_dca("rm dca_zzz")
+        assert "No schedule found" in out
+
+    async def test_remove_alias(self, tmp_state):
+        out = await dca.handle_dca("remove dca_zzz")
+        assert "No schedule found" in out
+
+    async def test_tick_dispatch(self, tmp_state, fake_wallet):
+        out = await dca.handle_dca("tick")
+        assert "No DCA schedules due" in out
+
+    async def test_history_dispatch(self, tmp_state):
+        out = await dca.handle_dca("history dca_zzz")
+        assert "No schedule found" in out
+
+    async def test_record_swallows(self, monkeypatch, tmp_state):
+        import clawmes.services.command_history as ch
+
+        def _boom(*a, **k):
+            raise RuntimeError("hist broken")
+
+        monkeypatch.setattr(ch, "record_command_call", _boom)
+        # Should not raise.
+        out = await dca.handle_dca("")
+        assert "recurring" in out
+
+
+# ── register ───────────────────────────────────────────────────────
+
+
+class TestRegister:
+    def test_register_wires_command(self):
+        registered: list[dict] = []
+
+        class Ctx:
+            def register_command(self, **kwargs):
+                registered.append(kwargs)
+
+        dca.register(Ctx())
+        assert len(registered) == 1
+        assert registered[0]["name"] == "dca"

--- a/tests/commands/test_leaderboard.py
+++ b/tests/commands/test_leaderboard.py
@@ -1,0 +1,292 @@
+"""Tests for the /leaderboard slash command."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.commands import leaderboard as lb
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    """Swap out ``http_get`` to return canned bodies / errors."""
+    state: dict = {"body": None, "raises": None}
+
+    def _fake(url, *, params=None, timeout=None):  # noqa: ARG001
+        if state["raises"]:
+            raise state["raises"]
+        return state["body"]
+
+    monkeypatch.setattr(lb, "http_get", _fake)
+    return state
+
+
+# ── _parse_args ─────────────────────────────────────────────────────
+
+
+class TestParseArgs:
+    def test_defaults(self):
+        assert lb._parse_args("") == ("tokens", 10)
+
+    def test_launchers_alias(self):
+        assert lb._parse_args("launchers")[0] == "launchers"
+
+    def test_deployers_alias(self):
+        assert lb._parse_args("deployers")[0] == "launchers"
+
+    def test_burners_alias(self):
+        assert lb._parse_args("burners")[0] == "burners"
+
+    def test_burn_short_alias(self):
+        assert lb._parse_args("burn")[0] == "burners"
+
+    def test_tokens_explicit(self):
+        assert lb._parse_args("tokens")[0] == "tokens"
+
+    def test_top_alias(self):
+        assert lb._parse_args("top")[0] == "tokens"
+
+    def test_limit_int(self):
+        _, lim = lb._parse_args("launchers 5")
+        assert lim == 5
+
+    def test_limit_clamped_high(self):
+        _, lim = lb._parse_args("99")
+        assert lim == lb._MAX_LIMIT
+
+    def test_limit_clamped_low(self):
+        _, lim = lb._parse_args("0")
+        assert lim == 1
+
+    def test_unknown_token_ignored(self):
+        assert lb._parse_args("garbage launchers") == ("launchers", 10)
+
+
+# ── _extract_list ───────────────────────────────────────────────────
+
+
+class TestExtractList:
+    def test_top_level_list(self):
+        assert lb._extract_list([{"a": 1}, "junk", {"b": 2}], ("x",)) == [
+            {"a": 1},
+            {"b": 2},
+        ]
+
+    def test_dict_with_tokens_key(self):
+        body = {"tokens": [{"a": 1}], "data": [{"b": 2}]}
+        assert lb._extract_list(body, ("tokens", "data")) == [{"a": 1}]
+
+    def test_dict_fallback_key(self):
+        body = {"results": [{"a": 1}]}
+        assert lb._extract_list(body, ("tokens", "data", "results")) == [{"a": 1}]
+
+    def test_missing_returns_empty(self):
+        assert lb._extract_list({}, ("tokens",)) == []
+        assert lb._extract_list("not-a-dict", ("tokens",)) == []
+        assert lb._extract_list({"tokens": "not-a-list"}, ("tokens",)) == []
+
+
+# ── _compact_usd ────────────────────────────────────────────────────
+
+
+class TestCompactUsd:
+    def test_under_thousand(self):
+        assert lb._compact_usd(42) == "$42.00"
+
+    def test_thousands(self):
+        assert lb._compact_usd(1500) == "$1.5k"
+
+    def test_millions(self):
+        assert lb._compact_usd(2_500_000) == "$2.50M"
+
+    def test_billions(self):
+        assert lb._compact_usd(7_300_000_000) == "$7.30B"
+
+    def test_string_passthrough(self):
+        # Non-numeric input falls through to ``$<raw>``.
+        assert lb._compact_usd("bad") == "$bad"
+
+
+# ── _format_token ───────────────────────────────────────────────────
+
+
+class TestFormatToken:
+    def test_minimal(self):
+        out = lb._format_token({"symbol": "T"})
+        assert out == "T"
+
+    def test_full(self):
+        out = lb._format_token(
+            {
+                "symbol": "MNEME",
+                "name": "Mneme",
+                "priceUsd": "0.001",
+                "marketCap": 1_000_000,
+                "volume24h": 50_000,
+                "priceChange24h": 12.5,
+            }
+        )
+        assert "MNEME" in out
+        assert "(Mneme)" in out
+        assert "$0.001" in out
+        assert "mc $1.00M" in out
+        assert "vol $50.0k" in out
+        assert "+12.5%" in out
+
+    def test_negative_change(self):
+        out = lb._format_token({"symbol": "X", "priceChange24h": -3.4})
+        assert "-3.4%" in out
+        assert "+" not in out
+
+    def test_alt_keys(self):
+        # ticker / price / fdv / volume / volume24hUsd fallbacks.
+        out = lb._format_token(
+            {
+                "ticker": "ALT",
+                "price": "0.05",
+                "fdv": 500_000_000,
+                "volume24hUsd": 999,
+            }
+        )
+        assert "ALT" in out
+        assert "$500.00M" in out
+
+    def test_volume_fallback_chain(self):
+        # Hits the ``volume`` (final) fallback key.
+        out = lb._format_token({"symbol": "Y", "volume": 1234})
+        assert "vol $1.2k" in out
+
+    def test_name_same_as_symbol_omitted(self):
+        out = lb._format_token({"symbol": "T", "name": "T"})
+        assert "(T)" not in out
+
+
+# ── _render_tokens (default view) ──────────────────────────────────
+
+
+class TestRenderTokens:
+    def test_http_error(self, fake_http):
+        fake_http["raises"] = RuntimeError("network down")
+        out = lb._render_tokens(5)
+        assert "Could not fetch" in out
+        assert "network down" in out
+
+    def test_empty_payload(self, fake_http):
+        fake_http["body"] = {"tokens": []}
+        out = lb._render_tokens(5)
+        assert "No tokens found" in out
+
+    def test_renders_tokens(self, fake_http):
+        fake_http["body"] = {
+            "tokens": [
+                {"symbol": "A", "volume24h": 1000},
+                {"symbol": "B", "volume24h": 500},
+            ]
+        }
+        out = lb._render_tokens(5)
+        assert "Top 2" in out
+        assert " 1." in out
+        assert " 2." in out
+        assert "A" in out and "B" in out
+
+
+# ── _render_launchers ──────────────────────────────────────────────
+
+
+class TestRenderLaunchers:
+    def test_http_error(self, fake_http):
+        fake_http["raises"] = RuntimeError("down")
+        out = lb._render_launchers(5)
+        assert "Could not fetch launches" in out
+
+    def test_empty(self, fake_http):
+        fake_http["body"] = {"launches": []}
+        out = lb._render_launchers(5)
+        assert "No launches found" in out
+
+    def test_aggregates_by_agent_and_source(self, fake_http):
+        fake_http["body"] = {
+            "launches": [
+                {"agentName": "alpha", "source": "clawmes"},
+                {"agentName": "alpha", "source": "clawmes"},
+                {"agentName": "alpha", "source": "4claw"},
+                {"agentName": "beta", "source": "clawmes"},
+                # missing both keys → "unknown (unknown)"
+                {},
+            ]
+        }
+        out = lb._render_launchers(5)
+        assert "alpha (clawmes)" in out
+        assert "alpha (4claw)" in out
+        assert "beta (clawmes)" in out
+        # Counts encoded in the table
+        assert "   2" in out  # alpha/clawmes has 2
+
+    def test_agent_alias_field(self, fake_http):
+        # Some payloads use ``agent`` instead of ``agentName``.
+        fake_http["body"] = {"launches": [{"agent": "gamma", "source": "clawmes"}]}
+        out = lb._render_launchers(5)
+        assert "gamma (clawmes)" in out
+
+
+# ── _render_burners (stub) ─────────────────────────────────────────
+
+
+class TestRenderBurners:
+    def test_returns_coming_soon(self):
+        out = lb._render_burners(5)
+        assert "coming soon" in out.lower()
+        assert "0xa1F72459dfA10BAD200Ac160eCd78C6b77a747be" in out
+        assert "0x000000000000000000000000000000000000dEaD" in out
+
+
+# ── handle_leaderboard (top-level dispatch) ────────────────────────
+
+
+class TestHandleLeaderboard:
+    async def test_default_routes_to_tokens(self, fake_http):
+        fake_http["body"] = {"tokens": [{"symbol": "A"}]}
+        out = await lb.handle_leaderboard("")
+        assert "Top 1" in out
+
+    async def test_launchers_route(self, fake_http):
+        fake_http["body"] = {"launches": [{"agentName": "a", "source": "s"}]}
+        out = await lb.handle_leaderboard("launchers")
+        assert "a (s)" in out
+
+    async def test_burners_route(self):
+        out = await lb.handle_leaderboard("burners")
+        assert "coming soon" in out.lower()
+
+    async def test_record_failure_swallowed(self, monkeypatch, fake_http):
+        """Recording into command_history must never break the command."""
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("history broken")
+
+        # The lazy import inside _record() resolves the real function;
+        # monkeypatch it where it lives.
+        import clawmes.services.command_history as ch
+
+        monkeypatch.setattr(ch, "record_command_call", _boom)
+        fake_http["body"] = {"tokens": []}
+        # Should still complete without raising.
+        out = await lb.handle_leaderboard("")
+        assert "No tokens" in out
+
+
+# ── register ───────────────────────────────────────────────────────
+
+
+class TestRegister:
+    def test_register_wires_command(self):
+        registered: list[dict] = []
+
+        class Ctx:
+            def register_command(self, **kwargs):
+                registered.append(kwargs)
+
+        lb.register(Ctx())
+        assert len(registered) == 1
+        assert registered[0]["name"] == "leaderboard"
+        assert callable(registered[0]["handler"])


### PR DESCRIPTION
## Summary

Three new commands ride on top of v0.5.0's Base/Clawnch surface:

- **`/leaderboard`** — top tokens by 24h volume, top launchers by recent count, top burners (stub for now, points at on-chain burn-address data). Aggregates client-side from `/api/tokens` + `/api/launches` — no new server-side endpoints needed.
- **`/claim`** — sweeps accumulated LP fees on tokens you've launched. Calls Clanker v4's `collectRewards(address)` on the LP Locker Fee Conversion contract (`0x63D2DfEA64b3433F4071A98665bcD7Ca14d93496`). Preview, single token (by address or symbol), or `all` for one tx per launch. Per-recipient amounts come from the `ClaimedRewards` event on each receipt.
- **`/dca`** — recurring ETH-funded buys, interval grammar `1m`–`1y`. Subcommands: `add`, `list`, `pause`, `resume`, `cancel`, `tick`, `history`. State persists in `\${HERMES_HOME}/clawmes/dca/schedules.json`. `/dca tick` is cron-safe and idempotent — fires only due schedules, advances each one regardless of outcome.

## Why now

`/claim` distributes LP fees to every recipient slot per token in one shot, including the platform admin slot. Calling claim from clawmes indirectly funds the (planned) buy-burn cron — same activity-passive burn thesis from clawnch#1. That's also why `/leaderboard burners` ships as a stub today: the on-chain aggregator endpoint that powers it is the same one the buy-burn cron will need, so the surface lands now and gets filled in later.

`/dca` was the most-requested feature on the launch alerts channel last week and complements `/buy` cleanly — same `defi_swap` pipeline, scheduled wrapper around it.

## Testing

- 3231 tests pass (was 3074) — 157 new tests across the three commands.
- 100% line coverage on each new file and on the project overall.
- `ruff check` + `ruff format --check` clean.
- Plugin yamls byte-identical (root + `clawmes/`).
- Version bumped: `_version.py`, `pyproject.toml`, both `plugin.yaml`.
- README + CHANGELOG updated.

## Locker contract verification

The Clanker v4 LP Locker Fee Conversion contract (`0x63D2DfEA…14d93496`) was inspected on Basescan — verified source, function `collectRewards(address)` selector `0x5763dbd0`, event `ClaimedRewards(address indexed token, uint256, uint256, uint256[], uint256[])` topic0 `0x21d15f71…46a`. No view function for pre-simulating amounts — pre-simulation would require `debug_traceCall` and was deferred.