### PR TITLE
feat(dca): v2 — auto-scheduler, safeguards, edit/skip/dry-run/status (v0.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.6.1 — 2026-05-27
+
+### Added — `/dca` v2: auto-scheduler, safeguards, new subcommands
+
+`/dca` graduates from a manual cron-curio to a real "set it and
+forget it" feature.
+
+- **Auto-scheduler** — new `DcaSchedulerService` (id
+  `clawmes.dca_scheduler`) ticks on the registry cadence (every ~60s
+  by default, driven by Hermes cron) and dispatches every due
+  schedule. The manual `/dca tick` subcommand is preserved for
+  testing and edge-case use. Per-schedule failures are caught
+  internally so one bad token cannot stall the loop.
+
+- **Safeguards** — every schedule gets four new optional caps:
+  - `--slippage <bps>` (default 100 = 1%) — passed through to
+    `defi_swap` on each execution.
+  - `--daily-cap <eth>` — skips the run if executing it would push
+    24h spend over the cap. Old runs (>24h ago) and non-`ok` runs are
+    excluded from the window.
+  - `--max-total <eth>` — auto-pauses the schedule once lifetime
+    spend hits the cap.
+  - `--max-failures <n>` (default 3) — auto-pauses after N
+    consecutive failures (`error`, `no_wallet`, `daily_capped`, or
+    `total_capped`) so a misconfigured schedule can't drain gas.
+
+- **New subcommands:**
+  - `/dca edit <id> <field> <value>` — change any field on an
+    existing schedule. Editable fields: `token`, `eth_amount`,
+    `interval`, `slippage_bps`, `daily_cap_eth`, `max_eth_total`,
+    `max_consecutive_failures`. Caps accept `none` to clear.
+  - `/dca skip <id>` — bump `next_run_epoch` by the interval without
+    executing. Useful when you know a run would fail (e.g., wallet
+    deliberately offline) and want to keep the cadence.
+  - `/dca dry-run <id>` — quote the swap via `defi_swap` (action
+    `quote`) without submitting. Returns the expected buy amount.
+  - `/dca status` — global summary across all senders, plus the
+    scheduler service's tick + run counters.
+
+### Internal
+
+- `_execute` refactored to `_execute_sync` (no actual `await` needed
+  — wallet + swap calls were already sync). The async `/dca tick`
+  command now delegates to `_run_due_with_lines()` which both surfaces
+  return.
+- 3318 tests pass at 100% coverage (was 3231).
+- `clawmes/services/dca_scheduler.py` added (`DcaSchedulerService`).
+- README service count: 23 → 24.
+
 ## 0.6.0 — 2026-05-27
 
 ### Added — leaderboards, fee claiming, dollar-cost averaging

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Clawmes is a [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin. Wallets, DEX trading, lending and staking, governance, on-chain automation. Python rewrite of [`@clawnch/openclaw-crypto`](https://github.com/clawnchdev/openclawnch) targeting Hermes.
 
-52 tools. 84 commands. 23 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
+52 tools. 84 commands. 24 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
 
 ## Quick start
 
@@ -265,17 +265,26 @@ After launching (or any time): three commands cover the basic loop of finding to
 /claim all                         # sweep every launch you own — one tx per token
 
 /dca add 0xa1F7…747be 0.001 1h     # buy 0.001 ETH of CLAWNCH every hour
-/dca list                          # show all your schedules + next run time
+/dca add 0x… 0.01 4h --slippage 50 --daily-cap 0.05 --max-total 1 --max-failures 5
+                                   # full safeguard set on a single schedule
+/dca list                          # show your schedules + next run time
+/dca edit dca_abc 0xabc eth_amount 0.02
+                                   # change one field (token, eth_amount, interval,
+                                   # slippage_bps, daily_cap_eth, max_eth_total,
+                                   # max_consecutive_failures)
+/dca skip dca_abc123               # advance next run, no execution this round
+/dca dry-run dca_abc123            # preview swap output, no submission
+/dca status                        # global summary + service health
 /dca pause dca_abc123              # suspend without removing
 /dca resume dca_abc123             # re-arm
 /dca cancel dca_abc123             # delete
 /dca history dca_abc123            # past executions for a schedule
-/dca tick                          # run any due schedules (cron-callable, idempotent)
+/dca tick                          # manually execute due schedules (testing/debug)
 ```
 
 - `/leaderboard` hits `/api/tokens?sort=volume` + `/api/launches` and aggregates client-side. No new server-side endpoints required.
 - `/claim` calls Clanker v4's `collectRewards(address)` on the LP Locker Fee Conversion contract (`0x63D2DfEA…14d93496`). The locker pays out to every recipient slot per token in one shot — caller pays gas, the slot allocations get distributed to the rewardRecipients on that position. Each tx emits a `ClaimedRewards` event with per-recipient `(amount0, amount1)` arrays.
-- `/dca` schedules persist in `${HERMES_HOME}/clawmes/dca/schedules.json`. Interval grammar: `1m`, `30m`, `1h`, `4h`, `1d`, `1w` (1m floor, 1y ceiling). `/dca tick` is idempotent — only fires schedules whose `next_run_epoch` has passed, advances each schedule once per tick regardless of swap success/failure, so transient errors don't cascade into retry storms. Wire the tick into Hermes cron once you've set up schedules.
+- `/dca` schedules persist in `${HERMES_HOME}/clawmes/dca/schedules.json`. Interval grammar: `1m`, `30m`, `1h`, `4h`, `1d`, `1w` (1m floor, 1y ceiling). The `DcaSchedulerService` ticks automatically on the registry cadence — no manual cron wiring needed. Safeguards (slippage, daily-cap, max-total, max-failures) attach per-schedule; the `max-failures` counter auto-pauses runaway schedules so a broken swap path can't burn gas in a loop. `/dca tick` is preserved as a synchronous testing entrypoint.
 
 ## Base ecosystem integration
 

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/clawmes/commands/dca.py
+++ b/clawmes/commands/dca.py
@@ -2,32 +2,54 @@
 
 Recurring ETH-funded buys against a target token. Schedules live in
 ``${HERMES_HOME}/clawmes/dca/schedules.json`` so they survive process
-restarts. Execution happens on ``/dca tick`` — a hook that's safe to
-call from Hermes' cron loop (every minute is fine; tick is idempotent
-and only runs schedules whose ``next_run_at`` has passed).
+restarts. Execution happens automatically — the
+``clawmes.services.dca_scheduler.DcaSchedulerService`` ticks on the
+registry cadence (60s by default, configurable via Hermes cron) and
+dispatches due schedules. The manual ``/dca tick`` subcommand is
+preserved for testing + edge-case use.
 
 Surface:
 
-  * ``/dca add <token> <eth_amount> <interval>``  schedule a recurring buy
-  * ``/dca list``                                  show all your schedules
-  * ``/dca pause <id>``                            suspend without losing state
-  * ``/dca resume <id>``                           re-arm
-  * ``/dca cancel <id>``                           remove
-  * ``/dca tick``                                  execute any due schedules
-  * ``/dca history <id>``                          past executions
+  * ``/dca add <token> <eth_amount> <interval> [--slippage bps]
+    [--daily-cap eth] [--max-total eth] [--max-failures n]``
+                                              schedule a recurring buy
+  * ``/dca list``                              show all your schedules
+  * ``/dca pause <id>``                        suspend without losing state
+  * ``/dca resume <id>``                       re-arm
+  * ``/dca cancel <id>``                       remove entirely
+  * ``/dca edit <id> <field> <value>``         change one field
+  * ``/dca skip <id>``                         advance next_run without running
+  * ``/dca dry-run <id>``                      preview swap output, no submit
+  * ``/dca tick``                              manually execute any due
+  * ``/dca status``                            global summary (all senders)
+  * ``/dca history <id>``                      past executions
 
-Interval grammar: ``1m``, ``30m``, ``1h``, ``4h``, ``1d``, ``1w``.
+Interval grammar: ``1m``, ``30m``, ``1h``, ``4h``, ``1d``, ``1w``
+(1m floor, 1y ceiling).
+
+Safeguards (all optional; default to permissive):
+  * ``slippage_bps`` — passed to ``defi_swap`` (default 100 = 1%).
+  * ``daily_cap_eth`` — auto-skip if executing would exceed N ETH spent
+    in the past 24h. Default: unlimited.
+  * ``max_eth_total`` — auto-pause when lifetime spend hits this cap.
+    Default: unlimited.
+  * ``max_consecutive_failures`` — auto-pause after N failed runs in
+    a row. Default: 3.
 
 Each tick:
-  * Walks all active schedules whose ``next_run_at <= now``
-  * Calls ``defi_swap`` with the configured ``token`` + ``eth_amount``
-  * Records the tx hash (or error) on the schedule's history
-  * Advances ``next_run_at`` by ``interval_seconds``
+  * Walks all active schedules whose ``next_run_epoch <= now``.
+  * For each due schedule, checks safeguards before submitting; if a
+    cap or failure-streak fires, the schedule is paused and the result
+    recorded.
+  * Otherwise calls ``defi_swap`` with the configured ``token`` +
+    ``eth_amount`` + ``slippage_bps``.
+  * Records the tx hash (or error) on the schedule's history.
+  * Advances ``next_run_epoch`` by ``interval_seconds`` regardless of
+    outcome (so transient errors don't cascade into retry storms).
 
 Wallet behavior: uses the active wallet at tick time. If no wallet is
 connected when a tick fires, the schedule's execution is logged as
-``no_wallet`` and ``next_run_at`` still advances (we don't infinitely
-retry — the next interval gets a fresh shot).
+``no_wallet`` and ``next_run_epoch`` still advances.
 """
 
 from __future__ import annotations
@@ -160,6 +182,14 @@ async def handle_dca(raw_args: str, *, sender_id: str = "default", **_kwargs: An
             out = _cmd_resume(sender_id, rest)
         elif sub == "cancel" or sub == "rm" or sub == "remove":
             out = _cmd_cancel(sender_id, rest)
+        elif sub == "edit":
+            out = _cmd_edit(sender_id, rest)
+        elif sub == "skip":
+            out = _cmd_skip(sender_id, rest)
+        elif sub in ("dry-run", "dryrun"):
+            out = _cmd_dry_run(sender_id, rest)
+        elif sub == "status":
+            out = _cmd_status(sender_id)
         elif sub == "tick":
             out = await _cmd_tick()
         elif sub == "history":
@@ -175,30 +205,69 @@ def _render_usage() -> str:
         "Dollar-cost average — recurring ETH-funded buys on a target token.\n"
         "\n"
         "  /dca add <token> <eth_amount> <interval>\n"
-        "                       Schedule a recurring buy. Interval grammar:\n"
-        "                       1m, 30m, 1h, 4h, 1d, 1w  (1m floor, 1y ceiling)\n"
-        "  /dca list            Show all your schedules + next run time\n"
-        "  /dca pause <id>      Suspend a schedule without removing it\n"
-        "  /dca resume <id>     Re-arm a paused schedule\n"
-        "  /dca cancel <id>     Remove a schedule entirely\n"
-        "  /dca history <id>    Past executions for a schedule\n"
-        "  /dca tick            Execute any due schedules (cron-driven)\n"
+        "      [--slippage <bps>] [--daily-cap <eth>]\n"
+        "      [--max-total <eth>] [--max-failures <n>]\n"
+        "                          Schedule a recurring buy. Interval grammar:\n"
+        "                          1m, 30m, 1h, 4h, 1d, 1w (1m floor, 1y ceiling)\n"
+        "  /dca list               Show your schedules + next run time\n"
+        "  /dca pause <id>         Suspend a schedule without removing it\n"
+        "  /dca resume <id>        Re-arm a paused schedule\n"
+        "  /dca cancel <id>        Remove a schedule entirely\n"
+        "  /dca edit <id> <field> <value>\n"
+        "                          Change one field on a schedule\n"
+        "  /dca skip <id>          Advance next run, no execution this round\n"
+        "  /dca dry-run <id>       Preview swap output, no submission\n"
+        "  /dca status             Global summary + service health\n"
+        "  /dca history <id>       Past executions for a schedule\n"
+        "  /dca tick               Manually execute due schedules\n"
         "\n"
         "Example:\n"
-        "  /dca add 0xa1F7…747be 0.001 1h   buy $3.50 of CLAWNCH every hour"
+        "  /dca add 0xa1F7…747be 0.001 1h --slippage 50 --daily-cap 0.05\n"
+        "    buy 0.001 ETH of CLAWNCH every hour, 0.5% slippage,\n"
+        "    skip if 24h spend would exceed 0.05 ETH"
     )
 
 
 # ── /dca add ────────────────────────────────────────────────────────
 
 
+_DEFAULT_SLIPPAGE_BPS = 100  # 1% — generous default; tighten per-schedule
+_DEFAULT_MAX_FAILURES = 3  # auto-pause after this many failures in a row
+
+
+def _split_flags(parts: list[str]) -> tuple[list[str], dict[str, str]]:
+    """Split a token stream into positional args and ``--flag value`` pairs.
+
+    Permissive: unknown flags pass through to caller. Each ``--flag``
+    consumes the next token as its value; bare flags (no following
+    value) attach an empty string and the caller decides.
+    """
+    positional: list[str] = []
+    flags: dict[str, str] = {}
+    i = 0
+    while i < len(parts):
+        tok = parts[i]
+        if tok.startswith("--"):
+            name = tok[2:]
+            value = parts[i + 1] if i + 1 < len(parts) else ""
+            flags[name] = value
+            i += 2
+        else:
+            positional.append(tok)
+            i += 1
+    return positional, flags
+
+
 def _cmd_add(sender_id: str, parts: list[str]) -> str:
-    if len(parts) < 3:
+    pos, flags = _split_flags(parts)
+    if len(pos) < 3:
         return (
             "Usage: /dca add <token> <eth_amount> <interval>\n"
-            "Example: /dca add 0xa1F7…747be 0.001 1h"
+            "  [--slippage <bps>] [--daily-cap <eth>]\n"
+            "  [--max-total <eth>] [--max-failures <n>]\n"
+            "Example: /dca add 0xa1F7…747be 0.001 1h --slippage 50 --daily-cap 0.05"
         )
-    token, eth_amount_raw, interval_raw = parts[0], parts[1], parts[2]
+    token, eth_amount_raw, interval_raw = pos[0], pos[1], pos[2]
 
     # Validate token: must be a 0x address. We don't resolve symbols here
     # because the DCA loop runs without interactive context, and we want
@@ -219,6 +288,45 @@ def _cmd_add(sender_id: str, parts: list[str]) -> str:
             "Try 5m / 1h / 4h / 1d / 1w (1m floor, 1y ceiling)."
         )
 
+    # Safeguard flag parsing — each is independently optional and
+    # validated; an invalid value rejects the whole add so the user
+    # doesn't end up with a half-configured schedule.
+    slippage_bps = _DEFAULT_SLIPPAGE_BPS
+    if "slippage" in flags:
+        try:
+            slippage_bps = int(flags["slippage"])
+        except ValueError:
+            return f"--slippage must be an integer bps value (got {flags['slippage']!r})."
+        if slippage_bps < 0 or slippage_bps > 10_000:
+            return f"--slippage must be 0–10000 bps (got {slippage_bps})."
+
+    daily_cap_eth: float | None = None
+    if "daily-cap" in flags:
+        try:
+            daily_cap_eth = float(flags["daily-cap"])
+        except ValueError:
+            return f"--daily-cap must be a number (got {flags['daily-cap']!r})."
+        if daily_cap_eth <= 0:
+            return f"--daily-cap must be positive (got {daily_cap_eth})."
+
+    max_eth_total: float | None = None
+    if "max-total" in flags:
+        try:
+            max_eth_total = float(flags["max-total"])
+        except ValueError:
+            return f"--max-total must be a number (got {flags['max-total']!r})."
+        if max_eth_total <= 0:
+            return f"--max-total must be positive (got {max_eth_total})."
+
+    max_failures = _DEFAULT_MAX_FAILURES
+    if "max-failures" in flags:
+        try:
+            max_failures = int(flags["max-failures"])
+        except ValueError:
+            return f"--max-failures must be an integer (got {flags['max-failures']!r})."
+        if max_failures < 1:
+            return f"--max-failures must be >= 1 (got {max_failures})."
+
     state = _load_state()
     sched_id = _new_id()
     now = _now_epoch()
@@ -232,19 +340,31 @@ def _cmd_add(sender_id: str, parts: list[str]) -> str:
         "status": "active",
         "created_at": _now_iso(),
         "executions": [],
+        # Safeguards. ``None`` here means "no cap"; the executor reads
+        # these via ``.get(key)`` so older schedules without them work.
+        "slippage_bps": slippage_bps,
+        "daily_cap_eth": daily_cap_eth,
+        "max_eth_total": max_eth_total,
+        "max_consecutive_failures": max_failures,
+        "total_eth_spent": 0.0,
     }
     state["schedules"].append(schedule)
     _save_state(state)
 
     return (
         f"Schedule added: {sched_id}\n"
-        f"  Token:    {token}\n"
-        f"  Amount:   {eth_amount} ETH per buy\n"
-        f"  Interval: {_format_interval(seconds)}\n"
-        f"  Next:     ~{_format_interval(seconds)} from now\n"
+        f"  Token:       {token}\n"
+        f"  Amount:      {eth_amount} ETH per buy\n"
+        f"  Interval:    {_format_interval(seconds)}\n"
+        f"  Slippage:    {slippage_bps} bps\n"
+        f"  Daily cap:   {daily_cap_eth if daily_cap_eth is not None else 'none'}\n"
+        f"  Total cap:   {max_eth_total if max_eth_total is not None else 'none'}\n"
+        f"  Max fails:   {max_failures}\n"
+        f"  Next run:    ~{_format_interval(seconds)} from now\n"
         "\n"
-        "Tick runs via /dca tick (call manually) or via Hermes cron when\n"
-        "configured. Use /dca list to see all schedules."
+        "The DCA scheduler service ticks automatically (every ~60s).\n"
+        "Use /dca list to see all schedules, or /dca dry-run <id> to\n"
+        "preview the swap without submitting."
     )
 
 
@@ -319,18 +439,235 @@ def _mutate(sender_id: str, parts: list[str], *, status: str, verb: str) -> str:
     return f"Schedule {sched_id} {verb}."
 
 
+# ── /dca edit / skip / dry-run / status ────────────────────────────
+
+
+_EDITABLE_FIELDS = {
+    "token",
+    "eth_amount",
+    "interval",
+    "slippage_bps",
+    "daily_cap_eth",
+    "max_eth_total",
+    "max_consecutive_failures",
+}
+
+
+def _cmd_edit(sender_id: str, parts: list[str]) -> str:
+    """``/dca edit <id> <field> <value>`` — change one schedule property in place."""
+    if len(parts) < 3:
+        return (
+            f"Usage: /dca edit <id> <field> <value>\nFields: {', '.join(sorted(_EDITABLE_FIELDS))}"
+        )
+    sched_id, field, value = parts[0], parts[1], parts[2]
+    if field not in _EDITABLE_FIELDS:
+        return f"Unknown field {field!r}. Editable: {', '.join(sorted(_EDITABLE_FIELDS))}"
+
+    state = _load_state()
+    sched = _find_sched(state, sched_id, sender_id)
+    if sched is None:
+        return f"No schedule found with id {sched_id!r}."
+
+    # Per-field validation, mirroring _cmd_add's rules.
+    if field == "token":
+        if not (value.startswith("0x") and len(value) == 42):
+            return f"token must be a 0x… address (got {value!r})."
+        sched["token"] = value.lower()
+    elif field == "eth_amount":
+        try:
+            v = float(value)
+        except ValueError:
+            return f"eth_amount must be a number (got {value!r})."
+        if v <= 0:
+            return f"eth_amount must be positive (got {v})."
+        sched["eth_amount"] = v
+    elif field == "interval":
+        secs = _parse_interval(value)
+        if secs is None:
+            return f"Could not parse interval {value!r} (1m floor, 1y ceiling)."
+        sched["interval_seconds"] = secs
+    elif field == "slippage_bps":
+        try:
+            v = int(value)
+        except ValueError:
+            return f"slippage_bps must be an integer (got {value!r})."
+        if v < 0 or v > 10_000:
+            return f"slippage_bps must be 0–10000 (got {v})."
+        sched["slippage_bps"] = v
+    elif field == "daily_cap_eth":
+        if value.lower() == "none":
+            sched["daily_cap_eth"] = None
+        else:
+            try:
+                v = float(value)
+            except ValueError:
+                return f"daily_cap_eth must be a number or 'none' (got {value!r})."
+            if v <= 0:
+                return f"daily_cap_eth must be positive (got {v})."
+            sched["daily_cap_eth"] = v
+    elif field == "max_eth_total":
+        if value.lower() == "none":
+            sched["max_eth_total"] = None
+        else:
+            try:
+                v = float(value)
+            except ValueError:
+                return f"max_eth_total must be a number or 'none' (got {value!r})."
+            if v <= 0:
+                return f"max_eth_total must be positive (got {v})."
+            sched["max_eth_total"] = v
+    else:  # max_consecutive_failures — last remaining field
+        try:
+            v = int(value)
+        except ValueError:
+            return f"max_consecutive_failures must be an integer (got {value!r})."
+        if v < 1:
+            return f"max_consecutive_failures must be >= 1 (got {v})."
+        sched["max_consecutive_failures"] = v
+
+    _save_state(state)
+    return f"Schedule {sched_id}: {field} = {value}."
+
+
+def _cmd_skip(sender_id: str, parts: list[str]) -> str:
+    """``/dca skip <id>`` — bump next_run_epoch by interval without running."""
+    if not parts:
+        return "Usage: /dca skip <id>"
+    sched_id = parts[0]
+    state = _load_state()
+    sched = _find_sched(state, sched_id, sender_id)
+    if sched is None:
+        return f"No schedule found with id {sched_id!r}."
+    sched["next_run_epoch"] = _now_epoch() + sched["interval_seconds"]
+    _save_state(state)
+    return (
+        f"Skipped next run for {sched_id}. "
+        f"Next attempt in {_format_interval(sched['interval_seconds'])}."
+    )
+
+
+def _cmd_dry_run(sender_id: str, parts: list[str]) -> str:
+    """``/dca dry-run <id>`` — quote the swap without submitting."""
+    if not parts:
+        return "Usage: /dca dry-run <id>"
+    sched_id = parts[0]
+    state = _load_state()
+    sched = _find_sched(state, sched_id, sender_id)
+    if sched is None:
+        return f"No schedule found with id {sched_id!r}."
+
+    try:
+        from clawmes.tools.defi_swap import defi_swap
+
+        raw = defi_swap(
+            {
+                "action": "quote",
+                "sell_token": "ETH",
+                "buy_token": sched["token"],
+                "sell_amount": str(sched["eth_amount"]),
+                "slippage_bps": int(sched.get("slippage_bps") or _DEFAULT_SLIPPAGE_BPS),
+            }
+        )
+    except Exception as exc:  # noqa: BLE001
+        return f"Dry-run failed: {exc}"
+
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return f"Dry-run failed (bad swap response): {raw}"
+    if payload.get("isError"):
+        msg = payload.get("content", [{}])[0].get("text", "quote failed")
+        return f"Dry-run quote failed: {msg}"
+
+    details = payload.get("details") or {}
+    buy_amount = details.get("buy_amount") or details.get("buyAmount") or details.get("amount_out")
+    return (
+        f"Dry-run for {sched_id}:\n"
+        f"  Sell: {sched['eth_amount']} ETH\n"
+        f"  Buy:  {buy_amount} {_short(sched['token'])}\n"
+        f"  Slippage: {sched.get('slippage_bps', _DEFAULT_SLIPPAGE_BPS)} bps\n"
+        "  (No transaction submitted.)"
+    )
+
+
+def _cmd_status(_sender_id: str) -> str:
+    """``/dca status`` — global summary across all senders.
+
+    Sender-scoped UX everywhere else uses ``sender_id`` to filter; this
+    command is intentionally global so operators can see whether the
+    scheduler is healthy across the whole install.
+    """
+    state = _load_state()
+    schedules = state.get("schedules", [])
+    if not schedules:
+        return "No DCA schedules exist. The scheduler service is idle."
+
+    by_status: dict[str, int] = {}
+    total_spent = 0.0
+    total_runs = 0
+    failures = 0
+    for s in schedules:
+        by_status[s.get("status", "?")] = by_status.get(s.get("status", "?"), 0) + 1
+        total_spent += float(s.get("total_eth_spent", 0.0))
+        runs = s.get("executions", [])
+        total_runs += len(runs)
+        for r in runs:
+            status = (r.get("result") or {}).get("status", "")
+            if status in ("error", "no_wallet", "daily_capped", "total_capped"):
+                failures += 1
+
+    lines = [
+        f"DCA scheduler status ({len(schedules)} schedule(s)):",
+        "",
+        f"  By status:    {', '.join(f'{k}={v}' for k, v in sorted(by_status.items()))}",
+        f"  Total runs:   {total_runs}",
+        f"  Failures:     {failures}",
+        f"  ETH spent:    {total_spent:.6f}",
+    ]
+
+    # Health snapshot of the cron-driver service.
+    try:
+        from clawmes.services.dca_scheduler import get_dca_scheduler_service
+
+        svc = get_dca_scheduler_service()
+        h = svc.health()
+        lines.append(
+            f"  Service:      {h.get('status')} (ticks={h.get('ticks')}, "
+            f"total_fired={h.get('total_runs')})"
+        )
+    except Exception:  # noqa: BLE001 — service may not be started in tests
+        pass
+
+    return "\n".join(lines)
+
+
+def _find_sched(state: dict[str, Any], sched_id: str, sender_id: str) -> dict[str, Any] | None:
+    """Return the matching schedule or ``None`` (used by edit/skip/dry-run)."""
+    for s in state["schedules"]:
+        if s.get("id") == sched_id and s.get("sender_id") == sender_id:
+            return s
+    return None
+
+
 # ── /dca tick ───────────────────────────────────────────────────────
 
 
 async def _cmd_tick() -> str:
-    """Execute any active schedule whose ``next_run_epoch`` has passed.
+    """Manual ``/dca tick`` entrypoint. Delegates to the sync runner."""
+    count, lines = _run_due_with_lines()
+    if count == 0:
+        return "No DCA schedules due."
+    return "\n".join([f"Executing {count} due schedule(s)..."] + lines)
 
-    Cron-safe: if nothing is due, returns immediately with no side
-    effects. If a tx submission fails (no wallet, RPC error, slippage,
-    etc.), the failure is recorded and ``next_run_epoch`` still
-    advances — so transient failures don't cascade into a flood of
-    retries.
-    """
+
+def _run_due_sync() -> int:
+    """Service entrypoint — execute all due schedules. Returns count fired."""
+    count, _ = _run_due_with_lines()
+    return count
+
+
+def _run_due_with_lines() -> tuple[int, list[str]]:
+    """Shared core: walk due schedules, execute, return ``(count, lines)``."""
     state = _load_state()
     now = _now_epoch()
     due = [
@@ -339,28 +676,106 @@ async def _cmd_tick() -> str:
         if s.get("status") == "active" and s.get("next_run_epoch", 0) <= now
     ]
     if not due:
-        return "No DCA schedules due."
+        return 0, []
 
-    lines = [f"Executing {len(due)} due schedule(s)..."]
+    lines: list[str] = []
     for sched in due:
-        result = await _execute(sched)
+        result = _execute_sync(sched)
         sched["executions"].append(
             {"at": _now_iso(), "result": result, "tx_hash": result.get("tx_hash", "")}
         )
         sched["next_run_epoch"] = now + sched["interval_seconds"]
+
+        # If the result was an actual swap (status == "ok"), accumulate
+        # spend for the lifetime + daily caps. Skipped/errored runs don't
+        # contribute to the spend total.
+        if result.get("status") == "ok":
+            sched["total_eth_spent"] = float(sched.get("total_eth_spent", 0.0)) + float(
+                sched["eth_amount"]
+            )
+
+        # Auto-pause on consecutive failure streak.
+        _maybe_auto_pause(sched)
+
         lines.append(f"  {sched['id']}  {result.get('status')}  {result.get('detail', '')}")
     _save_state(state)
-    return "\n".join(lines)
+    return len(due), lines
 
 
-async def _execute(sched: dict[str, Any]) -> dict[str, Any]:
-    """Submit one swap for ``sched``. Returns a result dict for history."""
+def _maybe_auto_pause(sched: dict[str, Any]) -> None:
+    """Pause the schedule if its tail of executions has ``max`` failures in a row."""
+    max_fails = int(sched.get("max_consecutive_failures") or _DEFAULT_MAX_FAILURES)
+    runs = sched.get("executions", [])
+    if len(runs) < max_fails:
+        return
+    tail = runs[-max_fails:]
+    failure_states = {"error", "no_wallet", "daily_capped", "total_capped"}
+    if all((r.get("result") or {}).get("status") in failure_states for r in tail):
+        sched["status"] = "paused"
+
+
+def _spend_in_last_24h(sched: dict[str, Any]) -> float:
+    """Sum eth_amount across successful executions in the past 24h."""
+    runs = sched.get("executions", [])
+    cutoff = _now_epoch() - 86400
+    total = 0.0
+    eth_amount = float(sched.get("eth_amount", 0.0))
+    for run in runs:
+        if (run.get("result") or {}).get("status") != "ok":
+            continue
+        # Parse ISO timestamp back to epoch — best-effort; if it fails
+        # we skip the run (defensive against malformed history files).
+        at = run.get("at", "")
+        try:
+            dt = datetime.strptime(at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+            ts = int(dt.timestamp())
+        except (ValueError, TypeError):
+            continue
+        if ts >= cutoff:
+            total += eth_amount
+    return total
+
+
+def _execute_sync(sched: dict[str, Any]) -> dict[str, Any]:
+    """Submit one swap for ``sched``. Synchronous so the service tick can call it.
+
+    Safeguard order matters: lifetime cap > daily cap > wallet > swap.
+    A schedule that's hit its lifetime cap should never even probe the
+    wallet (in case the wallet's gone offline — we'd surface the wrong
+    failure type).
+    """
+    eth_amount = float(sched.get("eth_amount", 0.0))
+
+    # Lifetime cap.
+    max_total = sched.get("max_eth_total")
+    if max_total is not None:
+        spent = float(sched.get("total_eth_spent", 0.0))
+        if spent + eth_amount > float(max_total):
+            return {
+                "status": "total_capped",
+                "detail": f"would exceed max-total {max_total} ETH (spent {spent})",
+                "tx_hash": "",
+            }
+
+    # Daily cap.
+    daily_cap = sched.get("daily_cap_eth")
+    if daily_cap is not None:
+        spent_24h = _spend_in_last_24h(sched)
+        if spent_24h + eth_amount > float(daily_cap):
+            return {
+                "status": "daily_capped",
+                "detail": f"would exceed daily-cap {daily_cap} ETH (spent {spent_24h:.6f} in 24h)",
+                "tx_hash": "",
+            }
+
+    # Wallet must be live.
     from clawmes.services.wallet import get_wallet_state
 
-    state = get_wallet_state()
-    if not state.connected:
+    wstate = get_wallet_state()
+    if not wstate.connected:
         return {"status": "no_wallet", "detail": "no wallet connected", "tx_hash": ""}
 
+    # Submit the swap.
     try:
         from clawmes.tools.defi_swap import defi_swap
 
@@ -369,7 +784,8 @@ async def _execute(sched: dict[str, Any]) -> dict[str, Any]:
                 "action": "swap",
                 "sell_token": "ETH",
                 "buy_token": sched["token"],
-                "sell_amount": str(sched["eth_amount"]),
+                "sell_amount": str(eth_amount),
+                "slippage_bps": int(sched.get("slippage_bps") or _DEFAULT_SLIPPAGE_BPS),
             }
         )
     except Exception as exc:  # noqa: BLE001

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.6.0
+version: 0.6.1
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/services/__init__.py
+++ b/clawmes/services/__init__.py
@@ -44,6 +44,7 @@ def start_all() -> None:
     from clawmes.services.coingecko import get_coingecko_service
     from clawmes.services.command_history import get_command_history_service
     from clawmes.services.credential_redactor import get_credential_redactor
+    from clawmes.services.dca_scheduler import get_dca_scheduler_service
     from clawmes.services.endpoint_allowlist import get_endpoint_allowlist_service
     from clawmes.services.evolution_mode import get_evolution_mode_service
     from clawmes.services.explorer import get_explorer_service
@@ -126,6 +127,10 @@ def start_all() -> None:
         get_opengateway_service,
         # 7. Background daemons — last so they pick up everything above.
         get_scheduler,  # ticking=True; needs cron driver to actually fire
+        # 7a. DCA scheduler — ticking=True. Fires due /dca schedules on
+        #     the registry cadence (60s by default). Sync execution path;
+        #     per-schedule errors caught + logged.
+        get_dca_scheduler_service,
         get_wc_notification_consumer,  # threaded; routes WC bridge notifs
     ]
     for factory in factories:

--- a/clawmes/services/dca_scheduler.py
+++ b/clawmes/services/dca_scheduler.py
@@ -1,0 +1,97 @@
+"""DCA scheduler service — drives ``/dca tick`` automatically.
+
+The ``/dca`` command provides a manual ``tick`` subcommand that runs
+due schedules synchronously. Wiring that into the Hermes cron loop
+turns DCA from a manual cron-curio into a real "set it and forget it"
+feature. This service does exactly that: every service tick (60s by
+default, configurable via Hermes cron) it dispatches due schedules.
+
+Lifecycle:
+
+  * ``start()`` — mark running; no-op otherwise (state lives in the
+    /dca command module, not the service).
+  * ``stop()``  — mark not running. Pending schedules wait for the
+    next service start.
+  * ``tick()``  — sync wrapper around the same execution path the
+    ``/dca tick`` command uses. Safe to call from the registry tick
+    loop because:
+      - The dispatch path itself is sync (no asyncio required at the
+        engine level — only the command interface is async).
+      - Failures inside one schedule do not bubble up; we catch + log
+        per-schedule so one bad token cannot stall the whole loop.
+
+This service intentionally has no state of its own. All persistence
+lives in ``${HERMES_HOME}/clawmes/dca/schedules.json`` (managed by the
+``/dca`` command). The service is just the cron-driver wrapper.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawmes.lib.logger import logger_for
+from clawmes.services._base import Service
+
+_log = logger_for("services.dca_scheduler")
+
+_SERVICE: DcaSchedulerService | None = None
+
+
+class DcaSchedulerService(Service):
+    """Cron-driven DCA execution loop."""
+
+    id = "clawmes.dca_scheduler"
+    ticking = True
+
+    def __init__(self) -> None:
+        self._running = False
+        self._ticks = 0
+        self._last_runs = 0
+        self._total_runs = 0
+
+    def start(self) -> None:
+        self._running = True
+        _log.info("dca scheduler started — tick cadence driven by registry")
+
+    def stop(self) -> None:
+        self._running = False
+        _log.info("dca scheduler stopped (ticks=%d, total_runs=%d)", self._ticks, self._total_runs)
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": "running" if self._running else "stopped",
+            "ticks": self._ticks,
+            "last_runs": self._last_runs,
+            "total_runs": self._total_runs,
+        }
+
+    def tick(self) -> None:
+        """Fire any due DCA schedules. Catches all per-schedule errors."""
+        if not self._running:
+            return
+        self._ticks += 1
+        try:
+            from clawmes.commands import dca
+
+            n = dca._run_due_sync()
+            self._last_runs = n
+            self._total_runs += n
+            if n > 0:
+                _log.info("dca tick fired %d schedule(s)", n)
+        except Exception:  # noqa: BLE001 — never let cron break the loop
+            _log.exception("dca scheduler tick raised; swallowing")
+
+
+def get_dca_scheduler_service() -> DcaSchedulerService:
+    """Module-level singleton accessor — production code never re-instantiates."""
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = DcaSchedulerService()
+    return _SERVICE
+
+
+def _reset_for_tests() -> None:
+    """Test hook to clear the singleton so each test starts fresh."""
+    global _SERVICE
+    _SERVICE = None

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.6.0
+version: 0.6.1
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.6.0"
+version = "0.6.1"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_dca.py
+++ b/tests/commands/test_dca.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from datetime import UTC
 from typing import Any
 
 import pytest
@@ -549,3 +550,634 @@ class TestRegister:
         dca.register(Ctx())
         assert len(registered) == 1
         assert registered[0]["name"] == "dca"
+
+
+# ── v0.6.1 additions ────────────────────────────────────────────────
+
+
+def _add_basic(sender_id: str = "u") -> str:
+    """Helper: add a schedule and return its id."""
+    out = dca._cmd_add(sender_id, ["0x" + "1" * 40, "0.01", "1h"])
+    return next(w for w in out.split() if w.startswith("dca_"))
+
+
+# ── _split_flags ────────────────────────────────────────────────────
+
+
+class TestSplitFlags:
+    def test_all_positional(self):
+        pos, flags = dca._split_flags(["a", "b", "c"])
+        assert pos == ["a", "b", "c"]
+        assert flags == {}
+
+    def test_flag_with_value(self):
+        pos, flags = dca._split_flags(["a", "--slippage", "50"])
+        assert pos == ["a"]
+        assert flags == {"slippage": "50"}
+
+    def test_bare_trailing_flag(self):
+        pos, flags = dca._split_flags(["a", "--bare"])
+        assert pos == ["a"]
+        # Bare flag at end attaches empty string per design.
+        assert flags == {"bare": ""}
+
+    def test_multiple_mixed(self):
+        pos, flags = dca._split_flags(["a", "b", "--x", "1", "c", "--y", "2", "--z"])
+        assert pos == ["a", "b", "c"]
+        assert flags == {"x": "1", "y": "2", "z": ""}
+
+
+# ── _cmd_add with flags ─────────────────────────────────────────────
+
+
+class TestCmdAddFlags:
+    def test_slippage(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--slippage", "50"])
+        assert "Schedule added" in out
+        sched = dca._load_state()["schedules"][0]
+        assert sched["slippage_bps"] == 50
+
+    def test_bad_slippage_non_int(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--slippage", "abc"])
+        assert "--slippage must be an integer" in out
+
+    def test_bad_slippage_range(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--slippage", "20000"])
+        assert "0–10000" in out
+
+    def test_daily_cap(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--daily-cap", "0.05"])
+        assert "Daily cap:   0.05" in out
+        sched = dca._load_state()["schedules"][0]
+        assert sched["daily_cap_eth"] == 0.05
+
+    def test_bad_daily_cap(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--daily-cap", "abc"])
+        assert "--daily-cap must be a number" in out
+
+    def test_daily_cap_zero_or_negative(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--daily-cap", "0"])
+        assert "--daily-cap must be positive" in out
+
+    def test_max_total(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--max-total", "1.5"])
+        sched = dca._load_state()["schedules"][0]
+        assert sched["max_eth_total"] == 1.5
+        assert "Total cap:   1.5" in out
+
+    def test_bad_max_total(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--max-total", "x"])
+        assert "--max-total must be a number" in out
+
+    def test_max_total_non_positive(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--max-total", "-1"])
+        assert "--max-total must be positive" in out
+
+    def test_max_failures(self, tmp_state):
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--max-failures", "5"])
+        sched = dca._load_state()["schedules"][0]
+        assert sched["max_consecutive_failures"] == 5
+
+    def test_bad_max_failures(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--max-failures", "x"])
+        assert "--max-failures must be an integer" in out
+
+    def test_max_failures_zero(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--max-failures", "0"])
+        assert "must be >= 1" in out
+
+    def test_defaults_set(self, tmp_state):
+        out = dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        assert "Schedule added" in out
+        sched = dca._load_state()["schedules"][0]
+        assert sched["slippage_bps"] == dca._DEFAULT_SLIPPAGE_BPS
+        assert sched["daily_cap_eth"] is None
+        assert sched["max_eth_total"] is None
+        assert sched["max_consecutive_failures"] == dca._DEFAULT_MAX_FAILURES
+        assert sched["total_eth_spent"] == 0.0
+
+
+# ── safeguards in _execute_sync ─────────────────────────────────────
+
+
+class TestSafeguards:
+    def test_total_cap_blocks(self, tmp_state, fake_wallet, fake_defi_swap):
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--max-total", "0.005"])
+        # Force a tick.
+        st = dca._load_state()
+        st["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(st)
+        out = dca._run_due_sync()
+        assert out == 1
+        # Verify the result was the safeguard, not a swap attempt.
+        st2 = dca._load_state()
+        result = st2["schedules"][0]["executions"][0]["result"]
+        assert result["status"] == "total_capped"
+        # defi_swap was never called.
+        assert fake_defi_swap["payload"] is None
+
+    def test_daily_cap_blocks(self, tmp_state, fake_wallet, fake_defi_swap):
+        # Seed one successful prior run in the past 24h, then cap is 0.015.
+        # New run would push total to 0.02 → blocked.
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--daily-cap", "0.015"])
+        st = dca._load_state()
+        st["schedules"][0]["executions"].append(
+            {
+                "at": dca._now_iso(),
+                "tx_hash": "0xabc",
+                "result": {"status": "ok"},
+            }
+        )
+        st["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(st)
+        dca._run_due_sync()
+        st2 = dca._load_state()
+        last = st2["schedules"][0]["executions"][-1]
+        assert last["result"]["status"] == "daily_capped"
+
+    def test_daily_cap_window_old_runs_ignored(self, tmp_state, fake_wallet, fake_defi_swap):
+        """Runs older than 24h must not count toward the daily cap."""
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeedabcdefg"},
+        }
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--daily-cap", "0.015"])
+        st = dca._load_state()
+        # A two-day-old successful run — must not block today's run.
+        from datetime import datetime, timedelta
+
+        old = (datetime.now(UTC) - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        st["schedules"][0]["executions"].append(
+            {"at": old, "tx_hash": "0xold", "result": {"status": "ok"}}
+        )
+        st["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(st)
+        dca._run_due_sync()
+        st2 = dca._load_state()
+        last = st2["schedules"][0]["executions"][-1]
+        assert last["result"]["status"] == "ok"
+
+    def test_daily_cap_skips_non_ok_runs(self, tmp_state, fake_wallet, fake_defi_swap):
+        """Errored prior runs should not count toward the daily cap window."""
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--daily-cap", "0.015"])
+        st = dca._load_state()
+        # A recent failed run — should be skipped in spend-window math.
+        st["schedules"][0]["executions"].append(
+            {
+                "at": dca._now_iso(),
+                "tx_hash": "",
+                "result": {"status": "error"},
+            }
+        )
+        st["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(st)
+        dca._run_due_sync()
+        st2 = dca._load_state()
+        last = st2["schedules"][0]["executions"][-1]
+        # Cap = 0.015 ETH, prior error run doesn't count, new run = 0.01,
+        # so total within cap → swap proceeds.
+        assert last["result"]["status"] == "ok"
+
+    def test_daily_cap_malformed_at_ignored(self, tmp_state, fake_wallet, fake_defi_swap):
+        """A malformed ``at`` field should be silently skipped (defensive)."""
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--daily-cap", "0.015"])
+        st = dca._load_state()
+        st["schedules"][0]["executions"].append(
+            {"at": "garbage", "tx_hash": "0x", "result": {"status": "ok"}}
+        )
+        st["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(st)
+        dca._run_due_sync()
+        st2 = dca._load_state()
+        last = st2["schedules"][0]["executions"][-1]
+        # Bad timestamp ignored — swap proceeds.
+        assert last["result"]["status"] == "ok"
+
+    def test_total_eth_spent_accumulates(self, tmp_state, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        # Tick once.
+        st = dca._load_state()
+        st["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(st)
+        dca._run_due_sync()
+        st2 = dca._load_state()
+        assert st2["schedules"][0]["total_eth_spent"] == 0.01
+
+    def test_auto_pause_after_failures(self, tmp_state, fake_wallet, fake_defi_swap):
+        """Three consecutive failures auto-pause the schedule."""
+        fake_wallet.connected = False  # forces no_wallet failures
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--max-failures", "2"])
+        # Tick three times, each fails with no_wallet.
+        for _ in range(3):
+            st = dca._load_state()
+            st["schedules"][0]["next_run_epoch"] = 0
+            dca._save_state(st)
+            dca._run_due_sync()
+
+        st = dca._load_state()
+        assert st["schedules"][0]["status"] == "paused"
+
+    def test_no_auto_pause_below_threshold(self, tmp_state, fake_wallet, fake_defi_swap):
+        fake_wallet.connected = False
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h", "--max-failures", "5"])
+        for _ in range(2):
+            st = dca._load_state()
+            st["schedules"][0]["next_run_epoch"] = 0
+            dca._save_state(st)
+            dca._run_due_sync()
+        st = dca._load_state()
+        assert st["schedules"][0]["status"] == "active"
+
+
+# ── _maybe_auto_pause direct ───────────────────────────────────────
+
+
+class TestMaybeAutoPause:
+    def test_too_few_runs(self):
+        sched = {"max_consecutive_failures": 3, "executions": [{"result": {"status": "error"}}]}
+        dca._maybe_auto_pause(sched)
+        assert "status" not in sched
+
+    def test_mixed_tail_no_pause(self):
+        sched = {
+            "max_consecutive_failures": 3,
+            "executions": [
+                {"result": {"status": "error"}},
+                {"result": {"status": "ok"}},
+                {"result": {"status": "error"}},
+            ],
+        }
+        dca._maybe_auto_pause(sched)
+        assert sched.get("status") != "paused"
+
+    def test_all_fail_pauses(self):
+        sched = {
+            "max_consecutive_failures": 3,
+            "executions": [
+                {"result": {"status": "error"}},
+                {"result": {"status": "no_wallet"}},
+                {"result": {"status": "daily_capped"}},
+            ],
+        }
+        dca._maybe_auto_pause(sched)
+        assert sched["status"] == "paused"
+
+    def test_uses_default_when_unset(self):
+        # Missing max field → default 3 applies.
+        sched = {
+            "executions": [
+                {"result": {"status": "error"}},
+                {"result": {"status": "error"}},
+                {"result": {"status": "error"}},
+            ],
+        }
+        dca._maybe_auto_pause(sched)
+        assert sched["status"] == "paused"
+
+
+# ── _cmd_edit ───────────────────────────────────────────────────────
+
+
+class TestCmdEdit:
+    def test_usage(self, tmp_state):
+        out = dca._cmd_edit("u", [])
+        assert "Usage:" in out
+        assert "Fields:" in out
+
+    def test_unknown_field(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "garbage", "1"])
+        assert "Unknown field" in out
+
+    def test_not_found(self, tmp_state):
+        out = dca._cmd_edit("u", ["dca_xxx", "eth_amount", "0.02"])
+        assert "No schedule found" in out
+
+    def test_token(self, tmp_state):
+        sid = _add_basic()
+        new_addr = "0x" + "9" * 40
+        out = dca._cmd_edit("u", [sid, "token", new_addr])
+        assert "token = " in out
+        assert dca._load_state()["schedules"][0]["token"] == new_addr
+
+    def test_token_bad(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "token", "notaddr"])
+        assert "must be a 0x… address" in out
+
+    def test_eth_amount(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "eth_amount", "0.05"])
+        assert "eth_amount = " in out
+        assert dca._load_state()["schedules"][0]["eth_amount"] == 0.05
+
+    def test_eth_amount_bad(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "eth_amount", "abc"])
+        assert "must be a number" in out
+
+    def test_eth_amount_non_positive(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "eth_amount", "0"])
+        assert "must be positive" in out
+
+    def test_interval(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "interval", "30m"])
+        assert "interval = " in out
+        assert dca._load_state()["schedules"][0]["interval_seconds"] == 1800
+
+    def test_interval_bad(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "interval", "garbage"])
+        assert "Could not parse interval" in out
+
+    def test_slippage_bps(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "slippage_bps", "75"])
+        assert "slippage_bps = " in out
+        assert dca._load_state()["schedules"][0]["slippage_bps"] == 75
+
+    def test_slippage_bps_bad_int(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "slippage_bps", "x"])
+        assert "must be an integer" in out
+
+    def test_slippage_bps_range(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "slippage_bps", "99999"])
+        assert "0–10000" in out
+
+    def test_daily_cap_eth_value(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "daily_cap_eth", "0.1"])
+        assert "daily_cap_eth" in out
+        assert dca._load_state()["schedules"][0]["daily_cap_eth"] == 0.1
+
+    def test_daily_cap_eth_none(self, tmp_state):
+        sid = _add_basic()
+        # Set first
+        dca._cmd_edit("u", [sid, "daily_cap_eth", "0.1"])
+        out = dca._cmd_edit("u", [sid, "daily_cap_eth", "none"])
+        assert "daily_cap_eth" in out
+        assert dca._load_state()["schedules"][0]["daily_cap_eth"] is None
+
+    def test_daily_cap_eth_bad(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "daily_cap_eth", "abc"])
+        assert "must be a number" in out
+
+    def test_daily_cap_eth_non_positive(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "daily_cap_eth", "0"])
+        assert "must be positive" in out
+
+    def test_max_eth_total_value(self, tmp_state):
+        sid = _add_basic()
+        dca._cmd_edit("u", [sid, "max_eth_total", "1.0"])
+        assert dca._load_state()["schedules"][0]["max_eth_total"] == 1.0
+
+    def test_max_eth_total_none(self, tmp_state):
+        sid = _add_basic()
+        dca._cmd_edit("u", [sid, "max_eth_total", "NONE"])
+        assert dca._load_state()["schedules"][0]["max_eth_total"] is None
+
+    def test_max_eth_total_bad(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "max_eth_total", "abc"])
+        assert "must be a number" in out
+
+    def test_max_eth_total_non_positive(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "max_eth_total", "-1"])
+        assert "must be positive" in out
+
+    def test_max_consecutive_failures(self, tmp_state):
+        sid = _add_basic()
+        dca._cmd_edit("u", [sid, "max_consecutive_failures", "7"])
+        assert dca._load_state()["schedules"][0]["max_consecutive_failures"] == 7
+
+    def test_max_consecutive_failures_bad(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "max_consecutive_failures", "x"])
+        assert "must be an integer" in out
+
+    def test_max_consecutive_failures_zero(self, tmp_state):
+        sid = _add_basic()
+        out = dca._cmd_edit("u", [sid, "max_consecutive_failures", "0"])
+        assert "must be >= 1" in out
+
+
+# ── _cmd_skip ───────────────────────────────────────────────────────
+
+
+class TestCmdSkip:
+    def test_usage(self, tmp_state):
+        out = dca._cmd_skip("u", [])
+        assert "Usage:" in out
+
+    def test_not_found(self, tmp_state):
+        out = dca._cmd_skip("u", ["dca_xxx"])
+        assert "No schedule found" in out
+
+    def test_advances_next_run(self, tmp_state):
+        sid = _add_basic()
+        # Force next_run to be in the past.
+        st = dca._load_state()
+        st["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(st)
+        out = dca._cmd_skip("u", [sid])
+        assert "Skipped next run" in out
+        st2 = dca._load_state()
+        assert st2["schedules"][0]["next_run_epoch"] > 0
+
+
+# ── _cmd_dry_run ────────────────────────────────────────────────────
+
+
+class TestCmdDryRun:
+    def test_usage(self, tmp_state):
+        out = dca._cmd_dry_run("u", [])
+        assert "Usage:" in out
+
+    def test_not_found(self, tmp_state):
+        out = dca._cmd_dry_run("u", ["dca_xxx"])
+        assert "No schedule found" in out
+
+    def test_swap_raises(self, tmp_state, fake_defi_swap):
+        fake_defi_swap["raises"] = RuntimeError("rpc down")
+        sid = _add_basic()
+        out = dca._cmd_dry_run("u", [sid])
+        assert "Dry-run failed" in out
+        assert "rpc down" in out
+
+    def test_swap_bad_json(self, tmp_state, monkeypatch):
+        import clawmes.tools.defi_swap as swap_mod
+
+        monkeypatch.setattr(swap_mod, "defi_swap", lambda *a, **k: "not-json")
+        sid = _add_basic()
+        out = dca._cmd_dry_run("u", [sid])
+        assert "bad swap response" in out
+
+    def test_swap_isError(self, tmp_state, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": True,
+            "content": [{"text": "no route"}],
+        }
+        sid = _add_basic()
+        out = dca._cmd_dry_run("u", [sid])
+        assert "Dry-run quote failed" in out
+        assert "no route" in out
+
+    def test_swap_isError_no_content(self, tmp_state, fake_defi_swap):
+        fake_defi_swap["payload"] = {"isError": True}
+        sid = _add_basic()
+        out = dca._cmd_dry_run("u", [sid])
+        assert "Dry-run quote failed" in out
+
+    def test_swap_success(self, tmp_state, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"buy_amount": "1234.5"},
+        }
+        sid = _add_basic()
+        out = dca._cmd_dry_run("u", [sid])
+        assert "Dry-run for" in out
+        assert "1234.5" in out
+        assert "No transaction submitted" in out
+
+
+# ── _cmd_status ─────────────────────────────────────────────────────
+
+
+class TestCmdStatus:
+    def test_empty(self, tmp_state):
+        out = dca._cmd_status("u")
+        assert "scheduler service is idle" in out
+
+    def test_summarizes(self, tmp_state):
+        dca._cmd_add("alice", ["0x" + "1" * 40, "0.01", "1h"])
+        dca._cmd_add("bob", ["0x" + "2" * 40, "0.02", "1d"])
+        # Mark bob's schedule paused + add some history.
+        st = dca._load_state()
+        st["schedules"][1]["status"] = "paused"
+        st["schedules"][0]["executions"] = [
+            {"at": "x", "tx_hash": "0xa", "result": {"status": "ok"}},
+            {"at": "y", "tx_hash": "0xb", "result": {"status": "error"}},
+        ]
+        st["schedules"][0]["total_eth_spent"] = 0.01
+        dca._save_state(st)
+
+        out = dca._cmd_status("u")
+        assert "(2 schedule(s))" in out
+        assert "active=1" in out
+        assert "paused=1" in out
+        assert "Total runs:   2" in out
+        assert "Failures:     1" in out
+        assert "0.010000" in out  # ETH spent
+
+    def test_service_health_swallow(self, monkeypatch, tmp_state):
+        # Force the service import to blow up — _cmd_status should
+        # still return cleanly without the service line.
+        import clawmes.services.dca_scheduler as svc_mod
+
+        def _boom():
+            raise RuntimeError("svc not initialized")
+
+        monkeypatch.setattr(svc_mod, "get_dca_scheduler_service", _boom)
+        dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+        out = dca._cmd_status("u")
+        assert "Service:" not in out
+
+    def test_service_health_present(self, tmp_state):
+        # Reset + start service so health() returns a real snapshot.
+        from clawmes.services import dca_scheduler as svc_mod
+
+        svc_mod._reset_for_tests()
+        svc = svc_mod.get_dca_scheduler_service()
+        svc.start()
+        try:
+            dca._cmd_add("u", ["0x" + "1" * 40, "0.01", "1h"])
+            out = dca._cmd_status("u")
+            assert "Service:" in out
+            assert "running" in out
+        finally:
+            svc.stop()
+            svc_mod._reset_for_tests()
+
+
+# ── _find_sched ─────────────────────────────────────────────────────
+
+
+class TestFindSched:
+    def test_match(self, tmp_state):
+        sid = _add_basic()
+        state = dca._load_state()
+        assert dca._find_sched(state, sid, "u") is not None
+
+    def test_wrong_sender(self, tmp_state):
+        sid = _add_basic("alice")
+        state = dca._load_state()
+        assert dca._find_sched(state, sid, "bob") is None
+
+    def test_missing_id(self, tmp_state):
+        state = dca._load_state()
+        assert dca._find_sched(state, "dca_xxx", "u") is None
+
+
+# ── dispatch for new subcommands ───────────────────────────────────
+
+
+class TestNewDispatch:
+    async def test_edit_dispatch(self, tmp_state):
+        out = await dca.handle_dca("edit dca_xxx eth_amount 0.02")
+        assert "No schedule found" in out
+
+    async def test_skip_dispatch(self, tmp_state):
+        out = await dca.handle_dca("skip dca_xxx")
+        assert "No schedule found" in out
+
+    async def test_dry_run_dispatch(self, tmp_state):
+        out = await dca.handle_dca("dry-run dca_xxx")
+        assert "No schedule found" in out
+
+    async def test_dryrun_alias(self, tmp_state):
+        out = await dca.handle_dca("dryrun dca_xxx")
+        assert "No schedule found" in out
+
+    async def test_status_dispatch(self, tmp_state):
+        out = await dca.handle_dca("status")
+        assert "scheduler" in out.lower()
+
+
+# ── _run_due_sync / _run_due_with_lines ────────────────────────────
+
+
+class TestRunDueSync:
+    def test_no_due(self, tmp_state, fake_wallet, fake_defi_swap):
+        # Add a schedule with future next_run.
+        _add_basic()
+        assert dca._run_due_sync() == 0
+
+    def test_due_runs_count(self, tmp_state, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        _add_basic()
+        st = dca._load_state()
+        st["schedules"][0]["next_run_epoch"] = 0
+        dca._save_state(st)
+        assert dca._run_due_sync() == 1

--- a/tests/services/test_dca_scheduler.py
+++ b/tests/services/test_dca_scheduler.py
@@ -1,0 +1,122 @@
+"""Tests for the DCA scheduler service."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.services import dca_scheduler
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Each test starts with a fresh service instance."""
+    dca_scheduler._reset_for_tests()
+    yield
+    dca_scheduler._reset_for_tests()
+
+
+class TestSingleton:
+    def test_returns_same_instance(self):
+        a = dca_scheduler.get_dca_scheduler_service()
+        b = dca_scheduler.get_dca_scheduler_service()
+        assert a is b
+
+    def test_reset_creates_new(self):
+        a = dca_scheduler.get_dca_scheduler_service()
+        dca_scheduler._reset_for_tests()
+        b = dca_scheduler.get_dca_scheduler_service()
+        assert a is not b
+
+
+class TestLifecycle:
+    def test_start_marks_running(self):
+        svc = dca_scheduler.get_dca_scheduler_service()
+        assert svc._running is False
+        svc.start()
+        assert svc._running is True
+
+    def test_stop_marks_stopped(self):
+        svc = dca_scheduler.get_dca_scheduler_service()
+        svc.start()
+        svc.stop()
+        assert svc._running is False
+
+    def test_health_shape(self):
+        svc = dca_scheduler.get_dca_scheduler_service()
+        h = svc.health()
+        assert h["id"] == "clawmes.dca_scheduler"
+        assert h["status"] == "stopped"
+        assert h["ticks"] == 0
+        assert h["total_runs"] == 0
+
+    def test_health_running(self):
+        svc = dca_scheduler.get_dca_scheduler_service()
+        svc.start()
+        assert svc.health()["status"] == "running"
+
+
+class TestTick:
+    def test_tick_skipped_when_not_running(self, monkeypatch):
+        """A stopped service must not call _run_due_sync."""
+        called = {"n": 0}
+
+        from clawmes.commands import dca as dca_mod
+
+        def _spy():
+            called["n"] += 1
+            return 0
+
+        monkeypatch.setattr(dca_mod, "_run_due_sync", _spy)
+
+        svc = dca_scheduler.get_dca_scheduler_service()
+        svc.tick()  # not started
+        assert called["n"] == 0
+        assert svc._ticks == 0
+
+    def test_tick_calls_dca_runner(self, monkeypatch):
+        from clawmes.commands import dca as dca_mod
+
+        def _spy():
+            return 3  # pretend three schedules fired
+
+        monkeypatch.setattr(dca_mod, "_run_due_sync", _spy)
+
+        svc = dca_scheduler.get_dca_scheduler_service()
+        svc.start()
+        svc.tick()
+        assert svc._ticks == 1
+        assert svc._last_runs == 3
+        assert svc._total_runs == 3
+
+    def test_tick_swallows_exceptions(self, monkeypatch):
+        """A runner that raises must not crash the cron loop."""
+        from clawmes.commands import dca as dca_mod
+
+        def _boom():
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(dca_mod, "_run_due_sync", _boom)
+
+        svc = dca_scheduler.get_dca_scheduler_service()
+        svc.start()
+        # No exception should escape.
+        svc.tick()
+        assert svc._ticks == 1
+        # Counters didn't advance (the increment is after the call).
+        assert svc._last_runs == 0
+        assert svc._total_runs == 0
+
+    def test_tick_accumulates_across_calls(self, monkeypatch):
+        from clawmes.commands import dca as dca_mod
+
+        runs = iter([1, 2, 0])
+        monkeypatch.setattr(dca_mod, "_run_due_sync", lambda: next(runs))
+
+        svc = dca_scheduler.get_dca_scheduler_service()
+        svc.start()
+        svc.tick()
+        svc.tick()
+        svc.tick()
+        assert svc._ticks == 3
+        assert svc._total_runs == 3
+        assert svc._last_runs == 0  # the most recent tick fired 0


### PR DESCRIPTION
## Summary

`/dca` graduates from a manual cron-curio to a real "set it and forget it" feature.

### Auto-scheduler
- New `DcaSchedulerService` (id `clawmes.dca_scheduler`) ticks on the registry cadence (~60s default, driven by Hermes cron).
- Dispatches every due schedule per tick. Per-schedule failures are caught internally so one bad token cannot stall the loop.
- The manual `/dca tick` subcommand is preserved for testing and edge-case use.

### Safeguards (per-schedule, all optional)
- `--slippage <bps>` (default 100 = 1%) — passed to `defi_swap` on each execution.
- `--daily-cap <eth>` — skips the run if executing it would push 24h spend over the cap. Old runs (>24h) and non-`ok` runs are excluded from the window.
- `--max-total <eth>` — auto-pauses the schedule once lifetime spend hits the cap.
- `--max-failures <n>` (default 3) — auto-pauses after N consecutive failures (`error`, `no_wallet`, `daily_capped`, or `total_capped`).

### New subcommands
- `/dca edit <id> <field> <value>` — change any field in-place (`token`, `eth_amount`, `interval`, `slippage_bps`, `daily_cap_eth`, `max_eth_total`, `max_consecutive_failures`). Caps accept `none` to clear.
- `/dca skip <id>` — advance `next_run_epoch` by interval without executing.
- `/dca dry-run <id>` — quote the swap via `defi_swap` action=quote without submitting.
- `/dca status` — global summary across all senders + service tick/run counters.

## Internal

- `_execute` refactored to `_execute_sync` (the original async wrapper didn't actually await anything — wallet + swap calls were already sync).
- `/dca tick` command delegates to shared `_run_due_with_lines()`; the service uses `_run_due_sync()` which returns just the count.
- New `clawmes/services/dca_scheduler.py` (~80 lines).
- README service count: 23 → 24.

## Testing

- 3318 tests pass (was 3231) — 87 new tests across `/dca` v2 and the scheduler service.
- 100% line coverage maintained on every file and on the project overall.
- `ruff check` + `ruff format --check` clean.
- Plugin yamls byte-identical.
- Version: `_version.py`, `pyproject.toml`, both `plugin.yaml` → 0.6.1.