### PR TITLE
feat(commands): /agent — natural-language plan compiler (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.8.0 — 2026-05-27
+
+### Added — `/agent` natural-language plan compiler
+
+`/agent <prompt>` parses common trading-intent phrasings into a
+sequence of clawmes slash commands. Nothing materializes until the
+user explicitly says `/agent confirm` — the parsed plan lives per-
+sender in memory and is re-printable via `/agent show`.
+
+Architecture is deliberately minimal: regex-based intent parsing
+covers the high-frequency surface area, and any unparsed segment is
+called out by name so users see exactly what we missed (rather than
+silently truncating their prompt). An LLM-backed fallback can land as
+``/agent --ai <prompt>`` after we have telemetry on what people
+actually ask for.
+
+- **Surface:**
+  - `/agent <prompt>` — parse, store as draft, show plan.
+  - `/agent show` — re-print current draft.
+  - `/agent confirm` — execute every step in the draft, then clear.
+  - `/agent cancel` — discard draft.
+  - `/agent examples` — list supported phrasings.
+
+- **Recognized intents:**
+  - DCA: `DCA <amount> ETH of <token> every <interval>` and the
+    equivalent `buy ... every ...` phrasing.
+  - One-shot buy: `buy <amount> ETH of <token>`.
+  - Copy-trading: `copy <wallet>` / `follow <wallet> [at <amount> eth]`.
+  - LP fee claim: `claim my fees` / `claim all` / `claim <token>`.
+  - Burn: `burn <amount> [CLAWNCH]` (supports `1,000,000` or `1_000_000`).
+  - Leaderboard: `leaderboard`, `top tokens`, `top launchers`.
+  - Discovery: `show my launches`, `launches`, `balance`,
+    `what's my balance`.
+  - Multi-step: join with `then` (e.g.
+    `DCA 0.001 ETH of CLAWNCH every 1h then claim my fees`).
+
+- **Safety:**
+  - Bare commas are NOT segment separators (they appear inside
+    numbers like `1,000,000`). Use `then` for multi-step prompts.
+  - Drafts are in-memory only — a parse that goes stale across a
+    restart re-prompts rather than executing against state the user
+    can't see.
+  - `_dispatch_step` calls the matching `handle_*` function for each
+    step, so each command's own safeguards (e.g. `/dca` v2 caps,
+    `/buy` quote-then-confirm) apply downstream.
+
+### Internal
+
+- `clawmes/commands/agent_plan.py` (~330 lines). New file rather
+  than extending the existing `agent.py` (which is `/register_agent`
+  — different command, conflicting name otherwise).
+- 3513 tests pass at 100% coverage (was 3455). README command count:
+  85 → 86.
+
 ## 0.7.0 — 2026-05-27
 
 ### Added — `/copy` copy-trading

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Clawmes is a [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin. Wallets, DEX trading, lending and staking, governance, on-chain automation. Python rewrite of [`@clawnch/openclaw-crypto`](https://github.com/clawnchdev/openclawnch) targeting Hermes.
 
-52 tools. 85 commands. 25 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
+52 tools. 86 commands. 25 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
 
 ## Quick start
 
@@ -68,7 +68,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 
 ## Commands
 
-85 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
+86 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
 
 | Category | Commands |
 |---|---|
@@ -79,7 +79,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 | **Plans & triggers** (10) | `/plans` `/plan` `/plan_logs` `/interrupt_plan` `/pause_plan` `/resume_plan` `/triggers` `/watch` `/unwatch` `/cron` |
 | **Onboarding** (19) | `/welcome`, 5 personas (`/professional` `/degen` `/chill` `/technical` `/mentor`), 10 capability toggles (`/cap_wallet` `/cap_prices` `/cap_portfolio` `/cap_trading` `/cap_liquidity` `/cap_launchpad` `/cap_bridge` `/cap_routing` `/cap_clawnx` `/cap_hummingbot`), `/skip` `/back` `/reonboard` |
 | **Balance & portfolio** (2) | `/balance` `/portfolio` |
-| **Trading & discovery** (9) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` `/leaderboard` `/claim` `/dca` `/copy` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link, top tokens/launchers/burners, sweep accumulated LP fees, dollar-cost averaging, copy-trade a wallet's buys |
+| **Trading & discovery** (10) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` `/leaderboard` `/claim` `/dca` `/copy` `/agent` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link, top tokens/launchers/burners, sweep accumulated LP fees, dollar-cost averaging, copy-trade a wallet's buys, NL plan compiler |
 | **Self-evolution** (3) | `/evolve` `/stable` `/evolution` — gates `agent_memory` and `skill_evolve` write actions; OFF by default |
 | **Endpoint allowlist** (3) | `/allowlist` `/allow` `/disallow` — session-scoped host allowlist + 100-entry block audit ring |
 | **Discoverability** (5) | `/skills` `/persona` `/chains` `/tools_list` `/safety_status` |
@@ -310,6 +310,23 @@ After launching (or any time): three commands cover the basic loop of finding to
 The `CopyTraderService` polls Basescan's `account.tokentx` for every active follow on each registry tick (~60s). New ERC-20 transfers into the watched wallet trigger a copy buy via `defi_swap` at the configured fixed ETH amount. Same safeguard surface as `/dca` v2 (slippage / daily cap / total cap / max consecutive failures) plus a per-follow blocklist for known airdrop / spam contracts. Per-tick cap of 20 copies keeps a runaway airdrop streak from spawning hundreds of buys at once.
 
 State persists in `${HERMES_HOME}/clawmes/copy/follows.json`. The watcher seeds `last_seen_block` from the current chain head (minus a 10-block lookback for new follows) so the first tick doesn't replay 100 days of history.
+
+### Natural-language plan compiler (v0.8.0)
+
+```
+/agent DCA 0.001 ETH of CLAWNCH every 1h
+/agent buy 0.01 ETH of CLAWNCH then claim my fees
+/agent follow 0xWhale… at 0.001 eth
+/agent burn 1,000,000 CLAWNCH
+/agent show           # re-print the parsed plan
+/agent confirm        # materialize: runs each /command
+/agent cancel         # discard
+/agent examples       # full list of supported phrasings
+```
+
+`/agent` is a regex-based intent parser — not an LLM. Common trading phrasings ("DCA X of Y every Z", "buy X of Y", "follow N at M eth", "claim my fees", "burn N CLAWNCH", "top tokens", "show my launches", "balance") compile into a sequence of clawmes slash commands. Nothing materializes until you say `/agent confirm` — the draft lives per-sender in memory.
+
+Multi-step prompts join with `then` (bare commas would split numbers like `1,000,000`). Each step routes through the matching `handle_*` function, so the underlying command's safeguards (`/dca` v2 caps, `/buy` quote-then-confirm, etc.) still apply at execution time.
 
 ## Base ecosystem integration
 

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from clawmes.commands import (
     agent,
+    agent_plan,
     allowlist,
     balance,
     burn,
@@ -77,6 +78,7 @@ def register_all(ctx) -> None:
     claim.register(ctx)
     dca.register(ctx)
     copy.register(ctx)
+    agent_plan.register(ctx)
     # TODO(v0.1.0+): model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
     # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/agent_plan.py
+++ b/clawmes/commands/agent_plan.py
@@ -1,0 +1,443 @@
+"""``/agent`` — natural-language prompt → plan IR + manual confirm.
+
+Compile a free-form prompt into a sequence of clawmes slash commands.
+Nothing materializes until the user explicitly confirms — the draft
+lives per-sender in memory and ``/agent show`` re-prints it before
+state changes.
+
+Pattern: parse → preview → confirm.
+
+  * ``/agent <prompt>``    parse the prompt, store draft, show plan
+  * ``/agent show``        re-print the current draft
+  * ``/agent confirm``     execute every step in the draft
+  * ``/agent cancel``      drop the draft without executing
+  * ``/agent examples``    show supported phrasings
+
+We deliberately avoid invoking an LLM here. A regex-based parser
+covers the high-frequency intents (buy / DCA / copy / claim / burn /
+leaderboard / my_launches / balance) and rejects everything else with
+a clear error + examples. An LLM-backed expansion can land later as a
+fallback (``/agent --ai <prompt>``) once we have telemetry on what
+users actually ask for.
+
+Multi-step prompts join with ``then`` or ``, then``:
+
+  /agent DCA 0.001 ETH of CLAWNCH every hour then follow 0xwhale at 0.001
+
+→ Plan:
+   1. /dca add 0xa1F72459...747be 0.001 1h
+   2. /copy add 0xwhale 0.001
+
+State changes are gated behind ``/agent confirm`` so a malformed parse
+never causes accidental tx submission.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# CLAWNCH token address — recognized as a symbol shortcut in prompts.
+_CLAWNCH_ADDR = "0xa1F72459dfA10BAD200Ac160eCd78C6b77a747be"
+_KNOWN_SYMBOLS = {
+    "clawnch": _CLAWNCH_ADDR,
+    "$clawnch": _CLAWNCH_ADDR,
+}
+
+# Per-sender draft cache. Drafts are intentionally in-memory (no disk
+# persistence) — a parse that goes stale across a restart should be
+# re-prompted; we never want to materialize a confirmation against a
+# state the user can't actually see.
+_DRAFTS: dict[str, list[dict[str, Any]]] = {}
+
+
+# ── regex intent patterns ──────────────────────────────────────────
+
+
+# We match against lowercased + whitespace-normalized text. Each
+# pattern captures the args we need to materialize the slash command.
+# The order of patterns matters — more specific matches first.
+
+_INTENT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # DCA: "dca <amount> eth of <token> every <interval>"
+    # also: "buy <amount> eth of <token> every <interval>"
+    (
+        re.compile(
+            r"^(?:dca|buy)\s+(?P<amount>[\d.]+)\s*eth\s+of\s+(?P<token>\S+)\s+every\s+(?P<interval>\S+)$"
+        ),
+        "dca_add",
+    ),
+    # Copy: "copy <wallet>" or "follow <wallet>" with optional "at N eth"
+    (
+        re.compile(
+            r"^(?:copy|follow)\s+(?P<wallet>0x[a-fA-F0-9]{40})(?:\s+at\s+(?P<amount>[\d.]+)\s*eth)?$"
+        ),
+        "copy_add",
+    ),
+    # Buy (one-shot, no "every"): "buy <amount> eth of <token>"
+    (
+        re.compile(r"^buy\s+(?P<amount>[\d.]+)\s*eth\s+of\s+(?P<token>\S+)$"),
+        "buy",
+    ),
+    # Claim everything: "claim my fees", "claim all", "claim fees"
+    (
+        re.compile(r"^claim\s+(?:my\s+|all\s+)?fees?$|^claim\s+all$"),
+        "claim_all",
+    ),
+    # Claim one token: "claim <symbol-or-address>"
+    (
+        re.compile(r"^claim\s+(?P<target>\S+)$"),
+        "claim_one",
+    ),
+    # Burn: "burn N clawnch" / "burn N"
+    (
+        re.compile(r"^burn\s+(?P<amount>[\d,_]+)(?:\s+clawnch)?$"),
+        "burn",
+    ),
+    # Leaderboard variants
+    (
+        re.compile(r"^(?:show\s+(?:me\s+)?)?leaderboard$|^top\s+tokens$"),
+        "leaderboard_tokens",
+    ),
+    (
+        re.compile(r"^top\s+launchers$|^leaderboard\s+launchers$"),
+        "leaderboard_launchers",
+    ),
+    # Discovery
+    (
+        re.compile(r"^(?:show\s+(?:me\s+)?)?(?:my\s+)?launches$"),
+        "my_launches",
+    ),
+    (
+        re.compile(r"^(?:what'?s|show)\s+(?:my\s+)?balance$|^balance$"),
+        "balance",
+    ),
+]
+
+
+def _resolve_token_arg(raw: str) -> str:
+    """Resolve a token symbol/address into the canonical form for clawmes."""
+    raw = raw.lower().lstrip("$")
+    if raw in _KNOWN_SYMBOLS:
+        return _KNOWN_SYMBOLS[raw]
+    return raw  # pass through; the downstream command resolves it
+
+
+def _parse_one(text: str) -> dict[str, Any] | None:
+    """Match ``text`` against intent patterns. Returns a plan step dict or None."""
+    text = text.strip().lower()
+    for pattern, action in _INTENT_PATTERNS:
+        m = pattern.match(text)
+        if not m:
+            continue
+        gd = m.groupdict()
+        if action == "dca_add":
+            token = _resolve_token_arg(gd["token"])
+            return {
+                "action": "dca_add",
+                "command": "dca",
+                "args": f"add {token} {gd['amount']} {gd['interval']}",
+                "summary": f"DCA {gd['amount']} ETH of {token} every {gd['interval']}",
+            }
+        if action == "buy":
+            token = _resolve_token_arg(gd["token"])
+            return {
+                "action": "buy",
+                "command": "buy",
+                "args": f"{token} {gd['amount']}",
+                "summary": f"Buy {gd['amount']} ETH of {token} (quote first; confirm separately)",
+            }
+        if action == "copy_add":
+            amount = gd.get("amount") or "0.001"
+            return {
+                "action": "copy_add",
+                "command": "copy",
+                "args": f"add {gd['wallet']} {amount}",
+                "summary": f"Follow {gd['wallet']} and copy each buy at {amount} ETH",
+            }
+        if action == "claim_all":
+            return {
+                "action": "claim_all",
+                "command": "claim",
+                "args": "all",
+                "summary": "Claim accumulated LP fees on every token you've launched",
+            }
+        if action == "claim_one":
+            return {
+                "action": "claim_one",
+                "command": "claim",
+                "args": gd["target"],
+                "summary": f"Claim accumulated LP fees on {gd['target']}",
+            }
+        if action == "burn":
+            amount = gd["amount"].replace(",", "").replace("_", "")
+            return {
+                "action": "burn",
+                "command": "burn",
+                "args": amount,
+                "summary": f"Burn {int(amount):,} $CLAWNCH for Clanker vault %",
+            }
+        if action == "leaderboard_tokens":
+            return {
+                "action": "leaderboard_tokens",
+                "command": "leaderboard",
+                "args": "",
+                "summary": "Show top 10 Clawnch tokens by 24h volume",
+            }
+        if action == "leaderboard_launchers":
+            return {
+                "action": "leaderboard_launchers",
+                "command": "leaderboard",
+                "args": "launchers",
+                "summary": "Show top 10 launchers by recent activity",
+            }
+        if action == "my_launches":
+            return {
+                "action": "my_launches",
+                "command": "my_launches",
+                "args": "",
+                "summary": "List the tokens this agent has launched",
+            }
+        if action == "balance":  # pragma: no branch — last entry
+            return {
+                "action": "balance",
+                "command": "balance",
+                "args": "",
+                "summary": "Show wallet balance",
+            }
+    return None
+
+
+def _parse_prompt(prompt: str) -> tuple[list[dict[str, Any]], list[str]]:
+    """Split on ``then`` (and ``, then``) and parse each segment.
+
+    Bare commas are NOT treated as segment separators because they
+    appear inside numbers (e.g. ``burn 1,000,000 CLAWNCH``). Users
+    composing multi-step prompts must say ``then``.
+    """
+    # Normalize "X, then Y" → "X then Y" so a single split handles both.
+    cleaned = re.sub(r",\s*then\b", " then ", prompt, flags=re.IGNORECASE)
+    segments = [s.strip() for s in re.split(r"\bthen\b", cleaned, flags=re.IGNORECASE) if s.strip()]
+    plan: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for seg in segments:
+        step = _parse_one(seg)
+        if step is None:
+            errors.append(seg)
+        else:
+            plan.append(step)
+    return plan, errors
+
+
+# ── command surface ────────────────────────────────────────────────
+
+
+def _record(name: str, args: str, result: str) -> None:
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+async def handle_agent(raw_args: str, *, sender_id: str = "default", **_kwargs: Any) -> str:
+    raw = (raw_args or "").strip()
+    if not raw:
+        out = _render_usage()
+    else:
+        sub = raw.split()[0].lower()
+        if sub == "show":
+            out = _cmd_show(sender_id)
+        elif sub == "confirm":
+            out = await _cmd_confirm(sender_id)
+        elif sub == "cancel":
+            out = _cmd_cancel(sender_id)
+        elif sub == "examples":
+            out = _render_examples()
+        else:
+            # Treat the whole input as the prompt to parse.
+            out = _cmd_parse(sender_id, raw)
+    _record("agent", raw_args, out)
+    return out
+
+
+def _render_usage() -> str:
+    return (
+        "Natural-language plan compiler.\n"
+        "\n"
+        "  /agent <prompt>         Parse the prompt, store as draft, show plan\n"
+        "  /agent show             Re-print the current draft\n"
+        "  /agent confirm          Execute every step in the draft\n"
+        "  /agent cancel           Drop the draft without executing\n"
+        "  /agent examples         Show supported phrasings\n"
+        "\n"
+        "Example:\n"
+        "  /agent DCA 0.001 ETH of CLAWNCH every hour then follow 0xWhale… at 0.001\n"
+        "  /agent show                # confirm what was parsed\n"
+        "  /agent confirm             # materialize the steps"
+    )
+
+
+def _render_examples() -> str:
+    return (
+        "Supported phrasings (case-insensitive):\n"
+        "\n"
+        "  DCA / buy schedules:\n"
+        "    DCA 0.01 ETH of CLAWNCH every 1h\n"
+        "    buy 0.001 ETH of 0xToken… every 4h\n"
+        "\n"
+        "  Copy-trading:\n"
+        "    copy 0xWhale…\n"
+        "    follow 0xWhale… at 0.001 eth\n"
+        "\n"
+        "  One-shot buys:\n"
+        "    buy 0.01 ETH of CLAWNCH\n"
+        "\n"
+        "  Claim LP fees:\n"
+        "    claim my fees           (sweeps all your launches)\n"
+        "    claim CLAWNCH           (specific token)\n"
+        "    claim 0xToken…\n"
+        "\n"
+        "  Burn:\n"
+        "    burn 1,000,000 CLAWNCH\n"
+        "    burn 1000000\n"
+        "\n"
+        "  Discovery:\n"
+        "    leaderboard / top tokens\n"
+        "    top launchers\n"
+        "    show my launches\n"
+        "    balance\n"
+        "\n"
+        "  Multi-step (join with `then` or `,`):\n"
+        "    DCA 0.001 ETH of CLAWNCH every hour then claim my fees\n"
+        "    buy 0.01 ETH of CLAWNCH, copy 0xWhale… at 0.001"
+    )
+
+
+def _cmd_parse(sender_id: str, prompt: str) -> str:
+    plan, errors = _parse_prompt(prompt)
+    if not plan and errors:
+        return (
+            "Couldn't parse the prompt. Segments not understood:\n"
+            + "\n".join(f"  - {seg!r}" for seg in errors)
+            + "\n\nTry /agent examples for supported phrasings."
+        )
+
+    _DRAFTS[sender_id] = plan
+    lines = [f"Plan parsed ({len(plan)} step(s)):", ""]
+    for i, step in enumerate(plan, start=1):
+        lines.append(f"  {i}. /{step['command']} {step['args']}")
+        lines.append(f"       → {step['summary']}")
+
+    if errors:
+        lines.append("")
+        lines.append("Could not parse:")
+        for seg in errors:
+            lines.append(f"  - {seg!r}")
+
+    lines.extend(
+        [
+            "",
+            "Next: /agent confirm to execute, /agent cancel to discard,",
+            "or /agent <new prompt> to overwrite the draft.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _cmd_show(sender_id: str) -> str:
+    plan = _DRAFTS.get(sender_id)
+    if not plan:
+        return "No draft. Run /agent <prompt> first."
+    lines = [f"Draft for {sender_id} ({len(plan)} step(s)):", ""]
+    for i, step in enumerate(plan, start=1):
+        lines.append(f"  {i}. /{step['command']} {step['args']}")
+        lines.append(f"       → {step['summary']}")
+    lines.append("")
+    lines.append("Use /agent confirm to execute, /agent cancel to discard.")
+    return "\n".join(lines)
+
+
+def _cmd_cancel(sender_id: str) -> str:
+    if sender_id not in _DRAFTS:
+        return "No draft to cancel."
+    del _DRAFTS[sender_id]
+    return "Draft cancelled."
+
+
+async def _cmd_confirm(sender_id: str) -> str:
+    plan = _DRAFTS.get(sender_id)
+    if not plan:
+        return "No draft to confirm. Run /agent <prompt> first."
+
+    lines = [f"Executing {len(plan)} step(s)..."]
+    for i, step in enumerate(plan, start=1):
+        result = await _dispatch_step(step, sender_id)
+        # Cut long step outputs down for the summary; they're already
+        # recorded into command_history individually.
+        snippet = result.split("\n", 1)[0][:120]
+        lines.append(f"  {i}. /{step['command']} {step['args']}")
+        lines.append(f"       → {snippet}")
+
+    # Clear the draft after executing so a follow-up /agent confirm
+    # doesn't accidentally re-run.
+    del _DRAFTS[sender_id]
+    lines.append("")
+    lines.append("Draft cleared. See individual command outputs in /history.")
+    return "\n".join(lines)
+
+
+async def _dispatch_step(step: dict[str, Any], sender_id: str) -> str:
+    """Invoke the matching slash command handler with the step's args."""
+    cmd = step["command"]
+    args = step["args"]
+
+    # Lazy imports per dispatch — keeps the agent module light at boot.
+    if cmd == "dca":
+        from clawmes.commands.dca import handle_dca
+
+        return await handle_dca(args, sender_id=sender_id)
+    if cmd == "buy":
+        from clawmes.commands.buy import handle_buy
+
+        return await handle_buy(args, sender_id=sender_id)
+    if cmd == "copy":
+        from clawmes.commands.copy import handle_copy
+
+        return await handle_copy(args, sender_id=sender_id)
+    if cmd == "claim":
+        from clawmes.commands.claim import handle_claim
+
+        return await handle_claim(args, sender_id=sender_id)
+    if cmd == "burn":
+        from clawmes.commands.burn import handle_burn
+
+        return await handle_burn(args, sender_id=sender_id)
+    if cmd == "leaderboard":
+        from clawmes.commands.leaderboard import handle_leaderboard
+
+        return await handle_leaderboard(args)
+    if cmd == "my_launches":
+        from clawmes.commands.my_launches import handle_my_launches
+
+        return await handle_my_launches(args)
+    if cmd == "balance":  # pragma: no branch — last branch covered by tests
+        from clawmes.commands.balance import handle_balance
+
+        return await handle_balance(args)
+    return f"unknown command in plan: {cmd}"  # pragma: no cover — defensive
+
+
+def _reset_for_tests() -> None:
+    """Clear the in-memory drafts cache. Test-only."""
+    _DRAFTS.clear()
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="agent",
+        handler=handle_agent,
+        description="Natural-language plan compiler with manual confirm",
+        args_hint="<prompt> | show | confirm | cancel | examples",
+    )

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.7.0
+version: 0.8.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.7.0
+version: 0.8.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.7.0"
+version = "0.8.0"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_agent_plan.py
+++ b/tests/commands/test_agent_plan.py
@@ -1,0 +1,416 @@
+"""Tests for the /agent slash command (NL prompt → plan IR)."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.commands import agent_plan
+
+
+@pytest.fixture(autouse=True)
+def _clear_drafts():
+    agent_plan._reset_for_tests()
+    yield
+    agent_plan._reset_for_tests()
+
+
+# ── _resolve_token_arg ──────────────────────────────────────────────
+
+
+class TestResolveTokenArg:
+    def test_known_symbol_clawnch(self):
+        assert agent_plan._resolve_token_arg("CLAWNCH") == agent_plan._CLAWNCH_ADDR
+
+    def test_known_symbol_dollar_sign(self):
+        assert agent_plan._resolve_token_arg("$CLAWNCH") == agent_plan._CLAWNCH_ADDR
+
+    def test_unknown_passes_through(self):
+        out = agent_plan._resolve_token_arg("0xABC")
+        assert out == "0xabc"
+
+
+# ── _parse_one ──────────────────────────────────────────────────────
+
+
+class TestParseOne:
+    def test_dca_pattern(self):
+        step = agent_plan._parse_one("DCA 0.001 ETH of CLAWNCH every 1h")
+        assert step["command"] == "dca"
+        assert "add" in step["args"]
+        assert "0.001" in step["args"]
+        assert "1h" in step["args"]
+
+    def test_buy_recurring_uses_dca(self):
+        step = agent_plan._parse_one("buy 0.01 eth of CLAWNCH every 4h")
+        assert step["command"] == "dca"
+
+    def test_buy_one_shot(self):
+        step = agent_plan._parse_one("buy 0.01 eth of CLAWNCH")
+        assert step["command"] == "buy"
+
+    def test_copy_with_amount(self):
+        step = agent_plan._parse_one("copy 0x" + "a" * 40 + " at 0.005 eth")
+        assert step["command"] == "copy"
+        assert "0.005" in step["args"]
+
+    def test_copy_without_amount_default(self):
+        step = agent_plan._parse_one("follow 0x" + "a" * 40)
+        assert step["command"] == "copy"
+        assert "0.001" in step["args"]  # default amount
+
+    def test_claim_my_fees(self):
+        step = agent_plan._parse_one("claim my fees")
+        assert step["command"] == "claim"
+        assert step["args"] == "all"
+
+    def test_claim_all(self):
+        step = agent_plan._parse_one("claim all")
+        assert step["args"] == "all"
+
+    def test_claim_fees(self):
+        step = agent_plan._parse_one("claim fees")
+        assert step["args"] == "all"
+
+    def test_claim_one_token(self):
+        step = agent_plan._parse_one("claim CLAWNCH")
+        assert step["command"] == "claim"
+        assert step["args"] == "clawnch"
+
+    def test_burn(self):
+        step = agent_plan._parse_one("burn 1,000,000 clawnch")
+        assert step["command"] == "burn"
+        assert step["args"] == "1000000"
+
+    def test_burn_no_token_suffix(self):
+        step = agent_plan._parse_one("burn 100000")
+        assert step["args"] == "100000"
+
+    def test_burn_underscores(self):
+        step = agent_plan._parse_one("burn 1_000_000")
+        assert step["args"] == "1000000"
+
+    def test_leaderboard(self):
+        step = agent_plan._parse_one("leaderboard")
+        assert step["command"] == "leaderboard"
+        assert step["args"] == ""
+
+    def test_top_tokens(self):
+        step = agent_plan._parse_one("top tokens")
+        assert step["command"] == "leaderboard"
+
+    def test_show_me_leaderboard(self):
+        step = agent_plan._parse_one("show me leaderboard")
+        assert step["command"] == "leaderboard"
+
+    def test_top_launchers(self):
+        step = agent_plan._parse_one("top launchers")
+        assert step["command"] == "leaderboard"
+        assert step["args"] == "launchers"
+
+    def test_leaderboard_launchers(self):
+        step = agent_plan._parse_one("leaderboard launchers")
+        assert step["args"] == "launchers"
+
+    def test_my_launches(self):
+        step = agent_plan._parse_one("show my launches")
+        assert step["command"] == "my_launches"
+
+    def test_launches_short(self):
+        step = agent_plan._parse_one("launches")
+        assert step["command"] == "my_launches"
+
+    def test_balance_question(self):
+        step = agent_plan._parse_one("what's my balance")
+        assert step["command"] == "balance"
+
+    def test_balance_short(self):
+        step = agent_plan._parse_one("balance")
+        assert step["command"] == "balance"
+
+    def test_unmatched_returns_none(self):
+        assert agent_plan._parse_one("total gibberish here") is None
+
+
+# ── _parse_prompt (multi-step) ──────────────────────────────────────
+
+
+class TestParsePrompt:
+    def test_single_segment(self):
+        plan, errs = agent_plan._parse_prompt("DCA 0.001 ETH of CLAWNCH every 1h")
+        assert len(plan) == 1
+        assert errs == []
+
+    def test_then_separator(self):
+        plan, errs = agent_plan._parse_prompt(
+            "DCA 0.001 ETH of CLAWNCH every 1h then claim my fees"
+        )
+        assert len(plan) == 2
+        assert errs == []
+
+    def test_comma_then_normalized(self):
+        plan, errs = agent_plan._parse_prompt(
+            "DCA 0.001 ETH of CLAWNCH every 1h, then claim my fees"
+        )
+        assert len(plan) == 2
+
+    def test_bare_comma_NOT_split(self):
+        # Bare commas inside numbers must NOT be treated as separators.
+        plan, errs = agent_plan._parse_prompt("burn 1,000,000 CLAWNCH")
+        assert len(plan) == 1
+        assert plan[0]["args"] == "1000000"
+
+    def test_mixed_success_failure(self):
+        plan, errs = agent_plan._parse_prompt(
+            "DCA 0.001 ETH of CLAWNCH every 1h then random nonsense"
+        )
+        assert len(plan) == 1
+        assert errs == ["random nonsense"]
+
+    def test_all_garbage(self):
+        plan, errs = agent_plan._parse_prompt("total gibberish here")
+        assert plan == []
+        assert errs == ["total gibberish here"]
+
+    def test_empty_prompt(self):
+        plan, errs = agent_plan._parse_prompt("")
+        assert plan == []
+        assert errs == []
+
+
+# ── _cmd_parse / _cmd_show / _cmd_cancel ───────────────────────────
+
+
+class TestCmdParse:
+    def test_all_parse_failure(self):
+        out = agent_plan._cmd_parse("u", "total nonsense")
+        assert "Couldn't parse" in out
+        assert "/agent examples" in out
+
+    def test_success_stores_draft(self):
+        out = agent_plan._cmd_parse("u", "claim my fees")
+        assert "Plan parsed" in out
+        assert "claim" in out
+        assert "u" in agent_plan._DRAFTS
+
+    def test_mixed_partial_success(self):
+        out = agent_plan._cmd_parse("u", "claim my fees then random garbage")
+        assert "Plan parsed" in out
+        assert "Could not parse" in out
+        assert "random garbage" in out
+
+
+class TestCmdShow:
+    def test_empty(self):
+        out = agent_plan._cmd_show("u")
+        assert "No draft" in out
+
+    def test_with_draft(self):
+        agent_plan._cmd_parse("u", "claim my fees")
+        out = agent_plan._cmd_show("u")
+        assert "Draft for u" in out
+        assert "claim" in out
+
+
+class TestCmdCancel:
+    def test_no_draft(self):
+        assert "No draft" in agent_plan._cmd_cancel("u")
+
+    def test_clears(self):
+        agent_plan._cmd_parse("u", "claim my fees")
+        out = agent_plan._cmd_cancel("u")
+        assert "cancelled" in out.lower()
+        assert "u" not in agent_plan._DRAFTS
+
+
+# ── _dispatch_step + _cmd_confirm ──────────────────────────────────
+
+
+class TestDispatch:
+    """Spy-based tests for each dispatch branch.
+
+    Each clawmes command's ``handle_*`` function is monkeypatched to a
+    spy that records the args it received. We then construct a plan
+    step, dispatch it, and verify the right command got the right args.
+    """
+
+    async def test_dispatch_dca(self, monkeypatch):
+        captured: dict[str, str] = {}
+
+        async def _fake(args, sender_id="default", **kw):
+            captured["args"] = args
+            captured["sender"] = sender_id
+            return "dca result"
+
+        import clawmes.commands.dca as mod
+
+        monkeypatch.setattr(mod, "handle_dca", _fake)
+        out = await agent_plan._dispatch_step({"command": "dca", "args": "add 0xabc 0.001 1h"}, "u")
+        assert "dca result" in out
+        assert captured["args"] == "add 0xabc 0.001 1h"
+        assert captured["sender"] == "u"
+
+    async def test_dispatch_buy(self, monkeypatch):
+        async def _fake(args, sender_id="default", **kw):
+            return f"buy {args}"
+
+        import clawmes.commands.buy as mod
+
+        monkeypatch.setattr(mod, "handle_buy", _fake)
+        out = await agent_plan._dispatch_step({"command": "buy", "args": "CLAWNCH 0.01"}, "u")
+        assert "buy CLAWNCH 0.01" in out
+
+    async def test_dispatch_copy(self, monkeypatch):
+        async def _fake(args, sender_id="default", **kw):
+            return f"copy {args}"
+
+        import clawmes.commands.copy as mod
+
+        monkeypatch.setattr(mod, "handle_copy", _fake)
+        out = await agent_plan._dispatch_step({"command": "copy", "args": "add 0xabc 0.001"}, "u")
+        assert "copy add" in out
+
+    async def test_dispatch_claim(self, monkeypatch):
+        async def _fake(args, sender_id="default", **kw):
+            return f"claim {args}"
+
+        import clawmes.commands.claim as mod
+
+        monkeypatch.setattr(mod, "handle_claim", _fake)
+        out = await agent_plan._dispatch_step({"command": "claim", "args": "all"}, "u")
+        assert "claim all" in out
+
+    async def test_dispatch_burn(self, monkeypatch):
+        async def _fake(args, sender_id="default", **kw):
+            return f"burn {args}"
+
+        import clawmes.commands.burn as mod
+
+        monkeypatch.setattr(mod, "handle_burn", _fake)
+        out = await agent_plan._dispatch_step({"command": "burn", "args": "1000000"}, "u")
+        assert "burn 1000000" in out
+
+    async def test_dispatch_leaderboard(self, monkeypatch):
+        async def _fake(args, **kw):
+            return f"lb {args}"
+
+        import clawmes.commands.leaderboard as mod
+
+        monkeypatch.setattr(mod, "handle_leaderboard", _fake)
+        out = await agent_plan._dispatch_step({"command": "leaderboard", "args": ""}, "u")
+        assert "lb" in out
+
+    async def test_dispatch_my_launches(self, monkeypatch):
+        async def _fake(args, **kw):
+            return f"ml {args}"
+
+        import clawmes.commands.my_launches as mod
+
+        monkeypatch.setattr(mod, "handle_my_launches", _fake)
+        out = await agent_plan._dispatch_step({"command": "my_launches", "args": ""}, "u")
+        assert "ml" in out
+
+    async def test_dispatch_balance(self, monkeypatch):
+        async def _fake(args, **kw):
+            return f"bal {args}"
+
+        import clawmes.commands.balance as mod
+
+        monkeypatch.setattr(mod, "handle_balance", _fake)
+        out = await agent_plan._dispatch_step({"command": "balance", "args": ""}, "u")
+        assert "bal" in out
+
+
+class TestCmdConfirm:
+    async def test_no_draft(self):
+        out = await agent_plan._cmd_confirm("u")
+        assert "No draft to confirm" in out
+
+    async def test_executes_each_step(self, monkeypatch):
+        # Stub each command handler so confirm runs end-to-end.
+        async def _fake_claim(args, sender_id="default", **kw):
+            return "claim ok\nextra detail line"
+
+        async def _fake_burn(args, sender_id="default", **kw):
+            return "burn ok"
+
+        import clawmes.commands.burn as burn_mod
+        import clawmes.commands.claim as claim_mod
+
+        monkeypatch.setattr(claim_mod, "handle_claim", _fake_claim)
+        monkeypatch.setattr(burn_mod, "handle_burn", _fake_burn)
+
+        agent_plan._cmd_parse("u", "claim my fees then burn 1000000")
+        out = await agent_plan._cmd_confirm("u")
+        assert "Executing 2 step(s)" in out
+        assert "claim ok" in out
+        assert "burn ok" in out
+        # Draft cleared after execution.
+        assert "u" not in agent_plan._DRAFTS
+
+    async def test_draft_cleared_after_confirm(self, monkeypatch):
+        async def _fake(args, sender_id="default", **kw):
+            return "done"
+
+        import clawmes.commands.claim as claim_mod
+
+        monkeypatch.setattr(claim_mod, "handle_claim", _fake)
+        agent_plan._cmd_parse("u", "claim my fees")
+        await agent_plan._cmd_confirm("u")
+        # Subsequent confirm should report no draft.
+        out2 = await agent_plan._cmd_confirm("u")
+        assert "No draft" in out2
+
+
+# ── handle_agent (dispatch) ────────────────────────────────────────
+
+
+class TestHandleAgent:
+    async def test_empty_shows_usage(self):
+        out = await agent_plan.handle_agent("")
+        assert "Natural-language plan compiler" in out
+
+    async def test_show_dispatch(self):
+        out = await agent_plan.handle_agent("show")
+        assert "No draft" in out
+
+    async def test_confirm_dispatch(self):
+        out = await agent_plan.handle_agent("confirm")
+        assert "No draft" in out
+
+    async def test_cancel_dispatch(self):
+        out = await agent_plan.handle_agent("cancel")
+        assert "No draft" in out
+
+    async def test_examples_dispatch(self):
+        out = await agent_plan.handle_agent("examples")
+        assert "Supported phrasings" in out
+
+    async def test_prompt_dispatch(self):
+        out = await agent_plan.handle_agent("claim my fees")
+        assert "Plan parsed" in out
+
+    async def test_record_swallows(self, monkeypatch):
+        import clawmes.services.command_history as ch
+
+        def _boom(*a, **k):
+            raise RuntimeError("hist broken")
+
+        monkeypatch.setattr(ch, "record_command_call", _boom)
+        out = await agent_plan.handle_agent("")
+        assert "Natural-language" in out
+
+
+# ── register ───────────────────────────────────────────────────────
+
+
+class TestRegister:
+    def test_register_wires_command(self):
+        registered: list[dict] = []
+
+        class Ctx:
+            def register_command(self, **kwargs):
+                registered.append(kwargs)
+
+        agent_plan.register(Ctx())
+        assert len(registered) == 1
+        assert registered[0]["name"] == "agent"


### PR DESCRIPTION
## Summary

`/agent <prompt>` parses common trading-intent phrasings into a sequence of clawmes slash commands. Nothing materializes until the user explicitly confirms — the parsed plan lives per-sender in memory.

### Surface
- `/agent <prompt>` — parse, store as draft, show plan.
- `/agent show` — re-print current draft.
- `/agent confirm` — execute every step, then clear draft.
- `/agent cancel` — discard draft.
- `/agent examples` — list supported phrasings.

### Recognized intents
- **DCA:** `DCA <amount> ETH of <token> every <interval>` (and the equivalent `buy ... every ...` phrasing)
- **One-shot buy:** `buy <amount> ETH of <token>`
- **Copy-trading:** `copy 0x...`, `follow 0x... at <amount> eth`
- **LP fee claim:** `claim my fees`, `claim all`, `claim <symbol-or-address>`
- **Burn:** `burn <amount> [CLAWNCH]` (handles `1,000,000` and `1_000_000`)
- **Leaderboard:** `leaderboard`, `top tokens`, `top launchers`
- **Discovery:** `show my launches`, `launches`, `balance`, `what's my balance`
- **Multi-step:** join with `then` (e.g. `DCA 0.001 ETH of CLAWNCH every 1h then claim my fees`)

### Architecture

Regex-based intent parser — deliberately no LLM in v1. Unparsed segments are called out by name so users see exactly what was missed (vs. silently truncated prompts). An LLM-backed fallback can land as `/agent --ai <prompt>` once we have telemetry on what users actually ask for.

Bare commas are NOT segment separators because they appear inside numbers (`burn 1,000,000` → one step, not three). Multi-step prompts must use `then`.

Each step routes through the matching `handle_*` function via `_dispatch_step`, so downstream command safeguards (e.g. `/dca` v2 caps, `/buy` quote-then-confirm, `/copy` blocklist + caps) still apply at execution time.

## Testing

- 3513 tests pass (was 3455) — 58 new tests covering every intent pattern, multi-step parsing, dispatch for each downstream command, and the parse/show/confirm/cancel lifecycle.
- 100% line coverage maintained on every file and on the project overall.
- `ruff check` + `ruff format --check` clean.
- Plugin yamls byte-identical.
- Version: `_version.py`, `pyproject.toml`, both `plugin.yaml` → 0.8.0.

## Why this scope

You picked "Plan IR + manual confirm" — the safest first cut. Nothing materializes without explicit user opt-in. Regex parser (vs. LLM) keeps the surface predictable and dependency-free; LLM fallback can land later as an opt-in flag.