### PR TITLE
feat(commands): /copy — copy-trade a wallet's buys with bounded execution (v0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.7.0 — 2026-05-27
+
+### Added — `/copy` copy-trading
+
+Watch a target wallet's ERC-20 receipts and mirror their buys at a
+configurable fixed ETH amount. Same safeguard surface as `/dca` v2
+(slippage / daily cap / total cap / max consecutive failures), plus a
+per-follow blocklist so airdrops and obvious spam don't trigger
+copies.
+
+- **Surface:**
+  - `/copy add <wallet> <eth_per_copy>` — follow a wallet's buys.
+    Flags: `--slippage <bps>`, `--daily-cap <eth>`, `--max-total <eth>`,
+    `--max-failures <n>`, `--blocklist <0xa,0xb,…>`.
+  - `/copy list` — show your follows + last seen block + copy count.
+  - `/copy pause <id>` / `resume <id>` / `cancel <id>` / `edit <id>
+    <field> <value>` — same mutation surface as `/dca`.
+  - `/copy tick` — manual poll-and-execute (cron-driven in production).
+  - `/copy status` — global summary + service health.
+  - `/copy history <id>` — last 25 copies for one follow.
+
+- **Watcher service** (`CopyTraderService`, id
+  `clawmes.copy_trader`) — ticking=True. Each tick polls Basescan's
+  `account.tokentx` endpoint for every active follow since the last
+  seen block, filters incoming transfers, drops blocklisted contracts,
+  and submits a copy buy at the configured amount. Per-tick cap of 20
+  to prevent runaway airdrop spam from spawning hundreds of buys.
+
+- **Safeguards:**
+  - Order: total cap → daily cap → wallet → swap, identical to
+    `/dca` v2 so the same failure-state vocabulary applies.
+  - Auto-pause after N consecutive failures (default 3).
+  - All Basescan + RPC + swap errors are caught per-follow inside the
+    runner; the service tick adds one more catch so one bad follow
+    cannot crash the cron loop.
+
+### Internal
+
+- `clawmes/commands/copy.py` (~620 lines), `clawmes/services/
+  copy_trader.py` (~80 lines).
+- 3455 tests pass at 100% coverage (was 3318).
+- README service count: 24 → 25. Commands: 84 → 85. Categories
+  unchanged (16).
+
 ## 0.6.1 — 2026-05-27
 
 ### Added — `/dca` v2: auto-scheduler, safeguards, new subcommands

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Clawmes is a [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin. Wallets, DEX trading, lending and staking, governance, on-chain automation. Python rewrite of [`@clawnch/openclaw-crypto`](https://github.com/clawnchdev/openclawnch) targeting Hermes.
 
-52 tools. 84 commands. 24 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
+52 tools. 85 commands. 25 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
 
 ## Quick start
 
@@ -68,7 +68,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 
 ## Commands
 
-84 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
+85 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
 
 | Category | Commands |
 |---|---|
@@ -79,7 +79,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 | **Plans & triggers** (10) | `/plans` `/plan` `/plan_logs` `/interrupt_plan` `/pause_plan` `/resume_plan` `/triggers` `/watch` `/unwatch` `/cron` |
 | **Onboarding** (19) | `/welcome`, 5 personas (`/professional` `/degen` `/chill` `/technical` `/mentor`), 10 capability toggles (`/cap_wallet` `/cap_prices` `/cap_portfolio` `/cap_trading` `/cap_liquidity` `/cap_launchpad` `/cap_bridge` `/cap_routing` `/cap_clawnx` `/cap_hummingbot`), `/skip` `/back` `/reonboard` |
 | **Balance & portfolio** (2) | `/balance` `/portfolio` |
-| **Trading & discovery** (8) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` `/leaderboard` `/claim` `/dca` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link, top tokens/launchers/burners, sweep accumulated LP fees, dollar-cost averaging |
+| **Trading & discovery** (9) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` `/leaderboard` `/claim` `/dca` `/copy` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link, top tokens/launchers/burners, sweep accumulated LP fees, dollar-cost averaging, copy-trade a wallet's buys |
 | **Self-evolution** (3) | `/evolve` `/stable` `/evolution` — gates `agent_memory` and `skill_evolve` write actions; OFF by default |
 | **Endpoint allowlist** (3) | `/allowlist` `/allow` `/disallow` — session-scoped host allowlist + 100-entry block audit ring |
 | **Discoverability** (5) | `/skills` `/persona` `/chains` `/tools_list` `/safety_status` |
@@ -285,6 +285,31 @@ After launching (or any time): three commands cover the basic loop of finding to
 - `/leaderboard` hits `/api/tokens?sort=volume` + `/api/launches` and aggregates client-side. No new server-side endpoints required.
 - `/claim` calls Clanker v4's `collectRewards(address)` on the LP Locker Fee Conversion contract (`0x63D2DfEA…14d93496`). The locker pays out to every recipient slot per token in one shot — caller pays gas, the slot allocations get distributed to the rewardRecipients on that position. Each tx emits a `ClaimedRewards` event with per-recipient `(amount0, amount1)` arrays.
 - `/dca` schedules persist in `${HERMES_HOME}/clawmes/dca/schedules.json`. Interval grammar: `1m`, `30m`, `1h`, `4h`, `1d`, `1w` (1m floor, 1y ceiling). The `DcaSchedulerService` ticks automatically on the registry cadence — no manual cron wiring needed. Safeguards (slippage, daily-cap, max-total, max-failures) attach per-schedule; the `max-failures` counter auto-pauses runaway schedules so a broken swap path can't burn gas in a loop. `/dca tick` is preserved as a synchronous testing entrypoint.
+
+### Copy-trading (v0.7.0)
+
+```
+/copy add 0xWhale… 0.001            # follow the whale's buys, copy at 0.001 ETH
+/copy add 0x… 0.005 --slippage 200 --daily-cap 0.05 --max-total 1
+                                    # full safeguard set on one follow
+/copy add 0x… 0.001 --blocklist 0xspam,0xspam2
+                                    # ignore known airdrop contracts
+/copy list                          # show your follows
+/copy edit copy_abc eth_per_copy 0.002
+                                    # change one field (eth_per_copy, slippage_bps,
+                                    # daily_cap_eth, max_eth_total, max_consecutive_failures,
+                                    # blocklist)
+/copy pause copy_abc                # stop watching without losing state
+/copy resume copy_abc               # re-arm
+/copy cancel copy_abc               # remove
+/copy status                        # global summary + service health
+/copy history copy_abc              # last 25 copies for one follow
+/copy tick                          # manual poll (testing)
+```
+
+The `CopyTraderService` polls Basescan's `account.tokentx` for every active follow on each registry tick (~60s). New ERC-20 transfers into the watched wallet trigger a copy buy via `defi_swap` at the configured fixed ETH amount. Same safeguard surface as `/dca` v2 (slippage / daily cap / total cap / max consecutive failures) plus a per-follow blocklist for known airdrop / spam contracts. Per-tick cap of 20 copies keeps a runaway airdrop streak from spawning hundreds of buys at once.
+
+State persists in `${HERMES_HOME}/clawmes/copy/follows.json`. The watcher seeds `last_seen_block` from the current chain head (minus a 10-block lookback for new follows) so the first tick doesn't replay 100 days of history.
 
 ## Base ecosystem integration
 

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -20,6 +20,7 @@ from clawmes.commands import (
     burn,
     buy,
     claim,
+    copy,
     dca,
     discovery,
     doctor,
@@ -75,6 +76,7 @@ def register_all(ctx) -> None:
     leaderboard.register(ctx)
     claim.register(ctx)
     dca.register(ctx)
+    copy.register(ctx)
     # TODO(v0.1.0+): model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
     # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/copy.py
+++ b/clawmes/commands/copy.py
@@ -1,0 +1,769 @@
+"""``/copy`` — copy-trade a wallet's buys with bounded execution.
+
+Watch another wallet's ERC-20 receipts. When the target receives a
+new token (i.e. they bought it on a DEX), submit our own buy of that
+token at a configurable fixed ETH amount. Safeguards mirror the ``/dca``
+v2 surface so the same auto-pause / cap discipline applies.
+
+Surface:
+
+  * ``/copy add <wallet> <eth_per_copy> [--slippage bps]
+    [--daily-cap eth] [--max-total eth] [--max-failures n]
+    [--blocklist 0x…,0x…]``
+                                              follow a wallet
+  * ``/copy list``                            show your follows
+  * ``/copy pause <id>``                      suspend without removing
+  * ``/copy resume <id>``                     re-arm
+  * ``/copy cancel <id>``                     remove entirely
+  * ``/copy edit <id> <field> <value>``       change one field
+  * ``/copy tick``                            manually poll + execute (testing)
+  * ``/copy status``                          global summary
+  * ``/copy history <id>``                    past copies
+
+Detection: each tick walks ``account.tokentx`` on Basescan for every
+followed wallet since the last seen block. Any incoming token transfer
+(``to == watched_wallet``) for a token NOT in the per-follow blocklist
+triggers a copy buy. We pay our own gas + slippage from the active
+wallet at tick time.
+
+False positives (airdrops, random sends) are minimized by:
+  * Per-follow blocklist (set via ``--blocklist`` or ``/copy edit``).
+  * Per-follow ETH cap (a runaway airdrop streak hits the daily cap
+    and the schedule pauses itself).
+  * Max-failures auto-pause when N consecutive copies fail.
+
+Storage: ``${HERMES_HOME}/clawmes/copy/follows.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from clawmes.lib.http import http_get
+
+_BASESCAN_BASE = "https://api.basescan.org/api"
+_DEFAULT_SLIPPAGE_BPS = 100
+_DEFAULT_MAX_FAILURES = 3
+_DEFAULT_LOOKBACK_BLOCKS = 10  # how far back to seed last_seen on first add
+_MAX_TX_PER_TICK = 20  # cap copies per tick to avoid runaway
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+def _follows_path() -> Path:
+    from clawmes.lib.paths import state_dir
+
+    return state_dir("copy") / "follows.json"
+
+
+def _load_state() -> dict[str, Any]:
+    path = _follows_path()
+    if not path.exists():
+        return {"follows": []}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {"follows": []}
+    if not isinstance(data, dict) or not isinstance(data.get("follows"), list):
+        return {"follows": []}
+    return data
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    path = _follows_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _now_epoch() -> int:
+    return int(time.time())
+
+
+def _new_id() -> str:
+    return f"copy_{uuid.uuid4().hex[:10]}"
+
+
+def _short(value: str) -> str:
+    if not isinstance(value, str) or len(value) <= 12:
+        return str(value)
+    return f"{value[:6]}…{value[-4:]}"
+
+
+def _split_flags(parts: list[str]) -> tuple[list[str], dict[str, str]]:
+    """Mirror of ``dca._split_flags`` — positional + ``--flag value`` pairs."""
+    positional: list[str] = []
+    flags: dict[str, str] = {}
+    i = 0
+    while i < len(parts):
+        tok = parts[i]
+        if tok.startswith("--"):
+            name = tok[2:]
+            value = parts[i + 1] if i + 1 < len(parts) else ""
+            flags[name] = value
+            i += 2
+        else:
+            positional.append(tok)
+            i += 1
+    return positional, flags
+
+
+def _parse_blocklist(raw: str) -> list[str]:
+    """Comma-separated token addresses → lowercased + validated list."""
+    if not raw:
+        return []
+    out = []
+    for tok in raw.split(","):
+        tok = tok.strip()
+        if tok.startswith("0x") and len(tok) == 42:
+            out.append(tok.lower())
+    return out
+
+
+def _record(name: str, args: str, result: str) -> None:
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ── command dispatch ───────────────────────────────────────────────
+
+
+async def handle_copy(raw_args: str, *, sender_id: str = "default", **_kwargs: Any) -> str:
+    raw = (raw_args or "").strip()
+    if not raw:
+        out = _render_usage()
+    else:
+        parts = raw.split()
+        sub = parts[0].lower()
+        rest = parts[1:]
+        if sub == "add":
+            out = _cmd_add(sender_id, rest)
+        elif sub in ("list", "ls"):
+            out = _cmd_list(sender_id)
+        elif sub == "pause":
+            out = _cmd_mutate(sender_id, rest, status="paused", verb="paused")
+        elif sub == "resume":
+            out = _cmd_mutate(sender_id, rest, status="active", verb="resumed")
+        elif sub in ("cancel", "rm", "remove"):
+            out = _cmd_cancel(sender_id, rest)
+        elif sub == "edit":
+            out = _cmd_edit(sender_id, rest)
+        elif sub == "tick":
+            out = await _cmd_tick()
+        elif sub == "status":
+            out = _cmd_status(sender_id)
+        elif sub == "history":
+            out = _cmd_history(sender_id, rest)
+        else:
+            out = f"Unknown subcommand: {sub!r}\n\n" + _render_usage()
+    _record("copy", raw_args, out)
+    return out
+
+
+def _render_usage() -> str:
+    return (
+        "Copy-trade — mirror a wallet's buys at a fixed ETH amount per copy.\n"
+        "\n"
+        "  /copy add <wallet> <eth_per_copy>\n"
+        "      [--slippage <bps>] [--daily-cap <eth>]\n"
+        "      [--max-total <eth>] [--max-failures <n>]\n"
+        "      [--blocklist <0xa,0xb,…>]\n"
+        "                          Follow a wallet's buys\n"
+        "  /copy list              Show your follows + last activity\n"
+        "  /copy pause <id>        Suspend without losing state\n"
+        "  /copy resume <id>       Re-arm a paused follow\n"
+        "  /copy cancel <id>       Remove a follow entirely\n"
+        "  /copy edit <id> <field> <value>\n"
+        "                          Change one field on a follow\n"
+        "  /copy tick              Manually poll + execute (testing)\n"
+        "  /copy status            Global summary + service health\n"
+        "  /copy history <id>      Past copies for a follow\n"
+        "\n"
+        "Example:\n"
+        "  /copy add 0xWhale… 0.001 --slippage 200 --daily-cap 0.05\n"
+        "    Watch the whale; copy each buy at 0.001 ETH with 2% slippage,\n"
+        "    cap 24h spend at 0.05 ETH. Service auto-pauses after 3 failures."
+    )
+
+
+# ── /copy add ───────────────────────────────────────────────────────
+
+
+def _cmd_add(sender_id: str, parts: list[str]) -> str:
+    pos, flags = _split_flags(parts)
+    if len(pos) < 2:
+        return (
+            "Usage: /copy add <wallet> <eth_per_copy>\n"
+            "  [--slippage bps] [--daily-cap eth]\n"
+            "  [--max-total eth] [--max-failures n]\n"
+            "  [--blocklist 0xa,0xb,…]"
+        )
+    wallet, eth_raw = pos[0], pos[1]
+    if not (wallet.startswith("0x") and len(wallet) == 42):
+        return f"wallet must be a 0x… address (got {wallet!r})."
+    try:
+        eth_per_copy = float(eth_raw)
+    except ValueError:
+        return f"eth_per_copy must be a number (got {eth_raw!r})."
+    if eth_per_copy <= 0:
+        return f"eth_per_copy must be positive (got {eth_per_copy})."
+
+    # Flag parsing — same shape as /dca add.
+    slippage_bps = _DEFAULT_SLIPPAGE_BPS
+    if "slippage" in flags:
+        try:
+            slippage_bps = int(flags["slippage"])
+        except ValueError:
+            return f"--slippage must be an integer bps value (got {flags['slippage']!r})."
+        if slippage_bps < 0 or slippage_bps > 10_000:
+            return f"--slippage must be 0–10000 bps (got {slippage_bps})."
+
+    daily_cap_eth: float | None = None
+    if "daily-cap" in flags:
+        try:
+            daily_cap_eth = float(flags["daily-cap"])
+        except ValueError:
+            return f"--daily-cap must be a number (got {flags['daily-cap']!r})."
+        if daily_cap_eth <= 0:
+            return f"--daily-cap must be positive (got {daily_cap_eth})."
+
+    max_eth_total: float | None = None
+    if "max-total" in flags:
+        try:
+            max_eth_total = float(flags["max-total"])
+        except ValueError:
+            return f"--max-total must be a number (got {flags['max-total']!r})."
+        if max_eth_total <= 0:
+            return f"--max-total must be positive (got {max_eth_total})."
+
+    max_failures = _DEFAULT_MAX_FAILURES
+    if "max-failures" in flags:
+        try:
+            max_failures = int(flags["max-failures"])
+        except ValueError:
+            return f"--max-failures must be an integer (got {flags['max-failures']!r})."
+        if max_failures < 1:
+            return f"--max-failures must be >= 1 (got {max_failures})."
+
+    blocklist = _parse_blocklist(flags.get("blocklist", ""))
+
+    # Seed last_seen_block from the current chain head. We default to a
+    # small lookback so the first tick doesn't replay 100 days of history
+    # but still catches anything from the last few blocks the user might
+    # have intended.
+    last_block = _current_block_height() - _DEFAULT_LOOKBACK_BLOCKS
+    if last_block < 0:
+        last_block = 0
+
+    state = _load_state()
+    follow_id = _new_id()
+    follow = {
+        "id": follow_id,
+        "sender_id": sender_id,
+        "wallet": wallet.lower(),
+        "eth_per_copy": eth_per_copy,
+        "slippage_bps": slippage_bps,
+        "daily_cap_eth": daily_cap_eth,
+        "max_eth_total": max_eth_total,
+        "max_consecutive_failures": max_failures,
+        "blocklist": blocklist,
+        "status": "active",
+        "created_at": _now_iso(),
+        "last_seen_block": last_block,
+        "total_eth_spent": 0.0,
+        "executions": [],
+    }
+    state["follows"].append(follow)
+    _save_state(state)
+
+    return (
+        f"Follow added: {follow_id}\n"
+        f"  Wallet:      {wallet}\n"
+        f"  Per copy:    {eth_per_copy} ETH\n"
+        f"  Slippage:    {slippage_bps} bps\n"
+        f"  Daily cap:   {daily_cap_eth if daily_cap_eth is not None else 'none'}\n"
+        f"  Total cap:   {max_eth_total if max_eth_total is not None else 'none'}\n"
+        f"  Max fails:   {max_failures}\n"
+        f"  Blocklist:   {len(blocklist)} token(s)\n"
+        f"  Last block:  {last_block}\n"
+        "\n"
+        "The copy-trader service polls Basescan every ~60s and submits a buy\n"
+        "whenever the followed wallet receives a non-blocklisted token. Use\n"
+        "/copy list to see all your follows."
+    )
+
+
+# ── /copy list / mutate / cancel ────────────────────────────────────
+
+
+def _cmd_list(sender_id: str) -> str:
+    state = _load_state()
+    mine = [f for f in state["follows"] if f.get("sender_id") == sender_id]
+    if not mine:
+        return "No /copy follows. Add one with /copy add <wallet> <eth_per_copy>."
+
+    lines = [f"Copy follows for {sender_id} ({len(mine)}):", ""]
+    for f in mine:
+        runs = len(f.get("executions", []))
+        lines.append(
+            f"  {f['id']}  {f.get('status'):<8s}"
+            f"  {f['eth_per_copy']} ETH/copy  → {_short(f['wallet'])}"
+            f"  ({runs} copies, last_block={f.get('last_seen_block')})"
+        )
+    return "\n".join(lines)
+
+
+def _cmd_mutate(sender_id: str, parts: list[str], *, status: str, verb: str) -> str:
+    if not parts:
+        return f"Usage: /copy {verb.removesuffix('d')} <id>"
+    fid = parts[0]
+    state = _load_state()
+    for f in state["follows"]:
+        if f.get("id") == fid and f.get("sender_id") == sender_id:
+            f["status"] = status
+            _save_state(state)
+            return f"Follow {fid} {verb}."
+    return f"No follow found with id {fid!r}."
+
+
+def _cmd_cancel(sender_id: str, parts: list[str]) -> str:
+    if not parts:
+        return "Usage: /copy cancel <id>"
+    fid = parts[0]
+    state = _load_state()
+    before = len(state["follows"])
+    state["follows"] = [
+        f for f in state["follows"] if not (f.get("id") == fid and f.get("sender_id") == sender_id)
+    ]
+    if len(state["follows"]) == before:
+        return f"No follow found with id {fid!r}."
+    _save_state(state)
+    return f"Cancelled follow {fid}."
+
+
+# ── /copy edit ──────────────────────────────────────────────────────
+
+
+_EDITABLE = {
+    "eth_per_copy",
+    "slippage_bps",
+    "daily_cap_eth",
+    "max_eth_total",
+    "max_consecutive_failures",
+    "blocklist",
+}
+
+
+def _cmd_edit(sender_id: str, parts: list[str]) -> str:
+    if len(parts) < 3:
+        return f"Usage: /copy edit <id> <field> <value>\nFields: {', '.join(sorted(_EDITABLE))}"
+    fid, field, value = parts[0], parts[1], parts[2]
+    if field not in _EDITABLE:
+        return f"Unknown field {field!r}. Editable: {', '.join(sorted(_EDITABLE))}"
+
+    state = _load_state()
+    follow = _find(state, fid, sender_id)
+    if follow is None:
+        return f"No follow found with id {fid!r}."
+
+    if field == "eth_per_copy":
+        try:
+            v = float(value)
+        except ValueError:
+            return f"eth_per_copy must be a number (got {value!r})."
+        if v <= 0:
+            return f"eth_per_copy must be positive (got {v})."
+        follow["eth_per_copy"] = v
+    elif field == "slippage_bps":
+        try:
+            v = int(value)
+        except ValueError:
+            return f"slippage_bps must be an integer (got {value!r})."
+        if v < 0 or v > 10_000:
+            return f"slippage_bps must be 0–10000 (got {v})."
+        follow["slippage_bps"] = v
+    elif field == "daily_cap_eth":
+        if value.lower() == "none":
+            follow["daily_cap_eth"] = None
+        else:
+            try:
+                v = float(value)
+            except ValueError:
+                return f"daily_cap_eth must be a number or 'none' (got {value!r})."
+            if v <= 0:
+                return f"daily_cap_eth must be positive (got {v})."
+            follow["daily_cap_eth"] = v
+    elif field == "max_eth_total":
+        if value.lower() == "none":
+            follow["max_eth_total"] = None
+        else:
+            try:
+                v = float(value)
+            except ValueError:
+                return f"max_eth_total must be a number or 'none' (got {value!r})."
+            if v <= 0:
+                return f"max_eth_total must be positive (got {v})."
+            follow["max_eth_total"] = v
+    elif field == "max_consecutive_failures":
+        try:
+            v = int(value)
+        except ValueError:
+            return f"max_consecutive_failures must be an integer (got {value!r})."
+        if v < 1:
+            return f"max_consecutive_failures must be >= 1 (got {v})."
+        follow["max_consecutive_failures"] = v
+    else:  # blocklist
+        follow["blocklist"] = _parse_blocklist(value)
+
+    _save_state(state)
+    return f"Follow {fid}: {field} = {value}."
+
+
+def _find(state: dict[str, Any], fid: str, sender_id: str) -> dict[str, Any] | None:
+    for f in state["follows"]:
+        if f.get("id") == fid and f.get("sender_id") == sender_id:
+            return f
+    return None
+
+
+# ── /copy tick — the actual watcher ─────────────────────────────────
+
+
+async def _cmd_tick() -> str:
+    """Manual ``/copy tick`` — delegates to the sync runner."""
+    n, lines = _run_due_with_lines()
+    if n == 0:
+        return "No copy follows had new activity."
+    return "\n".join([f"Processed {n} new tx(s)..."] + lines)
+
+
+def _run_due_sync() -> int:
+    """Service entrypoint — returns count of copies submitted across all follows."""
+    n, _ = _run_due_with_lines()
+    return n
+
+
+def _run_due_with_lines() -> tuple[int, list[str]]:
+    state = _load_state()
+    lines: list[str] = []
+    total = 0
+    for follow in state["follows"]:
+        if follow.get("status") != "active":
+            continue
+        try:
+            count = _process_follow(follow, lines)
+            total += count
+        except Exception as exc:  # noqa: BLE001
+            lines.append(f"  {follow['id']}  error fetching: {exc}")
+    if total > 0 or any(lines):
+        _save_state(state)
+    return total, lines
+
+
+def _process_follow(follow: dict[str, Any], lines: list[str]) -> int:
+    """Poll Basescan for new ERC-20 receipts on the followed wallet."""
+    txs = _basescan_token_receipts(
+        follow["wallet"], start_block=int(follow.get("last_seen_block", 0)) + 1
+    )
+    if not txs:
+        return 0
+
+    # Cap per-tick processing so a wallet that just received an airdrop
+    # to 500 tokens doesn't cause us to submit 500 buys.
+    txs = txs[:_MAX_TX_PER_TICK]
+    blocklist = set(follow.get("blocklist", []))
+    count = 0
+    max_block = int(follow.get("last_seen_block", 0))
+
+    for tx in txs:
+        token = (tx.get("contractAddress") or "").lower()
+        if not token or len(token) != 42:
+            continue
+        block_no = int(tx.get("blockNumber", 0))
+        if block_no > max_block:
+            max_block = block_no
+        if token in blocklist:
+            lines.append(f"  {follow['id']}  skipped {_short(token)} (blocklisted)")
+            follow["executions"].append(
+                {
+                    "at": _now_iso(),
+                    "tx_seen": tx.get("hash", ""),
+                    "token": token,
+                    "result": {"status": "blocklisted", "detail": "in follow blocklist"},
+                }
+            )
+            continue
+
+        result = _execute_copy(follow, token)
+        follow["executions"].append(
+            {
+                "at": _now_iso(),
+                "tx_seen": tx.get("hash", ""),
+                "token": token,
+                "result": result,
+            }
+        )
+        if result.get("status") == "ok":
+            follow["total_eth_spent"] = float(follow.get("total_eth_spent", 0.0)) + float(
+                follow["eth_per_copy"]
+            )
+            count += 1
+        lines.append(
+            f"  {follow['id']}  {result.get('status')}  {_short(token)}  {result.get('detail', '')}"
+        )
+
+    follow["last_seen_block"] = max_block
+    _maybe_auto_pause(follow)
+    return count
+
+
+def _maybe_auto_pause(follow: dict[str, Any]) -> None:
+    max_fails = int(follow.get("max_consecutive_failures") or _DEFAULT_MAX_FAILURES)
+    runs = follow.get("executions", [])
+    if len(runs) < max_fails:
+        return
+    tail = runs[-max_fails:]
+    fail_states = {"error", "no_wallet", "daily_capped", "total_capped"}
+    if all((r.get("result") or {}).get("status") in fail_states for r in tail):
+        follow["status"] = "paused"
+
+
+def _spend_in_last_24h(follow: dict[str, Any]) -> float:
+    runs = follow.get("executions", [])
+    cutoff = _now_epoch() - 86400
+    eth_per_copy = float(follow.get("eth_per_copy", 0.0))
+    total = 0.0
+    for run in runs:
+        if (run.get("result") or {}).get("status") != "ok":
+            continue
+        at = run.get("at", "")
+        try:
+            dt = datetime.strptime(at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+            ts = int(dt.timestamp())
+        except (ValueError, TypeError):
+            continue
+        if ts >= cutoff:
+            total += eth_per_copy
+    return total
+
+
+def _execute_copy(follow: dict[str, Any], token: str) -> dict[str, Any]:
+    """Submit one copy buy. Same safeguard order as /dca v2."""
+    eth_amount = float(follow.get("eth_per_copy", 0.0))
+
+    max_total = follow.get("max_eth_total")
+    if max_total is not None:
+        spent = float(follow.get("total_eth_spent", 0.0))
+        if spent + eth_amount > float(max_total):
+            return {
+                "status": "total_capped",
+                "detail": f"would exceed max-total {max_total} ETH (spent {spent})",
+                "tx_hash": "",
+            }
+
+    daily_cap = follow.get("daily_cap_eth")
+    if daily_cap is not None:
+        spent_24h = _spend_in_last_24h(follow)
+        if spent_24h + eth_amount > float(daily_cap):
+            return {
+                "status": "daily_capped",
+                "detail": f"would exceed daily-cap {daily_cap} ETH (spent {spent_24h:.6f} in 24h)",
+                "tx_hash": "",
+            }
+
+    from clawmes.services.wallet import get_wallet_state
+
+    wstate = get_wallet_state()
+    if not wstate.connected:
+        return {"status": "no_wallet", "detail": "no wallet connected", "tx_hash": ""}
+
+    try:
+        from clawmes.tools.defi_swap import defi_swap
+
+        raw = defi_swap(
+            {
+                "action": "swap",
+                "sell_token": "ETH",
+                "buy_token": token,
+                "sell_amount": str(eth_amount),
+                "slippage_bps": int(follow.get("slippage_bps") or _DEFAULT_SLIPPAGE_BPS),
+            }
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "error", "detail": str(exc), "tx_hash": ""}
+
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return {"status": "error", "detail": f"bad swap response: {raw}", "tx_hash": ""}
+    if payload.get("isError"):
+        msg = payload.get("content", [{}])[0].get("text", "swap failed")
+        return {"status": "error", "detail": msg, "tx_hash": ""}
+
+    details = payload.get("details") or {}
+    tx_hash = details.get("tx_hash") or details.get("txHash") or ""
+    return {"status": "ok", "detail": f"tx {tx_hash[:14]}…", "tx_hash": tx_hash}
+
+
+# ── Basescan polling ────────────────────────────────────────────────
+
+
+def _basescan_token_receipts(wallet: str, *, start_block: int) -> list[dict[str, Any]]:
+    """Return ERC-20 token transfers IN to ``wallet`` from ``start_block``+.
+
+    Uses Basescan's ``account.tokentx`` endpoint, filtered to incoming
+    transfers (``to == wallet``). Returns the raw entries; callers map
+    ``contractAddress`` → token to copy.
+    """
+    params = {
+        "module": "account",
+        "action": "tokentx",
+        "address": wallet,
+        "startblock": str(start_block),
+        "endblock": "99999999",
+        "sort": "asc",
+    }
+    api_key = os.environ.get("BASESCAN_API_KEY")
+    if api_key:
+        params["apikey"] = api_key
+
+    body = http_get(_BASESCAN_BASE, params=params, timeout=20.0)
+    if not isinstance(body, dict):
+        return []
+    if str(body.get("status")) != "1":
+        # status="0" usually means "No transactions found" — return [].
+        return []
+    result = body.get("result")
+    if not isinstance(result, list):
+        return []
+    # Keep only incoming transfers (``to`` matches the watched wallet).
+    incoming = [
+        x for x in result if isinstance(x, dict) and (x.get("to") or "").lower() == wallet.lower()
+    ]
+    return incoming
+
+
+def _current_block_height() -> int:
+    """Best-effort head-block fetch for seeding last_seen on new follows."""
+    params = {
+        "module": "proxy",
+        "action": "eth_blockNumber",
+    }
+    api_key = os.environ.get("BASESCAN_API_KEY")
+    if api_key:
+        params["apikey"] = api_key
+
+    try:
+        body = http_get(_BASESCAN_BASE, params=params, timeout=10.0)
+    except Exception:  # noqa: BLE001
+        return 0
+    if not isinstance(body, dict):
+        return 0
+    result = body.get("result")
+    if not isinstance(result, str) or not result.startswith("0x"):
+        return 0
+    try:
+        return int(result, 16)
+    except (ValueError, TypeError):
+        return 0
+
+
+# ── /copy status ────────────────────────────────────────────────────
+
+
+def _cmd_status(_sender_id: str) -> str:
+    state = _load_state()
+    follows = state.get("follows", [])
+    if not follows:
+        return "No /copy follows exist. The watcher service is idle."
+
+    by_status: dict[str, int] = {}
+    total_spent = 0.0
+    total_runs = 0
+    failures = 0
+    for f in follows:
+        s = f.get("status", "?")
+        by_status[s] = by_status.get(s, 0) + 1
+        total_spent += float(f.get("total_eth_spent", 0.0))
+        runs = f.get("executions", [])
+        total_runs += len(runs)
+        for r in runs:
+            status = (r.get("result") or {}).get("status", "")
+            if status in ("error", "no_wallet", "daily_capped", "total_capped"):
+                failures += 1
+
+    lines = [
+        f"/copy watcher status ({len(follows)} follow(s)):",
+        "",
+        f"  By status:    {', '.join(f'{k}={v}' for k, v in sorted(by_status.items()))}",
+        f"  Total copies: {total_runs}",
+        f"  Failures:     {failures}",
+        f"  ETH spent:    {total_spent:.6f}",
+    ]
+
+    try:
+        from clawmes.services.copy_trader import get_copy_trader_service
+
+        svc = get_copy_trader_service()
+        h = svc.health()
+        lines.append(
+            f"  Service:      {h.get('status')} "
+            f"(ticks={h.get('ticks')}, total_copies={h.get('total_runs')})"
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+    return "\n".join(lines)
+
+
+# ── /copy history ───────────────────────────────────────────────────
+
+
+def _cmd_history(sender_id: str, parts: list[str]) -> str:
+    if not parts:
+        return "Usage: /copy history <id>"
+    fid = parts[0]
+    state = _load_state()
+    follow = _find(state, fid, sender_id)
+    if follow is None:
+        return f"No follow found with id {fid!r}."
+    runs = follow.get("executions", [])
+    if not runs:
+        return f"Follow {fid}: no copies yet. (Watcher will surface new buys on the next tick.)"
+    lines = [f"Copies for {fid} ({len(runs)}):", ""]
+    for run in runs[-25:]:  # most recent 25
+        result = run.get("result") or {}
+        status = result.get("status", "?")
+        token = run.get("token", "")
+        when = run.get("at", "")
+        tx_seen = run.get("tx_seen", "")
+        seen_str = f"  seen {_short(tx_seen)}" if tx_seen else ""
+        lines.append(f"  {when}  {status:<13s}  {_short(token)}{seen_str}")
+    # Quiet the timedelta import warning — it's used by tests.
+    _ = timedelta
+    return "\n".join(lines)
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="copy",
+        handler=handle_copy,
+        description="Copy-trade a wallet's buys at a fixed ETH amount",
+        args_hint="add <wallet> <eth> | list | pause | resume | cancel | edit | tick | status | history",
+    )

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.6.1
+version: 0.7.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/services/__init__.py
+++ b/clawmes/services/__init__.py
@@ -43,6 +43,7 @@ def start_all() -> None:
     from clawmes.services.clawnch import get_clawnch_service
     from clawmes.services.coingecko import get_coingecko_service
     from clawmes.services.command_history import get_command_history_service
+    from clawmes.services.copy_trader import get_copy_trader_service
     from clawmes.services.credential_redactor import get_credential_redactor
     from clawmes.services.dca_scheduler import get_dca_scheduler_service
     from clawmes.services.endpoint_allowlist import get_endpoint_allowlist_service
@@ -131,6 +132,10 @@ def start_all() -> None:
         #     the registry cadence (60s by default). Sync execution path;
         #     per-schedule errors caught + logged.
         get_dca_scheduler_service,
+        # 7b. Copy-trader watcher — ticking=True. Polls Basescan for
+        #     followed wallets' new ERC-20 receipts and submits copy
+        #     buys at the configured fixed ETH amount per copy.
+        get_copy_trader_service,
         get_wc_notification_consumer,  # threaded; routes WC bridge notifs
     ]
     for factory in factories:

--- a/clawmes/services/copy_trader.py
+++ b/clawmes/services/copy_trader.py
@@ -1,0 +1,87 @@
+"""Copy-trader scheduler service — drives ``/copy tick`` automatically.
+
+Mirror of ``DcaSchedulerService`` for the ``/copy`` command. Each
+service tick polls Basescan for every active follow's new ERC-20
+receipts and submits a copy buy for any non-blocklisted token.
+
+Lifecycle:
+
+  * ``start()`` — mark running.
+  * ``stop()``  — mark not running.
+  * ``tick()``  — call ``copy._run_due_sync()``. Per-follow errors are
+    caught inside the runner; this layer adds one more catch so a
+    Basescan outage or RPC failure cannot crash the cron loop.
+
+Storage lives in the ``/copy`` command module. This service is just
+the cron-driver wrapper.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawmes.lib.logger import logger_for
+from clawmes.services._base import Service
+
+_log = logger_for("services.copy_trader")
+
+_SERVICE: CopyTraderService | None = None
+
+
+class CopyTraderService(Service):
+    id = "clawmes.copy_trader"
+    ticking = True
+
+    def __init__(self) -> None:
+        self._running = False
+        self._ticks = 0
+        self._last_runs = 0
+        self._total_runs = 0
+
+    def start(self) -> None:
+        self._running = True
+        _log.info("copy trader started — tick cadence driven by registry")
+
+    def stop(self) -> None:
+        self._running = False
+        _log.info(
+            "copy trader stopped (ticks=%d, total_runs=%d)",
+            self._ticks,
+            self._total_runs,
+        )
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": "running" if self._running else "stopped",
+            "ticks": self._ticks,
+            "last_runs": self._last_runs,
+            "total_runs": self._total_runs,
+        }
+
+    def tick(self) -> None:
+        if not self._running:
+            return
+        self._ticks += 1
+        try:
+            from clawmes.commands import copy
+
+            n = copy._run_due_sync()
+            self._last_runs = n
+            self._total_runs += n
+            if n > 0:
+                _log.info("copy tick fired %d buy(s)", n)
+        except Exception:  # noqa: BLE001
+            _log.exception("copy trader tick raised; swallowing")
+
+
+def get_copy_trader_service() -> CopyTraderService:
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = CopyTraderService()
+    return _SERVICE
+
+
+def _reset_for_tests() -> None:
+    global _SERVICE
+    _SERVICE = None

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.6.1
+version: 0.7.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.6.1"
+version = "0.7.0"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_copy.py
+++ b/tests/commands/test_copy.py
@@ -1,0 +1,1023 @@
+"""Tests for the /copy slash command."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from clawmes.commands import copy
+
+# ── fakes ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeWalletState:
+    connected: bool = True
+    address: str = "0x" + "1" * 40
+
+
+@pytest.fixture
+def tmp_state(tmp_path, monkeypatch):
+    p = tmp_path / "follows.json"
+
+    def _path():
+        return p
+
+    monkeypatch.setattr(copy, "_follows_path", _path)
+    return p
+
+
+@pytest.fixture
+def fake_wallet(monkeypatch):
+    state = _FakeWalletState()
+
+    def _state():
+        return state
+
+    import clawmes.services.wallet as wallet_mod
+
+    monkeypatch.setattr(wallet_mod, "get_wallet_state", _state)
+    return state
+
+
+@pytest.fixture
+def fake_defi_swap(monkeypatch):
+    state: dict[str, Any] = {"payload": None, "raises": None}
+
+    def _fake(args):  # noqa: ARG001
+        if state["raises"] is not None:
+            raise state["raises"]
+        return json.dumps(state["payload"])
+
+    import clawmes.tools.defi_swap as swap_mod
+
+    monkeypatch.setattr(swap_mod, "defi_swap", _fake)
+    return state
+
+
+@pytest.fixture
+def fake_basescan(monkeypatch):
+    """Patch ``http_get`` so Basescan endpoints return canned bodies."""
+    state: dict[str, Any] = {
+        "tokentx": None,  # body for account.tokentx
+        "blocknum": None,  # body for proxy.eth_blockNumber
+        "raises": None,
+    }
+
+    def _fake(url, *, params=None, timeout=None):  # noqa: ARG001
+        if state["raises"] is not None:
+            raise state["raises"]
+        action = (params or {}).get("action")
+        if action == "tokentx":
+            return state["tokentx"]
+        if action == "eth_blockNumber":
+            return state["blocknum"]
+        return None
+
+    monkeypatch.setattr(copy, "http_get", _fake)
+    return state
+
+
+def _add_basic_follow(monkeypatch, sender="u", wallet=None, eth="0.001") -> str:
+    """Add a follow and return its id. Stubs block height to 1000."""
+    addr = wallet or "0x" + "a" * 40
+    monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+    out = copy._cmd_add(sender, [addr, eth])
+    return next(w for w in out.split() if w.startswith("copy_"))
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_short_unchanged(self):
+        assert copy._short("0x123") == "0x123"
+
+    def test_short_truncated(self):
+        out = copy._short("0x" + "a" * 40)
+        assert "…" in out
+
+    def test_short_non_str(self):
+        assert copy._short(None) == "None"  # type: ignore[arg-type]
+
+    def test_now_iso_format(self):
+        s = copy._now_iso()
+        assert s.endswith("Z") and "T" in s
+
+    def test_new_id(self):
+        assert copy._new_id().startswith("copy_")
+
+    def test_now_epoch(self):
+        assert copy._now_epoch() > 0
+
+
+class TestSplitFlags:
+    def test_positional_only(self):
+        pos, flags = copy._split_flags(["a", "b"])
+        assert pos == ["a", "b"]
+        assert flags == {}
+
+    def test_flag_with_value(self):
+        pos, flags = copy._split_flags(["a", "--x", "1"])
+        assert flags == {"x": "1"}
+
+    def test_bare_trailing(self):
+        pos, flags = copy._split_flags(["--bare"])
+        assert flags == {"bare": ""}
+
+
+class TestParseBlocklist:
+    def test_empty(self):
+        assert copy._parse_blocklist("") == []
+
+    def test_single(self):
+        assert copy._parse_blocklist("0x" + "1" * 40) == ["0x" + "1" * 40]
+
+    def test_multi(self):
+        out = copy._parse_blocklist("0x" + "1" * 40 + ", 0x" + "2" * 40)
+        assert len(out) == 2
+
+    def test_filters_bad_entries(self):
+        out = copy._parse_blocklist("0x" + "1" * 40 + ",not-an-addr, 0xabc")
+        assert out == ["0x" + "1" * 40]
+
+
+# ── state I/O ───────────────────────────────────────────────────────
+
+
+class TestStateIO:
+    def test_load_missing(self, tmp_state):
+        assert copy._load_state() == {"follows": []}
+
+    def test_load_bad_json(self, tmp_state):
+        tmp_state.write_text("not-json")
+        assert copy._load_state() == {"follows": []}
+
+    def test_load_wrong_shape(self, tmp_state):
+        tmp_state.write_text(json.dumps({"follows": "not-a-list"}))
+        assert copy._load_state() == {"follows": []}
+
+    def test_load_not_a_dict(self, tmp_state):
+        tmp_state.write_text(json.dumps(["foo"]))
+        assert copy._load_state() == {"follows": []}
+
+    def test_roundtrip(self, tmp_state):
+        state = {"follows": [{"id": "x"}]}
+        copy._save_state(state)
+        assert copy._load_state() == state
+
+    def test_default_path_under_hermes_home(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = copy._follows_path()
+        assert p.name == "follows.json"
+        assert "copy" in str(p)
+
+
+# ── _cmd_add ────────────────────────────────────────────────────────
+
+
+class TestCmdAdd:
+    def test_usage(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", [])
+        assert "Usage:" in out
+
+    def test_bad_wallet(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["not-addr", "0.001"])
+        assert "must be a 0x… address" in out
+
+    def test_bad_eth_non_numeric(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "abc"])
+        assert "must be a number" in out
+
+    def test_bad_eth_zero(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0"])
+        assert "must be positive" in out
+
+    def test_bad_slippage_non_int(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001", "--slippage", "x"])
+        assert "--slippage must be an integer" in out
+
+    def test_bad_slippage_range(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001", "--slippage", "99999"])
+        assert "0–10000" in out
+
+    def test_bad_daily_cap(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001", "--daily-cap", "x"])
+        assert "--daily-cap must be a number" in out
+
+    def test_daily_cap_non_positive(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001", "--daily-cap", "0"])
+        assert "--daily-cap must be positive" in out
+
+    def test_bad_max_total(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001", "--max-total", "x"])
+        assert "--max-total must be a number" in out
+
+    def test_max_total_non_positive(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001", "--max-total", "-1"])
+        assert "--max-total must be positive" in out
+
+    def test_bad_max_failures(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001", "--max-failures", "x"])
+        assert "--max-failures must be an integer" in out
+
+    def test_max_failures_zero(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001", "--max-failures", "0"])
+        assert "must be >= 1" in out
+
+    def test_success_defaults(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001"])
+        assert "Follow added" in out
+        f = copy._load_state()["follows"][0]
+        assert f["wallet"] == "0x" + "a" * 40
+        assert f["eth_per_copy"] == 0.001
+        assert f["slippage_bps"] == copy._DEFAULT_SLIPPAGE_BPS
+        assert f["max_consecutive_failures"] == copy._DEFAULT_MAX_FAILURES
+        assert f["last_seen_block"] == 1000 - copy._DEFAULT_LOOKBACK_BLOCKS
+
+    def test_lookback_clamps_at_zero(self, tmp_state, monkeypatch):
+        # If chain height is very low (testnet, fresh chain), don't go negative.
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 3)
+        copy._cmd_add("u", ["0x" + "a" * 40, "0.001"])
+        f = copy._load_state()["follows"][0]
+        assert f["last_seen_block"] == 0
+
+    def test_success_all_flags(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        bl = "0x" + "1" * 40 + ",0x" + "2" * 40
+        out = copy._cmd_add(
+            "u",
+            [
+                "0x" + "a" * 40,
+                "0.001",
+                "--slippage",
+                "200",
+                "--daily-cap",
+                "0.05",
+                "--max-total",
+                "1.0",
+                "--max-failures",
+                "5",
+                "--blocklist",
+                bl,
+            ],
+        )
+        assert "Follow added" in out
+        f = copy._load_state()["follows"][0]
+        assert f["slippage_bps"] == 200
+        assert f["daily_cap_eth"] == 0.05
+        assert f["max_eth_total"] == 1.0
+        assert f["max_consecutive_failures"] == 5
+        assert len(f["blocklist"]) == 2
+
+
+# ── _cmd_list / mutate / cancel ────────────────────────────────────
+
+
+class TestCmdList:
+    def test_empty(self, tmp_state):
+        assert "No /copy follows" in copy._cmd_list("u")
+
+    def test_lists_mine(self, tmp_state, monkeypatch):
+        _add_basic_follow(monkeypatch, "alice")
+        _add_basic_follow(monkeypatch, "bob", wallet="0x" + "b" * 40)
+        out = copy._cmd_list("alice")
+        assert "alice" in out
+        # Only Alice's follow should appear (1 follow listed).
+        assert out.count("ETH/copy") == 1
+
+
+class TestMutate:
+    def test_pause_usage(self, tmp_state):
+        out = copy._cmd_mutate("u", [], status="paused", verb="paused")
+        assert "Usage:" in out
+
+    def test_pause_not_found(self, tmp_state):
+        out = copy._cmd_mutate("u", ["copy_xxx"], status="paused", verb="paused")
+        assert "No follow found" in out
+
+    def test_pause_success(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        out = copy._cmd_mutate("u", [fid], status="paused", verb="paused")
+        assert "paused" in out
+        assert copy._load_state()["follows"][0]["status"] == "paused"
+
+    def test_resume_success(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        copy._cmd_mutate("u", [fid], status="paused", verb="paused")
+        out = copy._cmd_mutate("u", [fid], status="active", verb="resumed")
+        assert "resumed" in out
+
+
+class TestCancel:
+    def test_usage(self, tmp_state):
+        assert "Usage:" in copy._cmd_cancel("u", [])
+
+    def test_not_found(self, tmp_state):
+        assert "No follow" in copy._cmd_cancel("u", ["copy_xxx"])
+
+    def test_success(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        out = copy._cmd_cancel("u", [fid])
+        assert "Cancelled" in out
+        assert copy._load_state()["follows"] == []
+
+    def test_isolated_by_sender(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch, "alice")
+        out = copy._cmd_cancel("bob", [fid])
+        assert "No follow" in out
+        assert len(copy._load_state()["follows"]) == 1
+
+
+# ── _cmd_edit ───────────────────────────────────────────────────────
+
+
+class TestCmdEdit:
+    def test_usage(self, tmp_state):
+        out = copy._cmd_edit("u", [])
+        assert "Usage:" in out
+
+    def test_unknown_field(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        out = copy._cmd_edit("u", [fid, "garbage", "1"])
+        assert "Unknown field" in out
+
+    def test_not_found(self, tmp_state):
+        out = copy._cmd_edit("u", ["copy_xxx", "eth_per_copy", "0.01"])
+        assert "No follow found" in out
+
+    def test_eth_per_copy(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        copy._cmd_edit("u", [fid, "eth_per_copy", "0.05"])
+        assert copy._load_state()["follows"][0]["eth_per_copy"] == 0.05
+
+    def test_eth_per_copy_bad(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "must be a number" in copy._cmd_edit("u", [fid, "eth_per_copy", "x"])
+
+    def test_eth_per_copy_non_positive(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "must be positive" in copy._cmd_edit("u", [fid, "eth_per_copy", "0"])
+
+    def test_slippage_bps(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        copy._cmd_edit("u", [fid, "slippage_bps", "75"])
+        assert copy._load_state()["follows"][0]["slippage_bps"] == 75
+
+    def test_slippage_bps_bad(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "integer" in copy._cmd_edit("u", [fid, "slippage_bps", "x"])
+
+    def test_slippage_bps_range(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "0–10000" in copy._cmd_edit("u", [fid, "slippage_bps", "99999"])
+
+    def test_daily_cap_value(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        copy._cmd_edit("u", [fid, "daily_cap_eth", "0.1"])
+        assert copy._load_state()["follows"][0]["daily_cap_eth"] == 0.1
+
+    def test_daily_cap_none(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        copy._cmd_edit("u", [fid, "daily_cap_eth", "0.1"])
+        copy._cmd_edit("u", [fid, "daily_cap_eth", "none"])
+        assert copy._load_state()["follows"][0]["daily_cap_eth"] is None
+
+    def test_daily_cap_bad(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "must be a number" in copy._cmd_edit("u", [fid, "daily_cap_eth", "x"])
+
+    def test_daily_cap_non_positive(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "must be positive" in copy._cmd_edit("u", [fid, "daily_cap_eth", "0"])
+
+    def test_max_total_value(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        copy._cmd_edit("u", [fid, "max_eth_total", "0.5"])
+        assert copy._load_state()["follows"][0]["max_eth_total"] == 0.5
+
+    def test_max_total_none(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        copy._cmd_edit("u", [fid, "max_eth_total", "NONE"])
+        assert copy._load_state()["follows"][0]["max_eth_total"] is None
+
+    def test_max_total_bad(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "must be a number" in copy._cmd_edit("u", [fid, "max_eth_total", "x"])
+
+    def test_max_total_non_positive(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "must be positive" in copy._cmd_edit("u", [fid, "max_eth_total", "-1"])
+
+    def test_max_failures(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        copy._cmd_edit("u", [fid, "max_consecutive_failures", "7"])
+        assert copy._load_state()["follows"][0]["max_consecutive_failures"] == 7
+
+    def test_max_failures_bad(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "integer" in copy._cmd_edit("u", [fid, "max_consecutive_failures", "x"])
+
+    def test_max_failures_zero(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "must be >= 1" in copy._cmd_edit("u", [fid, "max_consecutive_failures", "0"])
+
+    def test_blocklist(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        copy._cmd_edit("u", [fid, "blocklist", "0x" + "1" * 40 + ",0x" + "2" * 40])
+        assert len(copy._load_state()["follows"][0]["blocklist"]) == 2
+
+
+# ── _find ───────────────────────────────────────────────────────────
+
+
+class TestFind:
+    def test_match(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        state = copy._load_state()
+        assert copy._find(state, fid, "u") is not None
+
+    def test_wrong_sender(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch, "alice")
+        state = copy._load_state()
+        assert copy._find(state, fid, "bob") is None
+
+    def test_missing(self, tmp_state):
+        assert copy._find(copy._load_state(), "copy_xxx", "u") is None
+
+
+# ── _basescan_token_receipts ────────────────────────────────────────
+
+
+class TestBasescanTokenReceipts:
+    def test_non_dict_body(self, fake_basescan):
+        fake_basescan["tokentx"] = "not-a-dict"
+        assert copy._basescan_token_receipts("0xabc", start_block=0) == []
+
+    def test_status_zero(self, fake_basescan):
+        fake_basescan["tokentx"] = {"status": "0", "message": "No transactions found"}
+        assert copy._basescan_token_receipts("0xabc", start_block=0) == []
+
+    def test_result_not_list(self, fake_basescan):
+        fake_basescan["tokentx"] = {"status": "1", "result": "string"}
+        assert copy._basescan_token_receipts("0xabc", start_block=0) == []
+
+    def test_filters_incoming(self, fake_basescan):
+        wallet = "0x" + "a" * 40
+        fake_basescan["tokentx"] = {
+            "status": "1",
+            "result": [
+                {"to": wallet, "contractAddress": "0xT1", "blockNumber": "100"},
+                {"to": "0x" + "f" * 40, "contractAddress": "0xT2", "blockNumber": "101"},
+                {"contractAddress": "0xT3"},  # no `to`
+                "not-a-dict",  # noise
+            ],
+        }
+        out = copy._basescan_token_receipts(wallet, start_block=50)
+        assert len(out) == 1
+        assert out[0]["contractAddress"] == "0xT1"
+
+    def test_api_key_passed_through(self, monkeypatch, fake_basescan):
+        captured = {}
+
+        def _spy(url, *, params=None, timeout=None):  # noqa: ARG001
+            captured.update(params)
+            return {"status": "0"}
+
+        monkeypatch.setattr(copy, "http_get", _spy)
+        monkeypatch.setenv("BASESCAN_API_KEY", "MYKEY")
+        copy._basescan_token_receipts("0xabc", start_block=0)
+        assert captured.get("apikey") == "MYKEY"
+
+
+# ── _current_block_height ───────────────────────────────────────────
+
+
+class TestCurrentBlockHeight:
+    def test_http_error(self, fake_basescan):
+        fake_basescan["raises"] = RuntimeError("down")
+        assert copy._current_block_height() == 0
+
+    def test_non_dict(self, fake_basescan):
+        fake_basescan["blocknum"] = "junk"
+        assert copy._current_block_height() == 0
+
+    def test_no_result_string(self, fake_basescan):
+        fake_basescan["blocknum"] = {"result": 123}
+        assert copy._current_block_height() == 0
+
+    def test_bad_hex(self, fake_basescan):
+        fake_basescan["blocknum"] = {"result": "0xZZZ"}
+        assert copy._current_block_height() == 0
+
+    def test_success(self, fake_basescan):
+        fake_basescan["blocknum"] = {"result": "0x3e8"}
+        assert copy._current_block_height() == 1000
+
+    def test_api_key_passed_through(self, monkeypatch):
+        captured = {}
+
+        def _spy(url, *, params=None, timeout=None):  # noqa: ARG001
+            captured.update(params)
+            return {"result": "0x0"}
+
+        monkeypatch.setattr(copy, "http_get", _spy)
+        monkeypatch.setenv("BASESCAN_API_KEY", "MYKEY")
+        copy._current_block_height()
+        assert captured.get("apikey") == "MYKEY"
+
+
+# ── _maybe_auto_pause / _spend_in_last_24h ─────────────────────────
+
+
+class TestMaybeAutoPause:
+    def test_too_few(self):
+        follow = {"max_consecutive_failures": 3, "executions": [{"result": {"status": "error"}}]}
+        copy._maybe_auto_pause(follow)
+        assert "status" not in follow
+
+    def test_mixed_no_pause(self):
+        follow = {
+            "max_consecutive_failures": 3,
+            "executions": [
+                {"result": {"status": "error"}},
+                {"result": {"status": "ok"}},
+                {"result": {"status": "error"}},
+            ],
+        }
+        copy._maybe_auto_pause(follow)
+        assert follow.get("status") != "paused"
+
+    def test_all_fail_pauses(self):
+        follow = {
+            "max_consecutive_failures": 3,
+            "executions": [
+                {"result": {"status": "error"}},
+                {"result": {"status": "no_wallet"}},
+                {"result": {"status": "daily_capped"}},
+            ],
+        }
+        copy._maybe_auto_pause(follow)
+        assert follow["status"] == "paused"
+
+    def test_default_threshold(self):
+        follow = {
+            "executions": [
+                {"result": {"status": "error"}},
+                {"result": {"status": "error"}},
+                {"result": {"status": "error"}},
+            ]
+        }
+        copy._maybe_auto_pause(follow)
+        assert follow["status"] == "paused"
+
+
+class TestSpendInLast24h:
+    def test_no_runs(self):
+        assert copy._spend_in_last_24h({"eth_per_copy": 0.01, "executions": []}) == 0
+
+    def test_skips_non_ok(self):
+        follow = {
+            "eth_per_copy": 0.01,
+            "executions": [
+                {"at": copy._now_iso(), "result": {"status": "error"}},
+                {"at": copy._now_iso(), "result": {"status": "ok"}},
+            ],
+        }
+        assert copy._spend_in_last_24h(follow) == 0.01
+
+    def test_skips_old(self):
+        old = (datetime.now(UTC) - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        follow = {
+            "eth_per_copy": 0.01,
+            "executions": [{"at": old, "result": {"status": "ok"}}],
+        }
+        assert copy._spend_in_last_24h(follow) == 0
+
+    def test_skips_bad_timestamp(self):
+        follow = {
+            "eth_per_copy": 0.01,
+            "executions": [{"at": "garbage", "result": {"status": "ok"}}],
+        }
+        assert copy._spend_in_last_24h(follow) == 0
+
+
+# ── _execute_copy ───────────────────────────────────────────────────
+
+
+class TestExecuteCopy:
+    def test_total_capped(self, fake_wallet, fake_defi_swap):
+        follow = {
+            "eth_per_copy": 0.01,
+            "max_eth_total": 0.005,
+            "total_eth_spent": 0.0,
+            "executions": [],
+        }
+        result = copy._execute_copy(follow, "0x" + "1" * 40)
+        assert result["status"] == "total_capped"
+
+    def test_daily_capped(self, fake_wallet, fake_defi_swap):
+        follow = {
+            "eth_per_copy": 0.01,
+            "daily_cap_eth": 0.005,
+            "executions": [{"at": copy._now_iso(), "result": {"status": "ok"}}],
+        }
+        result = copy._execute_copy(follow, "0x" + "1" * 40)
+        assert result["status"] == "daily_capped"
+
+    def test_no_wallet(self, fake_wallet, fake_defi_swap):
+        fake_wallet.connected = False
+        follow = {"eth_per_copy": 0.01, "executions": []}
+        assert copy._execute_copy(follow, "0x" + "1" * 40)["status"] == "no_wallet"
+
+    def test_defi_swap_raises(self, fake_wallet, fake_defi_swap):
+        fake_defi_swap["raises"] = RuntimeError("rpc broke")
+        follow = {"eth_per_copy": 0.01, "executions": []}
+        result = copy._execute_copy(follow, "0x" + "1" * 40)
+        assert result["status"] == "error"
+        assert "rpc broke" in result["detail"]
+
+    def test_defi_swap_bad_json(self, fake_wallet, monkeypatch):
+        import clawmes.tools.defi_swap as swap_mod
+
+        monkeypatch.setattr(swap_mod, "defi_swap", lambda *a, **k: "not-json")
+        follow = {"eth_per_copy": 0.01, "executions": []}
+        result = copy._execute_copy(follow, "0x" + "1" * 40)
+        assert result["status"] == "error"
+
+    def test_defi_swap_isError(self, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": True,
+            "content": [{"text": "no route"}],
+        }
+        follow = {"eth_per_copy": 0.01, "executions": []}
+        result = copy._execute_copy(follow, "0x" + "1" * 40)
+        assert result["status"] == "error"
+        assert "no route" in result["detail"]
+
+    def test_defi_swap_isError_missing_content(self, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {"isError": True}
+        follow = {"eth_per_copy": 0.01, "executions": []}
+        result = copy._execute_copy(follow, "0x" + "1" * 40)
+        assert result["status"] == "error"
+
+    def test_success(self, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed1234567890abc"},
+        }
+        follow = {"eth_per_copy": 0.01, "executions": []}
+        result = copy._execute_copy(follow, "0x" + "1" * 40)
+        assert result["status"] == "ok"
+        assert "0xfeed" in result["tx_hash"]
+
+
+# ── _process_follow + runner ───────────────────────────────────────
+
+
+class TestProcessFollow:
+    def test_no_new_tx(self, tmp_state, fake_basescan, monkeypatch):
+        fake_basescan["tokentx"] = {"status": "0", "message": "No transactions found"}
+        _add_basic_follow(monkeypatch)
+        n = copy._run_due_sync()
+        assert n == 0
+
+    def test_blocklisted_skipped(
+        self, tmp_state, fake_basescan, monkeypatch, fake_wallet, fake_defi_swap
+    ):
+        fid = _add_basic_follow(monkeypatch)
+        # Add a blocklist entry.
+        copy._cmd_edit("u", [fid, "blocklist", "0x" + "T" * 40])
+
+        wallet = copy._load_state()["follows"][0]["wallet"]
+        fake_basescan["tokentx"] = {
+            "status": "1",
+            "result": [
+                {
+                    "to": wallet,
+                    "contractAddress": "0x" + "T" * 40,
+                    "blockNumber": "2000",
+                    "hash": "0xseen",
+                }
+            ],
+        }
+        n = copy._run_due_sync()
+        # Blocklisted ⇒ no actual buy submitted; counter is 0.
+        assert n == 0
+        state = copy._load_state()
+        assert state["follows"][0]["executions"][0]["result"]["status"] == "blocklisted"
+
+    def test_successful_copy(
+        self, tmp_state, fake_basescan, monkeypatch, fake_wallet, fake_defi_swap
+    ):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        _add_basic_follow(monkeypatch)
+        wallet = copy._load_state()["follows"][0]["wallet"]
+        token_addr = "0x" + "B" * 40
+        fake_basescan["tokentx"] = {
+            "status": "1",
+            "result": [
+                {
+                    "to": wallet,
+                    "contractAddress": token_addr,
+                    "blockNumber": "2000",
+                    "hash": "0xseen",
+                }
+            ],
+        }
+        n = copy._run_due_sync()
+        assert n == 1
+        state = copy._load_state()
+        follow = state["follows"][0]
+        assert follow["last_seen_block"] == 2000
+        assert follow["executions"][0]["result"]["status"] == "ok"
+        assert follow["total_eth_spent"] == 0.001  # eth_per_copy
+
+    def test_skips_invalid_contract(self, tmp_state, fake_basescan, monkeypatch, fake_wallet):
+        _add_basic_follow(monkeypatch)
+        wallet = copy._load_state()["follows"][0]["wallet"]
+        # Malformed contractAddress should be skipped silently.
+        fake_basescan["tokentx"] = {
+            "status": "1",
+            "result": [
+                {"to": wallet, "contractAddress": "0xbad", "blockNumber": "2000"},
+                {"to": wallet, "blockNumber": "2001"},
+            ],
+        }
+        n = copy._run_due_sync()
+        assert n == 0
+        state = copy._load_state()
+        # No executions recorded — malformed contractAddress is skipped.
+        assert state["follows"][0]["executions"] == []
+
+    def test_paused_follow_skipped(self, tmp_state, monkeypatch, fake_basescan):
+        fid = _add_basic_follow(monkeypatch)
+        copy._cmd_mutate("u", [fid], status="paused", verb="paused")
+        # Even though we have a Basescan response queued, the paused
+        # follow shouldn't even hit the polling path.
+        fake_basescan["tokentx"] = {
+            "status": "1",
+            "result": [{"to": "x", "contractAddress": "0x" + "C" * 40, "blockNumber": "2000"}],
+        }
+        n = copy._run_due_sync()
+        assert n == 0
+
+    def test_max_per_tick_cap(
+        self, tmp_state, fake_basescan, monkeypatch, fake_wallet, fake_defi_swap
+    ):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        _add_basic_follow(monkeypatch)
+        wallet = copy._load_state()["follows"][0]["wallet"]
+
+        # 30 incoming transfers — should be capped at _MAX_TX_PER_TICK (20).
+        result = [
+            {
+                "to": wallet,
+                "contractAddress": "0x" + f"{i:040x}",
+                "blockNumber": str(2000 + i),
+                "hash": f"0xseen{i}",
+            }
+            for i in range(30)
+        ]
+        fake_basescan["tokentx"] = {"status": "1", "result": result}
+        n = copy._run_due_sync()
+        assert n == copy._MAX_TX_PER_TICK
+
+    def test_runner_swallows_per_follow_errors(self, tmp_state, monkeypatch):
+        _add_basic_follow(monkeypatch)
+
+        def _boom(*a, **k):
+            raise RuntimeError("basescan down")
+
+        monkeypatch.setattr(copy, "_basescan_token_receipts", _boom)
+        n, lines = copy._run_due_with_lines()
+        assert n == 0
+        assert any("error fetching" in line for line in lines)
+
+
+# ── _cmd_status ─────────────────────────────────────────────────────
+
+
+class TestCmdStatus:
+    def test_empty(self, tmp_state):
+        out = copy._cmd_status("u")
+        assert "watcher service is idle" in out
+
+    def test_summarizes(self, tmp_state, monkeypatch):
+        _add_basic_follow(monkeypatch, "alice")
+        _add_basic_follow(monkeypatch, "bob", wallet="0x" + "b" * 40)
+        state = copy._load_state()
+        state["follows"][0]["executions"] = [
+            {"at": "x", "result": {"status": "ok"}},
+            {"at": "y", "result": {"status": "error"}},
+        ]
+        state["follows"][0]["total_eth_spent"] = 0.005
+        copy._save_state(state)
+        out = copy._cmd_status("alice")
+        assert "(2 follow(s))" in out
+        assert "active=2" in out
+        assert "Failures:     1" in out
+
+    def test_service_health_swallow(self, monkeypatch, tmp_state):
+        import clawmes.services.copy_trader as svc_mod
+
+        def _boom():
+            raise RuntimeError("svc not initialized")
+
+        monkeypatch.setattr(svc_mod, "get_copy_trader_service", _boom)
+        _add_basic_follow(monkeypatch)
+        out = copy._cmd_status("u")
+        assert "Service:" not in out
+
+    def test_service_health_present(self, tmp_state, monkeypatch):
+        from clawmes.services import copy_trader as svc_mod
+
+        svc_mod._reset_for_tests()
+        svc = svc_mod.get_copy_trader_service()
+        svc.start()
+        try:
+            _add_basic_follow(monkeypatch)
+            out = copy._cmd_status("u")
+            assert "Service:" in out
+            assert "running" in out
+        finally:
+            svc.stop()
+            svc_mod._reset_for_tests()
+
+
+# ── _cmd_history ───────────────────────────────────────────────────
+
+
+class TestCmdHistory:
+    def test_usage(self, tmp_state):
+        assert "Usage:" in copy._cmd_history("u", [])
+
+    def test_not_found(self, tmp_state):
+        assert "No follow" in copy._cmd_history("u", ["copy_xxx"])
+
+    def test_empty(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        assert "no copies yet" in copy._cmd_history("u", [fid])
+
+    def test_with_runs(self, tmp_state, monkeypatch):
+        fid = _add_basic_follow(monkeypatch)
+        state = copy._load_state()
+        state["follows"][0]["executions"] = [
+            {
+                "at": "2026-05-27T01:00:00Z",
+                "tx_seen": "0xabcd1234567890",
+                "token": "0x" + "T" * 40,
+                "result": {"status": "ok"},
+            },
+            {
+                "at": "2026-05-27T02:00:00Z",
+                "tx_seen": "",
+                "token": "0x" + "U" * 40,
+                "result": {"status": "blocklisted"},
+            },
+        ]
+        copy._save_state(state)
+        out = copy._cmd_history("u", [fid])
+        assert "Copies for" in out
+        assert "ok" in out
+        assert "blocklisted" in out
+        assert "seen 0xabcd" in out
+
+
+# ── handle_copy (dispatch) ─────────────────────────────────────────
+
+
+class TestHandleCopy:
+    async def test_empty(self, tmp_state):
+        out = await copy.handle_copy("")
+        assert "Copy-trade" in out
+
+    async def test_unknown(self, tmp_state):
+        out = await copy.handle_copy("garbage")
+        assert "Unknown subcommand" in out
+
+    async def test_add(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = await copy.handle_copy("add 0x" + "a" * 40 + " 0.001")
+        assert "Follow added" in out
+
+    async def test_list(self, tmp_state):
+        out = await copy.handle_copy("list")
+        assert "No /copy follows" in out
+
+    async def test_ls_alias(self, tmp_state):
+        out = await copy.handle_copy("ls")
+        assert "No /copy follows" in out
+
+    async def test_pause(self, tmp_state):
+        out = await copy.handle_copy("pause copy_xxx")
+        assert "No follow found" in out
+
+    async def test_resume(self, tmp_state):
+        out = await copy.handle_copy("resume copy_xxx")
+        assert "No follow found" in out
+
+    async def test_cancel(self, tmp_state):
+        out = await copy.handle_copy("cancel copy_xxx")
+        assert "No follow found" in out
+
+    async def test_rm_alias(self, tmp_state):
+        out = await copy.handle_copy("rm copy_xxx")
+        assert "No follow found" in out
+
+    async def test_remove_alias(self, tmp_state):
+        out = await copy.handle_copy("remove copy_xxx")
+        assert "No follow found" in out
+
+    async def test_edit(self, tmp_state):
+        out = await copy.handle_copy("edit copy_xxx eth_per_copy 0.01")
+        assert "No follow found" in out
+
+    async def test_tick(self, tmp_state):
+        out = await copy.handle_copy("tick")
+        assert "No copy follows" in out
+
+    async def test_status(self, tmp_state):
+        out = await copy.handle_copy("status")
+        assert "idle" in out
+
+    async def test_history(self, tmp_state):
+        out = await copy.handle_copy("history copy_xxx")
+        assert "No follow" in out
+
+    async def test_record_swallows(self, monkeypatch, tmp_state):
+        import clawmes.services.command_history as ch
+
+        def _boom(*a, **k):
+            raise RuntimeError("hist broken")
+
+        monkeypatch.setattr(ch, "record_command_call", _boom)
+        out = await copy.handle_copy("")
+        assert "Copy-trade" in out
+
+
+# ── register ───────────────────────────────────────────────────────
+
+
+class TestRegister:
+    def test_register_wires_command(self):
+        registered: list[dict] = []
+
+        class Ctx:
+            def register_command(self, **kwargs):
+                registered.append(kwargs)
+
+        copy.register(Ctx())
+        assert len(registered) == 1
+        assert registered[0]["name"] == "copy"
+
+
+# ── tick wrapper renders Processed line ────────────────────────────
+
+
+class TestManualTick:
+    async def test_with_activity(
+        self, tmp_state, fake_basescan, monkeypatch, fake_wallet, fake_defi_swap
+    ):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        _add_basic_follow(monkeypatch)
+        wallet = copy._load_state()["follows"][0]["wallet"]
+        fake_basescan["tokentx"] = {
+            "status": "1",
+            "result": [
+                {
+                    "to": wallet,
+                    "contractAddress": "0x" + "B" * 40,
+                    "blockNumber": "2000",
+                    "hash": "0xseen",
+                }
+            ],
+        }
+        out = await copy._cmd_tick()
+        assert "Processed 1" in out

--- a/tests/services/test_copy_trader.py
+++ b/tests/services/test_copy_trader.py
@@ -1,0 +1,108 @@
+"""Tests for the copy-trader scheduler service."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.services import copy_trader
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    copy_trader._reset_for_tests()
+    yield
+    copy_trader._reset_for_tests()
+
+
+class TestSingleton:
+    def test_same_instance(self):
+        a = copy_trader.get_copy_trader_service()
+        b = copy_trader.get_copy_trader_service()
+        assert a is b
+
+    def test_reset(self):
+        a = copy_trader.get_copy_trader_service()
+        copy_trader._reset_for_tests()
+        b = copy_trader.get_copy_trader_service()
+        assert a is not b
+
+
+class TestLifecycle:
+    def test_start_marks_running(self):
+        svc = copy_trader.get_copy_trader_service()
+        assert svc._running is False
+        svc.start()
+        assert svc._running is True
+
+    def test_stop_marks_stopped(self):
+        svc = copy_trader.get_copy_trader_service()
+        svc.start()
+        svc.stop()
+        assert svc._running is False
+
+    def test_health_shape(self):
+        svc = copy_trader.get_copy_trader_service()
+        h = svc.health()
+        assert h["id"] == "clawmes.copy_trader"
+        assert h["status"] == "stopped"
+        assert h["ticks"] == 0
+
+    def test_health_running(self):
+        svc = copy_trader.get_copy_trader_service()
+        svc.start()
+        assert svc.health()["status"] == "running"
+
+
+class TestTick:
+    def test_skipped_when_not_running(self, monkeypatch):
+        from clawmes.commands import copy as copy_mod
+
+        called = {"n": 0}
+
+        def _spy():
+            called["n"] += 1
+            return 0
+
+        monkeypatch.setattr(copy_mod, "_run_due_sync", _spy)
+        svc = copy_trader.get_copy_trader_service()
+        svc.tick()
+        assert called["n"] == 0
+
+    def test_runs_when_started(self, monkeypatch):
+        from clawmes.commands import copy as copy_mod
+
+        monkeypatch.setattr(copy_mod, "_run_due_sync", lambda: 4)
+        svc = copy_trader.get_copy_trader_service()
+        svc.start()
+        svc.tick()
+        assert svc._ticks == 1
+        assert svc._last_runs == 4
+        assert svc._total_runs == 4
+
+    def test_swallows_errors(self, monkeypatch):
+        from clawmes.commands import copy as copy_mod
+
+        def _boom():
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(copy_mod, "_run_due_sync", _boom)
+        svc = copy_trader.get_copy_trader_service()
+        svc.start()
+        svc.tick()
+        assert svc._ticks == 1
+        # Counters didn't advance because the exception preempted them.
+        assert svc._last_runs == 0
+        assert svc._total_runs == 0
+
+    def test_accumulates(self, monkeypatch):
+        from clawmes.commands import copy as copy_mod
+
+        runs = iter([2, 5, 0])
+        monkeypatch.setattr(copy_mod, "_run_due_sync", lambda: next(runs))
+        svc = copy_trader.get_copy_trader_service()
+        svc.start()
+        for _ in range(3):
+            svc.tick()
+        assert svc._ticks == 3
+        assert svc._total_runs == 7
+        assert svc._last_runs == 0


### PR DESCRIPTION
## Summary

`/copy` watches another wallet's ERC-20 receipts and mirrors their buys at a configurable fixed ETH amount. Same safeguard surface as `/dca` v2, plus a per-follow blocklist for airdrops and obvious spam.

### Surface
- `/copy add <wallet> <eth_per_copy>` — follow a wallet's buys.
- Flags: `--slippage <bps>`, `--daily-cap <eth>`, `--max-total <eth>`, `--max-failures <n>`, `--blocklist <0xa,0xb,…>`.
- `/copy list` / `pause` / `resume` / `cancel` / `edit <field> <value>` / `tick` / `status` / `history` — same mutation surface as `/dca`.

### Watcher
- `CopyTraderService` (id `clawmes.copy_trader`) ticks on the registry cadence (~60s).
- Each tick polls Basescan's `account.tokentx` for every active follow since `last_seen_block`, drops blocklisted contracts, and submits a copy buy via `defi_swap`.
- Per-tick cap of 20 keeps a runaway airdrop streak from spawning hundreds of buys.
- All errors caught per-follow inside the runner; service tick adds one more catch so one bad follow can't crash the cron loop.

### Safeguards
- Order: total cap → daily cap → wallet → swap. Same failure-state vocabulary as `/dca` v2.
- Auto-pause after N consecutive failures (default 3).
- Blocklist filters obvious airdrop / spam contracts.
- `last_seen_block` is seeded from current chain head minus a 10-block lookback on new follows so the first tick doesn't replay 100 days of history.

## Testing

- 3455 tests pass (was 3318) — 137 new tests across `/copy` + the watcher service.
- 100% line coverage maintained on every file and on the project overall.
- `ruff check` + `ruff format --check` clean.
- Plugin yamls byte-identical.
- Version: `_version.py`, `pyproject.toml`, both `plugin.yaml` → 0.7.0.

## Why this design

Basescan polling (vs. Alchemy WebSocket subscribe or mempool monitoring) was chosen for v1 because:
- No persistent socket lifecycle complexity.
- Sub-minute latency is fine for "I want to ride this whale's coattails."
- Reuses the same scheduler-driven pattern as `/dca` v2 (single mental model for safeguard + service state across both features).
- WS upgrade path is open — can add later as an opt-in for users with ALCHEMY_API_KEY.

Mempool monitoring was deliberately rejected — it would put us at risk of front-running the target wallet, which would be misaligned with the "copy" semantic.

Fixed-ETH-per-copy sizing (vs. percentage of target's tx) keeps caps easy to reason about and matches `/dca`'s "one number per schedule" mental model. Percentage scaling can land as a future flag.