### PR TITLE
feat(commands): /alerts + token gating on power features (v0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.9.0 — 2026-05-27
+
+### Added — token-gated power features + `/alerts`
+
+Two new surfaces that together push more $CLAWNCH demand to clawmes
+power users while expanding what the agent can react to.
+
+- **Token gating** (`clawmes/services/token_gate.py`) — power features
+  unlock based on $CLAWNCH balance. Two tiers:
+  - `FREE` (no balance required) — `/buy`, `/trending`, `/balance`,
+    `/leaderboard`, `/claim`, `/onramp`, `/launch`, `/burn`,
+    `/agent` single-step. Capped versions of recurring features: 1
+    active `/dca`, 1 active `/copy`, 3 active `/alerts`, no
+    safeguard flags on `/dca`.
+  - `HOLDER` — any wallet holding **10,000+ $CLAWNCH** (~$0.10).
+    Unlocks unlimited `/dca` schedules + safeguard flags,
+    unlimited `/copy` follows, `/agent` multi-step prompts,
+    unlimited `/alerts`.
+  - Implementation: lazy balance read via `eth_call`, 60-second
+    cache to avoid hammering RPC. Gate helpers
+    (`check_tier_or_error`, `check_cap_or_error`) return a
+    human-readable error string when blocked, with the exact
+    balance shortfall + how-to-buy hints. No wallet connected →
+    treated as free tier; the gate never crashes a command.
+
+- **`/alerts`** — price + wallet-activity alerts. Notification-only;
+  no transactions submitted.
+  - `/alerts add price <token> <above|below> <usd>` — fire when token
+    price crosses the threshold. Polls `defi_price` on the registry
+    tick. Auto-deactivates after firing so we don't re-notify.
+  - `/alerts add wallet <address>` — fire on any new ERC-20 receipt
+    to the watched wallet. Same Basescan poller as `/copy`. Stays
+    active so each new tx fires.
+  - `/alerts list` / `pause` / `resume` / `cancel` / `edit` /
+    `tick` / `status` / `history` — same mutation surface as `/dca`.
+  - `AlertsSchedulerService` (id `clawmes.alerts_scheduler`) ticks
+    on the registry cadence (~60s). Per-alert errors caught
+    internally so one bad alert can't crash the loop.
+
+### Internal
+
+- `clawmes/services/token_gate.py` (+ `tests/services/test_token_gate.py`).
+- `clawmes/commands/alerts.py` (+ `tests/commands/test_alerts.py`).
+- `clawmes/services/alerts_scheduler.py` (+
+  `tests/services/test_alerts_scheduler.py`).
+- Gate calls added to `/dca add`, `/copy add`, `/agent` multi-step
+  parse. Free tier behaviour is the default; HOLDER tier removes the
+  cap.
+- `tests/conftest.py` autouse fixture patches the gate helpers to
+  always-pass for the existing test suite — new tests in
+  `tests/commands/test_token_gating.py` and the corresponding new-
+  command test files specifically exercise the rejection branches.
+- 3660 tests pass at 100% coverage (was 3513). README counts: 86 →
+  87 commands, 25 → 27 services.
+
 ## 0.8.0 — 2026-05-27
 
 ### Added — `/agent` natural-language plan compiler

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Clawmes is a [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin. Wallets, DEX trading, lending and staking, governance, on-chain automation. Python rewrite of [`@clawnch/openclaw-crypto`](https://github.com/clawnchdev/openclawnch) targeting Hermes.
 
-52 tools. 86 commands. 25 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
+52 tools. 87 commands. 27 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
 
 ## Quick start
 
@@ -68,7 +68,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 
 ## Commands
 
-86 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
+87 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
 
 | Category | Commands |
 |---|---|
@@ -79,7 +79,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 | **Plans & triggers** (10) | `/plans` `/plan` `/plan_logs` `/interrupt_plan` `/pause_plan` `/resume_plan` `/triggers` `/watch` `/unwatch` `/cron` |
 | **Onboarding** (19) | `/welcome`, 5 personas (`/professional` `/degen` `/chill` `/technical` `/mentor`), 10 capability toggles (`/cap_wallet` `/cap_prices` `/cap_portfolio` `/cap_trading` `/cap_liquidity` `/cap_launchpad` `/cap_bridge` `/cap_routing` `/cap_clawnx` `/cap_hummingbot`), `/skip` `/back` `/reonboard` |
 | **Balance & portfolio** (2) | `/balance` `/portfolio` |
-| **Trading & discovery** (10) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` `/leaderboard` `/claim` `/dca` `/copy` `/agent` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link, top tokens/launchers/burners, sweep accumulated LP fees, dollar-cost averaging, copy-trade a wallet's buys, NL plan compiler |
+| **Trading & discovery** (11) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` `/leaderboard` `/claim` `/dca` `/copy` `/agent` `/alerts` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link, top tokens/launchers/burners, sweep accumulated LP fees, dollar-cost averaging, copy-trade a wallet's buys, NL plan compiler, price + wallet activity alerts |
 | **Self-evolution** (3) | `/evolve` `/stable` `/evolution` — gates `agent_memory` and `skill_evolve` write actions; OFF by default |
 | **Endpoint allowlist** (3) | `/allowlist` `/allow` `/disallow` — session-scoped host allowlist + 100-entry block audit ring |
 | **Discoverability** (5) | `/skills` `/persona` `/chains` `/tools_list` `/safety_status` |
@@ -327,6 +327,28 @@ State persists in `${HERMES_HOME}/clawmes/copy/follows.json`. The watcher seeds 
 `/agent` is a regex-based intent parser — not an LLM. Common trading phrasings ("DCA X of Y every Z", "buy X of Y", "follow N at M eth", "claim my fees", "burn N CLAWNCH", "top tokens", "show my launches", "balance") compile into a sequence of clawmes slash commands. Nothing materializes until you say `/agent confirm` — the draft lives per-sender in memory.
 
 Multi-step prompts join with `then` (bare commas would split numbers like `1,000,000`). Each step routes through the matching `handle_*` function, so the underlying command's safeguards (`/dca` v2 caps, `/buy` quote-then-confirm, etc.) still apply at execution time.
+
+### Alerts + token gating (v0.9.0)
+
+```
+/alerts add price CLAWNCH above 0.00002     # fire when price crosses
+/alerts add wallet 0xWhale…                 # fire on any new ERC-20 receipt
+/alerts list                                # all your alerts + last fire
+/alerts edit alert_abc threshold_usd 0.0001 # change a price threshold
+/alerts pause alert_abc                     # suspend
+/alerts history alert_abc                   # past fires
+/alerts status                              # global summary + service health
+```
+
+`/alerts` is notification-only — no transactions submitted, no wallet required. Price alerts auto-deactivate after firing (so a crossing doesn't repeatedly notify on every subsequent tick). Wallet alerts stay active and re-fire on each new tx because `last_seen_block` advances past the seen receipt. `AlertsSchedulerService` polls on the registry cadence (~60s).
+
+**Token gating.** Power features in `/dca`, `/copy`, `/agent`, and `/alerts` unlock at the `HOLDER` tier — any wallet holding 10,000+ $CLAWNCH (~$0.10). Free tier still gets each feature with these caps:
+- 1 active `/dca` schedule (HOLDER: unlimited + safeguard flags)
+- 1 active `/copy` follow (HOLDER: unlimited)
+- 3 active `/alerts` (HOLDER: unlimited)
+- `/agent` single-step prompts (HOLDER: multi-step with `then` chains)
+
+The gate reads your active wallet's $CLAWNCH balance via `eth_call`, caches the result for 60s, and never crashes a command on RPC error (transient failures fall back to free tier). Implementation in `clawmes/services/token_gate.py`.
 
 ## Base ecosystem integration
 

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from clawmes.commands import (
     agent,
     agent_plan,
+    alerts,
     allowlist,
     balance,
     burn,
@@ -79,6 +80,7 @@ def register_all(ctx) -> None:
     dca.register(ctx)
     copy.register(ctx)
     agent_plan.register(ctx)
+    alerts.register(ctx)
     # TODO(v0.1.0+): model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
     # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/agent_plan.py
+++ b/clawmes/commands/agent_plan.py
@@ -324,6 +324,15 @@ def _cmd_parse(sender_id: str, prompt: str) -> str:
             + "\n\nTry /agent examples for supported phrasings."
         )
 
+    # Multi-step prompts (2+ parsed steps) require HOLDER tier. Single-
+    # step prompts stay free so the regex compiler is approachable.
+    if len(plan) > 1:
+        from clawmes.services.token_gate import Tier, check_tier_or_error
+
+        gate_err = check_tier_or_error(Tier.HOLDER, feature="/agent multi-step prompts")
+        if gate_err:
+            return gate_err
+
     _DRAFTS[sender_id] = plan
     lines = [f"Plan parsed ({len(plan)} step(s)):", ""]
     for i, step in enumerate(plan, start=1):

--- a/clawmes/commands/alerts.py
+++ b/clawmes/commands/alerts.py
@@ -1,0 +1,608 @@
+"""``/alerts`` — price + wallet-activity alerts.
+
+Notification-only triggers. Two alert types:
+
+  * ``price <token> <above|below> <usd>`` — fires when the token's
+    USD price crosses the threshold. Polls ``defi_price`` on the
+    service tick (~60s).
+  * ``wallet <address>`` — fires on any new ERC-20 receipt to the
+    watched wallet. Polls Basescan's ``account.tokentx`` endpoint,
+    same pattern as ``/copy``.
+
+Alerts do **not** submit transactions or move funds. They just record
+a fired-event on the alert's history; when the user runs
+``/alerts list`` or ``/alerts history <id>`` they see what fired and
+when. Notification delivery to Telegram / Slack / etc. happens via
+the Hermes channel layer reading clawmes command history (out of
+scope for this command).
+
+Surface:
+
+  * ``/alerts add price <token> <above|below> <usd>``
+  * ``/alerts add wallet <address>``
+  * ``/alerts list``
+  * ``/alerts pause <id>`` / ``resume`` / ``cancel`` / ``edit``
+  * ``/alerts tick``  — manual tick (testing)
+  * ``/alerts status``  — global summary + service health
+  * ``/alerts history <id>``
+
+Storage: ``${HERMES_HOME}/clawmes/alerts/alerts.json``.
+
+State machine: alerts auto-deactivate once they fire (``status: 'fired'``)
+so a price crossing doesn't repeatedly notify on every subsequent tick.
+Wallet alerts re-arm after each fire so an active wallet keeps notifying
+on each new tx.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from clawmes.lib.http import http_get
+
+_BASESCAN_BASE = "https://api.basescan.org/api"
+
+
+# ── state I/O ───────────────────────────────────────────────────────
+
+
+def _alerts_path() -> Path:
+    from clawmes.lib.paths import state_dir
+
+    return state_dir("alerts") / "alerts.json"
+
+
+def _load_state() -> dict[str, Any]:
+    path = _alerts_path()
+    if not path.exists():
+        return {"alerts": []}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {"alerts": []}
+    if not isinstance(data, dict) or not isinstance(data.get("alerts"), list):
+        return {"alerts": []}
+    return data
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    path = _alerts_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _now_epoch() -> int:
+    return int(time.time())
+
+
+def _new_id() -> str:
+    return f"alert_{uuid.uuid4().hex[:10]}"
+
+
+def _short(value: str) -> str:
+    if not isinstance(value, str) or len(value) <= 12:
+        return str(value)
+    return f"{value[:6]}…{value[-4:]}"
+
+
+def _record(name: str, args: str, result: str) -> None:
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ── command dispatch ───────────────────────────────────────────────
+
+
+async def handle_alerts(raw_args: str, *, sender_id: str = "default", **_kwargs: Any) -> str:
+    raw = (raw_args or "").strip()
+    if not raw:
+        out = _render_usage()
+    else:
+        parts = raw.split()
+        sub = parts[0].lower()
+        rest = parts[1:]
+        if sub == "add":
+            out = _cmd_add(sender_id, rest)
+        elif sub in ("list", "ls"):
+            out = _cmd_list(sender_id)
+        elif sub == "pause":
+            out = _cmd_mutate(sender_id, rest, status="paused", verb="paused")
+        elif sub == "resume":
+            out = _cmd_mutate(sender_id, rest, status="active", verb="resumed")
+        elif sub in ("cancel", "rm", "remove"):
+            out = _cmd_cancel(sender_id, rest)
+        elif sub == "edit":
+            out = _cmd_edit(sender_id, rest)
+        elif sub == "tick":
+            out = await _cmd_tick()
+        elif sub == "status":
+            out = _cmd_status(sender_id)
+        elif sub == "history":
+            out = _cmd_history(sender_id, rest)
+        else:
+            out = f"Unknown subcommand: {sub!r}\n\n" + _render_usage()
+    _record("alerts", raw_args, out)
+    return out
+
+
+def _render_usage() -> str:
+    return (
+        "Price + wallet alerts. Notification-only; no transactions submitted.\n"
+        "\n"
+        "  /alerts add price <token> <above|below> <usd>\n"
+        "                          Fire when token price crosses threshold\n"
+        "  /alerts add wallet <address>\n"
+        "                          Fire on any new ERC-20 receipt to the address\n"
+        "  /alerts list            Show your alerts + last fire time\n"
+        "  /alerts pause <id>      Suspend without removing\n"
+        "  /alerts resume <id>     Re-arm\n"
+        "  /alerts cancel <id>     Remove entirely\n"
+        "  /alerts edit <id> <field> <value>\n"
+        "                          Change one field on a price alert\n"
+        "  /alerts status          Global summary + service health\n"
+        "  /alerts history <id>    Past fires for one alert\n"
+        "  /alerts tick            Manually poll (testing)\n"
+        "\n"
+        "Example:\n"
+        "  /alerts add price CLAWNCH above 0.00002\n"
+        "  /alerts add wallet 0xWhale…"
+    )
+
+
+# ── /alerts add ─────────────────────────────────────────────────────
+
+
+def _cmd_add(sender_id: str, parts: list[str]) -> str:
+    if not parts:
+        return (
+            "Usage: /alerts add price <token> <above|below> <usd>\n"
+            "   or: /alerts add wallet <address>"
+        )
+
+    # Free-tier cap: 3 active alerts per sender.
+    from clawmes.services.token_gate import check_cap_or_error
+
+    state_check = _load_state()
+    active_mine = sum(
+        1
+        for a in state_check["alerts"]
+        if a.get("sender_id") == sender_id and a.get("status") == "active"
+    )
+    cap_err = check_cap_or_error("alerts", active_count=active_mine, feature="alert")
+    if cap_err:
+        return cap_err
+
+    kind = parts[0].lower()
+    if kind == "price":
+        return _add_price(sender_id, parts[1:])
+    if kind == "wallet":
+        return _add_wallet(sender_id, parts[1:])
+    return f"Unknown alert type {kind!r}. Use 'price' or 'wallet'."
+
+
+def _add_price(sender_id: str, parts: list[str]) -> str:
+    if len(parts) < 3:
+        return "Usage: /alerts add price <token> <above|below> <usd>"
+    token, direction, usd_raw = parts[0], parts[1].lower(), parts[2]
+    if direction not in ("above", "below"):
+        return f"direction must be 'above' or 'below' (got {direction!r})."
+    try:
+        threshold_usd = float(usd_raw)
+    except ValueError:
+        return f"usd threshold must be a number (got {usd_raw!r})."
+    if threshold_usd <= 0:
+        return f"usd threshold must be positive (got {threshold_usd})."
+
+    state = _load_state()
+    alert_id = _new_id()
+    alert = {
+        "id": alert_id,
+        "sender_id": sender_id,
+        "type": "price",
+        "token": token,
+        "direction": direction,
+        "threshold_usd": threshold_usd,
+        "status": "active",
+        "created_at": _now_iso(),
+        "fires": [],
+    }
+    state["alerts"].append(alert)
+    _save_state(state)
+    return (
+        f"Alert added: {alert_id}\n"
+        f"  Type:      price\n"
+        f"  Token:     {token}\n"
+        f"  Trigger:   price {direction} ${threshold_usd}\n"
+        "\n"
+        "The alert scheduler polls prices on the registry cadence (~60s)\n"
+        "and records a fire when the threshold is crossed. Use /alerts list\n"
+        "to see all your alerts."
+    )
+
+
+def _add_wallet(sender_id: str, parts: list[str]) -> str:
+    if not parts:
+        return "Usage: /alerts add wallet <address>"
+    address = parts[0]
+    if not (address.startswith("0x") and len(address) == 42):
+        return f"wallet must be a 0x… address (got {address!r})."
+
+    # Seed last_seen_block so the first tick doesn't replay history.
+    last_block = _current_block_height() - 10
+    if last_block < 0:
+        last_block = 0
+
+    state = _load_state()
+    alert_id = _new_id()
+    alert = {
+        "id": alert_id,
+        "sender_id": sender_id,
+        "type": "wallet",
+        "wallet": address.lower(),
+        "status": "active",
+        "created_at": _now_iso(),
+        "last_seen_block": last_block,
+        "fires": [],
+    }
+    state["alerts"].append(alert)
+    _save_state(state)
+    return (
+        f"Alert added: {alert_id}\n"
+        f"  Type:      wallet\n"
+        f"  Wallet:    {address}\n"
+        f"  Trigger:   any new ERC-20 receipt\n"
+        f"  Last block: {last_block}\n"
+        "\n"
+        "The alert scheduler polls Basescan on the registry cadence.\n"
+        "Each detected receipt records a fire on this alert's history."
+    )
+
+
+# ── /alerts list / mutate / cancel ─────────────────────────────────
+
+
+def _cmd_list(sender_id: str) -> str:
+    state = _load_state()
+    mine = [a for a in state["alerts"] if a.get("sender_id") == sender_id]
+    if not mine:
+        return "No alerts. Add one with /alerts add ..."
+    lines = [f"Alerts for {sender_id} ({len(mine)}):", ""]
+    for a in mine:
+        fires = len(a.get("fires", []))
+        if a.get("type") == "price":
+            trigger = f"price {a.get('direction')} ${a.get('threshold_usd')}"
+            target = a.get("token", "?")
+        else:
+            trigger = "wallet receipt"
+            target = _short(a.get("wallet", "?"))
+        lines.append(
+            f"  {a['id']}  {a.get('status'):<8s}"
+            f"  {a.get('type'):<7s}  {target}"
+            f"  {trigger}  ({fires} fires)"
+        )
+    return "\n".join(lines)
+
+
+def _cmd_mutate(sender_id: str, parts: list[str], *, status: str, verb: str) -> str:
+    if not parts:
+        return f"Usage: /alerts {verb.removesuffix('d')} <id>"
+    aid = parts[0]
+    state = _load_state()
+    for a in state["alerts"]:
+        if a.get("id") == aid and a.get("sender_id") == sender_id:
+            a["status"] = status
+            _save_state(state)
+            return f"Alert {aid} {verb}."
+    return f"No alert found with id {aid!r}."
+
+
+def _cmd_cancel(sender_id: str, parts: list[str]) -> str:
+    if not parts:
+        return "Usage: /alerts cancel <id>"
+    aid = parts[0]
+    state = _load_state()
+    before = len(state["alerts"])
+    state["alerts"] = [
+        a for a in state["alerts"] if not (a.get("id") == aid and a.get("sender_id") == sender_id)
+    ]
+    if len(state["alerts"]) == before:
+        return f"No alert found with id {aid!r}."
+    _save_state(state)
+    return f"Cancelled alert {aid}."
+
+
+# ── /alerts edit ───────────────────────────────────────────────────
+
+
+def _cmd_edit(sender_id: str, parts: list[str]) -> str:
+    if len(parts) < 3:
+        return (
+            "Usage: /alerts edit <id> <field> <value>\n"
+            "Price alert fields: direction, threshold_usd, token"
+        )
+    aid, field, value = parts[0], parts[1], parts[2]
+    state = _load_state()
+    alert = _find(state, aid, sender_id)
+    if alert is None:
+        return f"No alert found with id {aid!r}."
+
+    # Wallet alerts have no editable fields beyond pause/resume — the
+    # surface is intentionally narrow. Tell the user explicitly.
+    if alert.get("type") != "price":
+        return "Only price alerts are editable. Cancel + re-add to change a wallet alert."
+
+    if field == "direction":
+        if value.lower() not in ("above", "below"):
+            return f"direction must be 'above' or 'below' (got {value!r})."
+        alert["direction"] = value.lower()
+    elif field == "threshold_usd":
+        try:
+            v = float(value)
+        except ValueError:
+            return f"threshold_usd must be a number (got {value!r})."
+        if v <= 0:
+            return f"threshold_usd must be positive (got {v})."
+        alert["threshold_usd"] = v
+    elif field == "token":
+        alert["token"] = value
+    else:
+        return f"Unknown field {field!r}. Editable: direction, threshold_usd, token."
+
+    _save_state(state)
+    return f"Alert {aid}: {field} = {value}."
+
+
+def _find(state: dict[str, Any], aid: str, sender_id: str) -> dict[str, Any] | None:
+    for a in state["alerts"]:
+        if a.get("id") == aid and a.get("sender_id") == sender_id:
+            return a
+    return None
+
+
+# ── /alerts tick — the watcher ─────────────────────────────────────
+
+
+async def _cmd_tick() -> str:
+    n, lines = _run_due_with_lines()
+    if n == 0:
+        return "No alerts fired."
+    return "\n".join([f"Fired {n} alert(s):"] + lines)
+
+
+def _run_due_sync() -> int:
+    n, _ = _run_due_with_lines()
+    return n
+
+
+def _run_due_with_lines() -> tuple[int, list[str]]:
+    state = _load_state()
+    lines: list[str] = []
+    total = 0
+    for alert in state["alerts"]:
+        if alert.get("status") != "active":
+            continue
+        try:
+            fired = _check_alert(alert)
+            if fired:
+                lines.append(
+                    f"  {alert['id']}  {alert.get('type')}  fired: {fired.get('detail', '')}"
+                )
+                alert["fires"].append({"at": _now_iso(), **fired})
+                # Price alerts auto-deactivate so we don't repeatedly
+                # notify on every tick after the threshold is crossed.
+                # Wallet alerts re-arm naturally because
+                # last_seen_block advances past the seen tx.
+                if alert.get("type") == "price":
+                    alert["status"] = "fired"
+                total += 1
+        except Exception as exc:  # noqa: BLE001
+            lines.append(f"  {alert['id']}  error: {exc}")
+    if total > 0 or any(lines):
+        _save_state(state)
+    return total, lines
+
+
+def _check_alert(alert: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a fire-event dict if the alert should fire, else None."""
+    if alert.get("type") == "price":
+        return _check_price_alert(alert)
+    if alert.get("type") == "wallet":
+        return _check_wallet_alert(alert)
+    return None
+
+
+def _check_price_alert(alert: dict[str, Any]) -> dict[str, Any] | None:
+    """Hit defi_price for a USD quote, compare to threshold, return fire."""
+    try:
+        from clawmes.tools.defi_price import defi_price
+
+        raw = defi_price(
+            {
+                "action": "quote",
+                "symbol": alert["token"],
+                "quote_currency": "USD",
+            }
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "error", "detail": f"price fetch: {exc}"}
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return {"status": "error", "detail": f"bad price response: {raw}"}
+    if payload.get("isError"):
+        msg = payload.get("content", [{}])[0].get("text", "price failed")
+        return {"status": "error", "detail": msg}
+    details = payload.get("details") or {}
+    price_usd = details.get("price_usd") or details.get("price") or 0
+    try:
+        price_usd = float(price_usd)
+    except (TypeError, ValueError):
+        return None
+
+    threshold = float(alert["threshold_usd"])
+    direction = alert["direction"]
+    crossed = (direction == "above" and price_usd >= threshold) or (
+        direction == "below" and price_usd <= threshold
+    )
+    if not crossed:
+        return None
+    return {
+        "status": "fired",
+        "detail": f"{alert['token']} = ${price_usd} ({direction} ${threshold})",
+        "price_usd": price_usd,
+    }
+
+
+def _check_wallet_alert(alert: dict[str, Any]) -> dict[str, Any] | None:
+    """Poll Basescan for new ERC-20 receipts to the watched wallet."""
+    wallet = alert["wallet"]
+    start_block = int(alert.get("last_seen_block", 0)) + 1
+    txs = _basescan_token_receipts(wallet, start_block=start_block)
+    if not txs:
+        return None
+
+    # Take the most recent block from what we saw.
+    max_block = max(int(tx.get("blockNumber", 0)) for tx in txs)
+    alert["last_seen_block"] = max_block
+
+    # Summarize: how many txs, what tokens.
+    tokens = sorted({tx.get("contractAddress") for tx in txs if tx.get("contractAddress")})
+    sample = ", ".join(_short(t) for t in tokens[:3])
+    if len(tokens) > 3:
+        sample += f" (+{len(tokens) - 3} more)"
+    return {
+        "status": "fired",
+        "detail": f"{len(txs)} new tx(s), token(s): {sample}",
+        "tx_count": len(txs),
+        "sample_tokens": tokens[:5],
+    }
+
+
+def _basescan_token_receipts(wallet: str, *, start_block: int) -> list[dict[str, Any]]:
+    """Same shape as the /copy poller — incoming ERC-20 transfers only."""
+    params = {
+        "module": "account",
+        "action": "tokentx",
+        "address": wallet,
+        "startblock": str(start_block),
+        "endblock": "99999999",
+        "sort": "asc",
+    }
+    api_key = os.environ.get("BASESCAN_API_KEY")
+    if api_key:
+        params["apikey"] = api_key
+    body = http_get(_BASESCAN_BASE, params=params, timeout=20.0)
+    if not isinstance(body, dict):
+        return []
+    if str(body.get("status")) != "1":
+        return []
+    result = body.get("result")
+    if not isinstance(result, list):
+        return []
+    return [
+        x for x in result if isinstance(x, dict) and (x.get("to") or "").lower() == wallet.lower()
+    ]
+
+
+def _current_block_height() -> int:
+    params = {"module": "proxy", "action": "eth_blockNumber"}
+    api_key = os.environ.get("BASESCAN_API_KEY")
+    if api_key:
+        params["apikey"] = api_key
+    try:
+        body = http_get(_BASESCAN_BASE, params=params, timeout=10.0)
+    except Exception:  # noqa: BLE001
+        return 0
+    if not isinstance(body, dict):
+        return 0
+    result = body.get("result")
+    if not isinstance(result, str) or not result.startswith("0x"):
+        return 0
+    try:
+        return int(result, 16)
+    except (ValueError, TypeError):
+        return 0
+
+
+# ── /alerts status / history ───────────────────────────────────────
+
+
+def _cmd_status(_sender_id: str) -> str:
+    state = _load_state()
+    alerts = state.get("alerts", [])
+    if not alerts:
+        return "No alerts exist. The scheduler service is idle."
+
+    by_status: dict[str, int] = {}
+    by_type: dict[str, int] = {}
+    total_fires = 0
+    for a in alerts:
+        s = a.get("status", "?")
+        by_status[s] = by_status.get(s, 0) + 1
+        t = a.get("type", "?")
+        by_type[t] = by_type.get(t, 0) + 1
+        total_fires += len(a.get("fires", []))
+
+    lines = [
+        f"/alerts status ({len(alerts)} alert(s)):",
+        "",
+        f"  By status:    {', '.join(f'{k}={v}' for k, v in sorted(by_status.items()))}",
+        f"  By type:      {', '.join(f'{k}={v}' for k, v in sorted(by_type.items()))}",
+        f"  Total fires:  {total_fires}",
+    ]
+    try:
+        from clawmes.services.alerts_scheduler import get_alerts_scheduler_service
+
+        svc = get_alerts_scheduler_service()
+        h = svc.health()
+        lines.append(
+            f"  Service:      {h.get('status')} "
+            f"(ticks={h.get('ticks')}, total_fires={h.get('total_runs')})"
+        )
+    except Exception:  # noqa: BLE001
+        pass
+    return "\n".join(lines)
+
+
+def _cmd_history(sender_id: str, parts: list[str]) -> str:
+    if not parts:
+        return "Usage: /alerts history <id>"
+    aid = parts[0]
+    state = _load_state()
+    alert = _find(state, aid, sender_id)
+    if alert is None:
+        return f"No alert found with id {aid!r}."
+    fires = alert.get("fires", [])
+    if not fires:
+        return f"Alert {aid}: no fires yet."
+    lines = [f"Fires for {aid} ({len(fires)}):", ""]
+    for fire in fires[-25:]:
+        when = fire.get("at", "")
+        detail = fire.get("detail", "")
+        lines.append(f"  {when}  {detail}")
+    return "\n".join(lines)
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="alerts",
+        handler=handle_alerts,
+        description="Price + wallet activity alerts (notification-only)",
+        args_hint="add price|wallet ... | list | pause | resume | cancel | edit | tick | status | history",
+    )

--- a/clawmes/commands/copy.py
+++ b/clawmes/commands/copy.py
@@ -214,6 +214,20 @@ def _cmd_add(sender_id: str, parts: list[str]) -> str:
             "  [--max-total eth] [--max-failures n]\n"
             "  [--blocklist 0xa,0xb,…]"
         )
+
+    # Free-tier cap on active follows. Holders bypass.
+    from clawmes.services.token_gate import check_cap_or_error
+
+    state_check = _load_state()
+    active_mine = sum(
+        1
+        for f in state_check["follows"]
+        if f.get("sender_id") == sender_id and f.get("status") == "active"
+    )
+    cap_err = check_cap_or_error("copy", active_count=active_mine, feature="copy follow")
+    if cap_err:
+        return cap_err
+
     wallet, eth_raw = pos[0], pos[1]
     if not (wallet.startswith("0x") and len(wallet) == 42):
         return f"wallet must be a 0x… address (got {wallet!r})."

--- a/clawmes/commands/dca.py
+++ b/clawmes/commands/dca.py
@@ -267,6 +267,33 @@ def _cmd_add(sender_id: str, parts: list[str]) -> str:
             "  [--max-total <eth>] [--max-failures <n>]\n"
             "Example: /dca add 0xa1F7…747be 0.001 1h --slippage 50 --daily-cap 0.05"
         )
+
+    # Free-tier cap: limit active schedules per sender. Holders bypass.
+    from clawmes.services.token_gate import Tier, check_cap_or_error, check_tier_or_error
+
+    state_check = _load_state()
+    active_mine = sum(
+        1
+        for s in state_check["schedules"]
+        if s.get("sender_id") == sender_id and s.get("status") == "active"
+    )
+    cap_err = check_cap_or_error("dca", active_count=active_mine, feature="DCA schedule")
+    if cap_err:
+        return cap_err
+
+    # Safeguard flags are a HOLDER-tier feature. The gate runs only when
+    # the user actually passed a safeguard flag — free-tier add without
+    # flags is fine.
+    safeguard_flags = {"slippage", "daily-cap", "max-total", "max-failures"}
+    used_safeguards = safeguard_flags & set(flags)
+    if used_safeguards:
+        tier_err = check_tier_or_error(
+            Tier.HOLDER,
+            feature=f"/dca safeguard flags ({', '.join(sorted(used_safeguards))})",
+        )
+        if tier_err:
+            return tier_err
+
     token, eth_amount_raw, interval_raw = pos[0], pos[1], pos[2]
 
     # Validate token: must be a 0x address. We don't resolve symbols here

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.8.0
+version: 0.9.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/services/__init__.py
+++ b/clawmes/services/__init__.py
@@ -38,6 +38,7 @@ def start_all() -> None:
     crashing.
     """
     from clawmes.plans.scheduler import get_scheduler
+    from clawmes.services.alerts_scheduler import get_alerts_scheduler_service
     from clawmes.services.bankr_service import get_bankr_service
     from clawmes.services.bv7x import get_bv7x_service
     from clawmes.services.clawnch import get_clawnch_service
@@ -58,6 +59,7 @@ def start_all() -> None:
     from clawmes.services.price import get_price_service
     from clawmes.services.rpc import get_rpc_service
     from clawmes.services.token_decimals import get_token_decimals_service
+    from clawmes.services.token_gate import get_token_gate_service
     from clawmes.services.wallet import get_wallet_service
     from clawmes.services.wc_notifications import get_wc_notification_consumer
     from clawmes.services.zerox import get_zerox_service
@@ -96,6 +98,10 @@ def start_all() -> None:
         get_rpc_service,
         # 4. Token decimals cache — depends on RPC.
         get_token_decimals_service,
+        # 4b. Token gate — depends on RPC. Resolves wallet → tier
+        #     based on $CLAWNCH balance. Gated features in /dca / /copy
+        #     / /agent / /alerts read from this on each gated call.
+        get_token_gate_service,
         # 4a. Block-explorer client — read-side, no dependencies; lives
         #     here so block_explorer tool dispatch is ready.
         get_explorer_service,
@@ -136,6 +142,11 @@ def start_all() -> None:
         #     followed wallets' new ERC-20 receipts and submits copy
         #     buys at the configured fixed ETH amount per copy.
         get_copy_trader_service,
+        # 7c. Alerts scheduler — ticking=True. Polls active alerts on
+        #     each tick (price quotes via defi_price, wallet receipts
+        #     via Basescan) and records fires. Notification delivery
+        #     is downstream via the channel layer.
+        get_alerts_scheduler_service,
         get_wc_notification_consumer,  # threaded; routes WC bridge notifs
     ]
     for factory in factories:

--- a/clawmes/services/alerts_scheduler.py
+++ b/clawmes/services/alerts_scheduler.py
@@ -1,0 +1,82 @@
+"""Alerts scheduler service — drives ``/alerts tick`` automatically.
+
+Same shape as ``DcaSchedulerService`` and ``CopyTraderService``. Each
+service tick polls every active alert (price or wallet type), records
+fires on the alert's history, and (for price alerts) flips the alert
+to ``status="fired"`` so we don't repeatedly notify on subsequent
+ticks after a threshold has been crossed.
+
+Notification delivery (Telegram / Slack / etc.) happens via the
+Hermes channel layer reading clawmes command history — this service
+is responsible only for detecting fires and persisting them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawmes.lib.logger import logger_for
+from clawmes.services._base import Service
+
+_log = logger_for("services.alerts_scheduler")
+
+_SERVICE: AlertsSchedulerService | None = None
+
+
+class AlertsSchedulerService(Service):
+    id = "clawmes.alerts_scheduler"
+    ticking = True
+
+    def __init__(self) -> None:
+        self._running = False
+        self._ticks = 0
+        self._last_runs = 0
+        self._total_runs = 0
+
+    def start(self) -> None:
+        self._running = True
+        _log.info("alerts scheduler started — tick cadence driven by registry")
+
+    def stop(self) -> None:
+        self._running = False
+        _log.info(
+            "alerts scheduler stopped (ticks=%d, total_fires=%d)",
+            self._ticks,
+            self._total_runs,
+        )
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": "running" if self._running else "stopped",
+            "ticks": self._ticks,
+            "last_runs": self._last_runs,
+            "total_runs": self._total_runs,
+        }
+
+    def tick(self) -> None:
+        if not self._running:
+            return
+        self._ticks += 1
+        try:
+            from clawmes.commands import alerts
+
+            n = alerts._run_due_sync()
+            self._last_runs = n
+            self._total_runs += n
+            if n > 0:
+                _log.info("alerts tick fired %d alert(s)", n)
+        except Exception:  # noqa: BLE001
+            _log.exception("alerts scheduler tick raised; swallowing")
+
+
+def get_alerts_scheduler_service() -> AlertsSchedulerService:
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = AlertsSchedulerService()
+    return _SERVICE
+
+
+def _reset_for_tests() -> None:
+    global _SERVICE
+    _SERVICE = None

--- a/clawmes/services/token_gate.py
+++ b/clawmes/services/token_gate.py
@@ -1,0 +1,244 @@
+"""Token gating — power features unlock based on $CLAWNCH balance.
+
+Two tiers in v1:
+
+  * ``free`` — no balance required. Everything you need to onboard and
+    play around: ``/buy`` ``/trending`` ``/balance`` ``/leaderboard``
+    ``/claim`` ``/onramp`` ``/launch`` ``/burn`` ``/agent`` single-step.
+    Plus capped versions of the power features: 1 active ``/dca``
+    schedule, 1 active ``/copy`` follow, 3 active ``/alerts``, no
+    safeguard flags on ``/dca``.
+
+  * ``holder`` — any wallet holding **at least 10,000 $CLAWNCH**
+    (~$0.10 at session-time price). Unlocks:
+      - Unlimited ``/dca`` schedules + safeguard flags (slippage,
+        daily-cap, max-total, max-failures)
+      - Unlimited ``/copy`` follows + advanced flags (blocklist, etc.)
+      - ``/agent`` multi-step prompts (``then`` chains)
+      - Unlimited ``/alerts``
+
+The gate is intentionally minimal: a single 10k threshold rather than
+a 4-tier ladder. Easy to reason about, easy to test, low barrier to
+becoming a holder so nobody who actually wants the power features is
+priced out. Threshold is reviewable in one place
+(:data:`HOLDER_THRESHOLD_WEI`) so we can adjust as the price moves
+without scattering magic numbers.
+
+Implementation: each gated command imports
+:func:`check_tier_or_error` and calls it before touching state. The
+helper returns ``None`` when allowed and a human-readable error
+string otherwise (with the exact balance shortfall + a hint at how
+to buy more). When no wallet is connected, the user is treated as
+free tier — the gate never crashes on a missing wallet, it just
+returns the free-tier limit.
+"""
+
+from __future__ import annotations
+
+import time
+from enum import Enum
+from typing import Any
+
+from clawmes.lib.logger import logger_for
+from clawmes.services._base import Service
+
+_log = logger_for("services.token_gate")
+
+# $CLAWNCH token on Base. Pinned constant — the gate is currently
+# single-token; multi-token gating (e.g. CLAWNCH-or-USDC) would land
+# as a tuple/list here and a "highest tier across all" resolution.
+CLAWNCH_ADDR = "0xa1F72459dfA10BAD200Ac160eCd78C6b77a747be"
+
+# Holder threshold: 10,000 $CLAWNCH at 18 decimals = 1e22 wei.
+# At session-time price of ~$0.0000105 / $CLAWNCH, this is ~$0.10 USD —
+# small enough to be aspirational for any actual user, large enough to
+# function as a real signal of "I'm in this ecosystem."
+HOLDER_THRESHOLD = 10_000
+HOLDER_THRESHOLD_WEI = HOLDER_THRESHOLD * (10**18)
+
+# Cache TTL — balance reads hit the RPC, which is slow + rate-limited.
+# A 60-second cache is fine because tier changes are rare (you bought
+# 10k $CLAWNCH; you don't immediately sell 9k of it).
+_CACHE_TTL_SECONDS = 60
+
+
+class Tier(Enum):
+    """Resolved tier for a wallet."""
+
+    FREE = "free"
+    HOLDER = "holder"
+
+
+# Per-command free-tier caps. Keys are command names; values are the
+# maximum number of active items that command allows at the free tier.
+# Free tier still gets each feature, just rate-limited; upgrading to
+# HOLDER (any 10k+ balance) removes the cap.
+FREE_TIER_CAPS = {
+    "dca": 1,
+    "copy": 1,
+    "alerts": 3,
+}
+
+
+_SERVICE: TokenGateService | None = None
+
+
+class TokenGateService(Service):
+    """Singleton that resolves wallet → tier via on-chain balance reads."""
+
+    id = "clawmes.token_gate"
+
+    def __init__(self) -> None:
+        self._running = False
+        # Cache key: lowercased address. Value: (tier, balance_wei, expires_at_epoch).
+        self._cache: dict[str, tuple[Tier, int, float]] = {}
+
+    def start(self) -> None:
+        self._running = True
+        _log.info("token gate started (threshold=%d $CLAWNCH)", HOLDER_THRESHOLD)
+
+    def stop(self) -> None:
+        self._running = False
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": "running" if self._running else "stopped",
+            "threshold_clawnch": HOLDER_THRESHOLD,
+            "cached_entries": len(self._cache),
+        }
+
+    def resolve_tier(self, address: str | None) -> tuple[Tier, int]:
+        """Return (tier, balance_wei) for the wallet.
+
+        No wallet → FREE with 0 balance. Cache hits return without
+        touching RPC. Cache misses (or expired entries) make one
+        ``balanceOf`` eth_call.
+        """
+        if not address:
+            return Tier.FREE, 0
+        key = address.lower()
+        now = time.time()
+        cached = self._cache.get(key)
+        if cached and cached[2] > now:
+            return cached[0], cached[1]
+
+        balance = _read_clawnch_balance(address)
+        tier = Tier.HOLDER if balance >= HOLDER_THRESHOLD_WEI else Tier.FREE
+        self._cache[key] = (tier, balance, now + _CACHE_TTL_SECONDS)
+        return tier, balance
+
+    def invalidate(self, address: str | None) -> None:
+        """Drop cached tier for ``address`` — call after a buy/sell tx."""
+        if address:
+            self._cache.pop(address.lower(), None)
+
+
+def _read_clawnch_balance(address: str) -> int:
+    """Read the wallet's $CLAWNCH balance via ``balanceOf`` eth_call.
+
+    Catches all errors and returns ``0`` — the gate must never crash a
+    command on a network blip. A user with a transient RPC failure will
+    be treated as free tier for ~60s until the cache naturally refreshes.
+    """
+    try:
+        from clawmes.lib.abi import decode_uint, encode_balance_of
+        from clawmes.services.rpc import get_rpc_service
+
+        rpc = get_rpc_service()
+        raw = rpc.eth_call(
+            to=CLAWNCH_ADDR,
+            data=encode_balance_of(address),
+            chain_id=8453,
+        )
+        return decode_uint(raw)
+    except Exception:  # noqa: BLE001 — gate never raises
+        return 0
+
+
+def get_token_gate_service() -> TokenGateService:
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = TokenGateService()
+    return _SERVICE
+
+
+def _reset_for_tests() -> None:
+    global _SERVICE
+    _SERVICE = None
+
+
+# ── high-level helpers used by gated command handlers ──────────────
+
+
+def check_tier_or_error(min_tier: Tier, *, feature: str) -> str | None:
+    """Return ``None`` if the active wallet meets ``min_tier``, else an error.
+
+    Reads the active wallet via :func:`clawmes.services.wallet.get_wallet_state`.
+    If no wallet is connected, treats the user as free tier (so the
+    error message tells them what they need to unlock the feature).
+    """
+    if min_tier == Tier.FREE:
+        return None  # always allowed
+
+    address = _active_wallet_address()
+    tier, balance = get_token_gate_service().resolve_tier(address)
+    if tier == Tier.HOLDER:
+        return None
+
+    # User is free-tier; build a helpful error.
+    shortfall = HOLDER_THRESHOLD - (balance // (10**18))
+    lines = [
+        f"{feature} requires holding at least {HOLDER_THRESHOLD:,} $CLAWNCH.",
+    ]
+    if not address:
+        lines.append("No wallet connected. Run /connect to read your balance.")
+    else:
+        held = balance // (10**18)
+        lines.append(f"Active wallet holds {held:,} $CLAWNCH (need {shortfall:,} more).")
+    lines.extend(
+        [
+            "",
+            f"Buy with: /buy {CLAWNCH_ADDR} 0.01",
+            "Or load up via: /onramp 1",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def free_tier_cap(command: str) -> int | None:
+    """Return the free-tier active-item cap for ``command``, or ``None``."""
+    return FREE_TIER_CAPS.get(command)
+
+
+def check_cap_or_error(command: str, *, active_count: int, feature: str) -> str | None:
+    """Return ``None`` if the user is under cap or a HOLDER, else error.
+
+    Used by ``/dca add`` / ``/copy add`` / ``/alerts add`` to enforce
+    per-command active-item limits at the free tier. Holder tier has
+    no cap.
+    """
+    cap = free_tier_cap(command)
+    if cap is None or active_count < cap:
+        return None
+    address = _active_wallet_address()
+    tier, _ = get_token_gate_service().resolve_tier(address)
+    if tier == Tier.HOLDER:
+        return None
+    return (
+        f"Free tier allows {cap} active {feature}(s). "
+        f"You have {active_count}. "
+        f"Hold {HOLDER_THRESHOLD:,}+ $CLAWNCH to unlock unlimited."
+    )
+
+
+def _active_wallet_address() -> str | None:
+    try:
+        from clawmes.services.wallet import get_wallet_state
+
+        state = get_wallet_state()
+        if state.connected and state.address:
+            return state.address
+    except Exception:  # noqa: BLE001
+        return None
+    return None

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.8.0
+version: 0.9.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.8.0"
+version = "0.9.0"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_alerts.py
+++ b/tests/commands/test_alerts.py
@@ -1,0 +1,787 @@
+"""Tests for the /alerts slash command."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from clawmes.commands import alerts
+
+
+@pytest.fixture
+def tmp_state(tmp_path, monkeypatch):
+    p = tmp_path / "alerts.json"
+    monkeypatch.setattr(alerts, "_alerts_path", lambda: p)
+    return p
+
+
+@pytest.fixture
+def fake_basescan(monkeypatch):
+    state: dict[str, Any] = {"tokentx": None, "blocknum": None, "raises": None}
+
+    def _fake(url, *, params=None, timeout=None):  # noqa: ARG001
+        if state["raises"] is not None:
+            raise state["raises"]
+        action = (params or {}).get("action")
+        if action == "tokentx":
+            return state["tokentx"]
+        if action == "eth_blockNumber":
+            return state["blocknum"]
+        return None
+
+    monkeypatch.setattr(alerts, "http_get", _fake)
+    return state
+
+
+@pytest.fixture
+def fake_defi_price(monkeypatch):
+    state: dict[str, Any] = {"payload": None, "raises": None}
+
+    def _fake(args):  # noqa: ARG001
+        if state["raises"] is not None:
+            raise state["raises"]
+        return json.dumps(state["payload"])
+
+    import clawmes.tools.defi_price as price_mod
+
+    monkeypatch.setattr(price_mod, "defi_price", _fake)
+    return state
+
+
+def _add_price(sender="u", token="CLAWNCH", direction="above", usd="0.0001"):
+    return alerts._cmd_add(sender, ["price", token, direction, usd])
+
+
+def _add_wallet(sender="u", wallet=None, monkeypatch=None, height=1000):
+    addr = wallet or "0x" + "a" * 40
+    if monkeypatch is not None:
+        monkeypatch.setattr(alerts, "_current_block_height", lambda: height)
+    return alerts._cmd_add(sender, ["wallet", addr])
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_short_unchanged(self):
+        assert alerts._short("0x123") == "0x123"
+
+    def test_short_truncated(self):
+        out = alerts._short("0x" + "a" * 40)
+        assert "…" in out
+
+    def test_short_non_str(self):
+        assert alerts._short(None) == "None"  # type: ignore[arg-type]
+
+    def test_now_iso_format(self):
+        s = alerts._now_iso()
+        assert s.endswith("Z") and "T" in s
+
+    def test_new_id(self):
+        assert alerts._new_id().startswith("alert_")
+
+    def test_now_epoch(self):
+        assert alerts._now_epoch() > 0
+
+
+# ── state I/O ───────────────────────────────────────────────────────
+
+
+class TestStateIO:
+    def test_load_missing(self, tmp_state):
+        assert alerts._load_state() == {"alerts": []}
+
+    def test_load_bad_json(self, tmp_state):
+        tmp_state.write_text("not-json")
+        assert alerts._load_state() == {"alerts": []}
+
+    def test_load_wrong_shape(self, tmp_state):
+        tmp_state.write_text(json.dumps({"alerts": "not-a-list"}))
+        assert alerts._load_state() == {"alerts": []}
+
+    def test_load_not_a_dict(self, tmp_state):
+        tmp_state.write_text(json.dumps([]))
+        assert alerts._load_state() == {"alerts": []}
+
+    def test_roundtrip(self, tmp_state):
+        s = {"alerts": [{"id": "x"}]}
+        alerts._save_state(s)
+        assert alerts._load_state() == s
+
+    def test_default_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert alerts._alerts_path().name == "alerts.json"
+
+
+# ── /alerts add ─────────────────────────────────────────────────────
+
+
+class TestCmdAdd:
+    def test_usage(self, tmp_state):
+        out = alerts._cmd_add("u", [])
+        assert "Usage:" in out
+
+    def test_unknown_kind(self, tmp_state):
+        out = alerts._cmd_add("u", ["garbage", "x"])
+        assert "Unknown alert type" in out
+
+    def test_free_tier_cap_rejection(self, tmp_state, monkeypatch):
+        """When the free-tier cap helper returns an error, /alerts add bails."""
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(
+            tg,
+            "check_cap_or_error",
+            lambda *a, **k: "Free tier allows N active alert(s).",
+        )
+        out = alerts._cmd_add("u", ["price", "CLAWNCH", "above", "0.001"])
+        assert "Free tier allows" in out
+
+
+class TestAddPrice:
+    def test_usage(self, tmp_state):
+        out = alerts._cmd_add("u", ["price"])
+        assert "Usage:" in out
+
+    def test_bad_direction(self, tmp_state):
+        out = alerts._cmd_add("u", ["price", "CLAWNCH", "sideways", "0.001"])
+        assert "above" in out and "below" in out
+
+    def test_bad_usd_non_numeric(self, tmp_state):
+        out = alerts._cmd_add("u", ["price", "CLAWNCH", "above", "abc"])
+        assert "must be a number" in out
+
+    def test_bad_usd_zero(self, tmp_state):
+        out = alerts._cmd_add("u", ["price", "CLAWNCH", "above", "0"])
+        assert "must be positive" in out
+
+    def test_success(self, tmp_state):
+        out = _add_price()
+        assert "Alert added" in out
+        a = alerts._load_state()["alerts"][0]
+        assert a["type"] == "price"
+        assert a["direction"] == "above"
+        assert a["threshold_usd"] == 0.0001
+
+
+class TestAddWallet:
+    def test_usage(self, tmp_state):
+        out = alerts._cmd_add("u", ["wallet"])
+        assert "Usage:" in out
+
+    def test_bad_address(self, tmp_state):
+        out = alerts._cmd_add("u", ["wallet", "not-an-addr"])
+        assert "must be a 0x… address" in out
+
+    def test_success(self, tmp_state, monkeypatch):
+        monkeypatch.setattr(alerts, "_current_block_height", lambda: 1000)
+        out = _add_wallet(monkeypatch=monkeypatch)
+        assert "Alert added" in out
+        a = alerts._load_state()["alerts"][0]
+        assert a["type"] == "wallet"
+        assert a["last_seen_block"] == 990  # 1000 - 10
+
+    def test_block_seed_floor_at_zero(self, tmp_state, monkeypatch):
+        _add_wallet(monkeypatch=monkeypatch, height=3)
+        assert alerts._load_state()["alerts"][0]["last_seen_block"] == 0
+
+
+# ── /alerts list / mutate / cancel ─────────────────────────────────
+
+
+class TestList:
+    def test_empty(self, tmp_state):
+        assert "No alerts" in alerts._cmd_list("u")
+
+    def test_lists_mine_only(self, tmp_state, monkeypatch):
+        _add_price("alice")
+        _add_wallet("bob", monkeypatch=monkeypatch)
+        out = alerts._cmd_list("alice")
+        # Only alice's alert in output.
+        assert "price" in out
+        assert "wallet" not in out
+
+    def test_lists_wallet_alert(self, tmp_state, monkeypatch):
+        """Render path for wallet-type alerts (covers else-branch in _cmd_list)."""
+        _add_wallet("bob", monkeypatch=monkeypatch)
+        out = alerts._cmd_list("bob")
+        assert "wallet" in out
+        assert "wallet receipt" in out
+
+
+class TestMutate:
+    def test_pause_usage(self, tmp_state):
+        out = alerts._cmd_mutate("u", [], status="paused", verb="paused")
+        assert "Usage:" in out
+
+    def test_pause_not_found(self, tmp_state):
+        out = alerts._cmd_mutate("u", ["alert_xxx"], status="paused", verb="paused")
+        assert "No alert found" in out
+
+    def test_pause_resume(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        alerts._cmd_mutate("u", [aid], status="paused", verb="paused")
+        assert alerts._load_state()["alerts"][0]["status"] == "paused"
+        alerts._cmd_mutate("u", [aid], status="active", verb="resumed")
+        assert alerts._load_state()["alerts"][0]["status"] == "active"
+
+
+class TestCancel:
+    def test_usage(self, tmp_state):
+        assert "Usage:" in alerts._cmd_cancel("u", [])
+
+    def test_not_found(self, tmp_state):
+        assert "No alert" in alerts._cmd_cancel("u", ["alert_xxx"])
+
+    def test_success(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        result = alerts._cmd_cancel("u", [aid])
+        assert "Cancelled" in result
+        assert alerts._load_state()["alerts"] == []
+
+    def test_isolated_by_sender(self, tmp_state):
+        out = _add_price("alice")
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        assert "No alert" in alerts._cmd_cancel("bob", [aid])
+
+
+# ── /alerts edit ───────────────────────────────────────────────────
+
+
+class TestEdit:
+    def test_usage(self, tmp_state):
+        out = alerts._cmd_edit("u", [])
+        assert "Usage:" in out
+
+    def test_not_found(self, tmp_state):
+        out = alerts._cmd_edit("u", ["alert_xxx", "direction", "above"])
+        assert "No alert found" in out
+
+    def test_wallet_alert_rejected(self, tmp_state, monkeypatch):
+        out = _add_wallet(monkeypatch=monkeypatch)
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        result = alerts._cmd_edit("u", [aid, "direction", "above"])
+        assert "Only price alerts are editable" in result
+
+    def test_direction(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        alerts._cmd_edit("u", [aid, "direction", "below"])
+        assert alerts._load_state()["alerts"][0]["direction"] == "below"
+
+    def test_direction_bad(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        result = alerts._cmd_edit("u", [aid, "direction", "garbage"])
+        assert "above" in result and "below" in result
+
+    def test_threshold_usd(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        alerts._cmd_edit("u", [aid, "threshold_usd", "0.002"])
+        assert alerts._load_state()["alerts"][0]["threshold_usd"] == 0.002
+
+    def test_threshold_usd_bad(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        result = alerts._cmd_edit("u", [aid, "threshold_usd", "abc"])
+        assert "must be a number" in result
+
+    def test_threshold_usd_non_positive(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        result = alerts._cmd_edit("u", [aid, "threshold_usd", "0"])
+        assert "must be positive" in result
+
+    def test_token(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        alerts._cmd_edit("u", [aid, "token", "USDC"])
+        assert alerts._load_state()["alerts"][0]["token"] == "USDC"
+
+    def test_unknown_field(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        result = alerts._cmd_edit("u", [aid, "garbage", "1"])
+        assert "Unknown field" in result
+
+
+# ── _find ──────────────────────────────────────────────────────────
+
+
+class TestFind:
+    def test_found(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        s = alerts._load_state()
+        assert alerts._find(s, aid, "u") is not None
+
+    def test_wrong_sender(self, tmp_state):
+        out = _add_price("alice")
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        s = alerts._load_state()
+        assert alerts._find(s, aid, "bob") is None
+
+    def test_missing_id(self, tmp_state):
+        assert alerts._find(alerts._load_state(), "alert_xxx", "u") is None
+
+
+# ── price alert evaluation ─────────────────────────────────────────
+
+
+class TestCheckPriceAlert:
+    def test_above_crosses(self, fake_defi_price):
+        fake_defi_price["payload"] = {
+            "isError": False,
+            "details": {"price_usd": 0.0002},
+        }
+        alert = {"token": "CLAWNCH", "direction": "above", "threshold_usd": 0.0001}
+        out = alerts._check_price_alert(alert)
+        assert out["status"] == "fired"
+
+    def test_below_crosses(self, fake_defi_price):
+        fake_defi_price["payload"] = {
+            "isError": False,
+            "details": {"price_usd": 0.00005},
+        }
+        alert = {"token": "CLAWNCH", "direction": "below", "threshold_usd": 0.0001}
+        out = alerts._check_price_alert(alert)
+        assert out["status"] == "fired"
+
+    def test_above_not_crossed(self, fake_defi_price):
+        fake_defi_price["payload"] = {
+            "isError": False,
+            "details": {"price_usd": 0.00005},
+        }
+        alert = {"token": "CLAWNCH", "direction": "above", "threshold_usd": 0.0001}
+        assert alerts._check_price_alert(alert) is None
+
+    def test_below_not_crossed(self, fake_defi_price):
+        fake_defi_price["payload"] = {
+            "isError": False,
+            "details": {"price_usd": 0.0005},
+        }
+        alert = {"token": "CLAWNCH", "direction": "below", "threshold_usd": 0.0001}
+        assert alerts._check_price_alert(alert) is None
+
+    def test_price_alias_key(self, fake_defi_price):
+        # ``price`` instead of ``price_usd`` should still parse.
+        fake_defi_price["payload"] = {"isError": False, "details": {"price": 1.0}}
+        alert = {"token": "CLAWNCH", "direction": "above", "threshold_usd": 0.5}
+        assert alerts._check_price_alert(alert)["status"] == "fired"
+
+    def test_price_raises(self, fake_defi_price):
+        fake_defi_price["raises"] = RuntimeError("rate limit")
+        alert = {"token": "CLAWNCH", "direction": "above", "threshold_usd": 0.5}
+        out = alerts._check_price_alert(alert)
+        assert out["status"] == "error"
+        assert "rate limit" in out["detail"]
+
+    def test_price_bad_json(self, monkeypatch):
+        import clawmes.tools.defi_price as price_mod
+
+        monkeypatch.setattr(price_mod, "defi_price", lambda *a, **k: "not-json")
+        alert = {"token": "CLAWNCH", "direction": "above", "threshold_usd": 0.5}
+        out = alerts._check_price_alert(alert)
+        assert out["status"] == "error"
+
+    def test_price_isError(self, fake_defi_price):
+        fake_defi_price["payload"] = {
+            "isError": True,
+            "content": [{"text": "unknown symbol"}],
+        }
+        alert = {"token": "BOGUS", "direction": "above", "threshold_usd": 0.5}
+        out = alerts._check_price_alert(alert)
+        assert out["status"] == "error"
+
+    def test_price_isError_no_content(self, fake_defi_price):
+        fake_defi_price["payload"] = {"isError": True}
+        alert = {"token": "BOGUS", "direction": "above", "threshold_usd": 0.5}
+        out = alerts._check_price_alert(alert)
+        assert out["status"] == "error"
+
+    def test_price_non_numeric(self, fake_defi_price):
+        fake_defi_price["payload"] = {
+            "isError": False,
+            "details": {"price_usd": "not-a-number"},
+        }
+        alert = {"token": "CLAWNCH", "direction": "above", "threshold_usd": 0.5}
+        assert alerts._check_price_alert(alert) is None
+
+
+# ── wallet alert evaluation ────────────────────────────────────────
+
+
+class TestCheckWalletAlert:
+    def test_no_new_tx(self, fake_basescan):
+        fake_basescan["tokentx"] = {"status": "0", "message": "No transactions found"}
+        alert = {"wallet": "0x" + "a" * 40, "last_seen_block": 0}
+        assert alerts._check_wallet_alert(alert) is None
+
+    def test_fires_on_new_tx(self, fake_basescan):
+        wallet = "0x" + "a" * 40
+        fake_basescan["tokentx"] = {
+            "status": "1",
+            "result": [
+                {"to": wallet, "contractAddress": "0x" + "T" * 40, "blockNumber": "2000"},
+                {"to": wallet, "contractAddress": "0x" + "U" * 40, "blockNumber": "2001"},
+            ],
+        }
+        alert = {"wallet": wallet, "last_seen_block": 1000}
+        out = alerts._check_wallet_alert(alert)
+        assert out["status"] == "fired"
+        assert out["tx_count"] == 2
+        assert alert["last_seen_block"] == 2001
+
+    def test_many_tokens_truncates_sample(self, fake_basescan):
+        wallet = "0x" + "a" * 40
+        fake_basescan["tokentx"] = {
+            "status": "1",
+            "result": [
+                {
+                    "to": wallet,
+                    "contractAddress": "0x" + f"{i:040x}",
+                    "blockNumber": "2000",
+                }
+                for i in range(10)
+            ],
+        }
+        alert = {"wallet": wallet, "last_seen_block": 0}
+        out = alerts._check_wallet_alert(alert)
+        assert "+7 more" in out["detail"]
+
+
+# ── Basescan helpers ───────────────────────────────────────────────
+
+
+class TestBasescanReceipts:
+    def test_non_dict(self, fake_basescan):
+        fake_basescan["tokentx"] = "junk"
+        assert alerts._basescan_token_receipts("0xabc", start_block=0) == []
+
+    def test_status_zero(self, fake_basescan):
+        fake_basescan["tokentx"] = {"status": "0"}
+        assert alerts._basescan_token_receipts("0xabc", start_block=0) == []
+
+    def test_result_not_list(self, fake_basescan):
+        fake_basescan["tokentx"] = {"status": "1", "result": "string"}
+        assert alerts._basescan_token_receipts("0xabc", start_block=0) == []
+
+    def test_filters_to(self, fake_basescan):
+        wallet = "0x" + "a" * 40
+        fake_basescan["tokentx"] = {
+            "status": "1",
+            "result": [
+                {"to": wallet, "contractAddress": "0xT1"},
+                {"to": "0x" + "f" * 40, "contractAddress": "0xT2"},
+                "junk",
+            ],
+        }
+        out = alerts._basescan_token_receipts(wallet, start_block=0)
+        assert len(out) == 1
+
+    def test_api_key_passed(self, monkeypatch):
+        captured = {}
+
+        def _spy(url, *, params=None, timeout=None):  # noqa: ARG001
+            captured.update(params)
+            return {"status": "0"}
+
+        monkeypatch.setattr(alerts, "http_get", _spy)
+        monkeypatch.setenv("BASESCAN_API_KEY", "MYKEY")
+        alerts._basescan_token_receipts("0xabc", start_block=0)
+        assert captured.get("apikey") == "MYKEY"
+
+
+class TestCurrentBlockHeight:
+    def test_http_error(self, fake_basescan):
+        fake_basescan["raises"] = RuntimeError("down")
+        assert alerts._current_block_height() == 0
+
+    def test_non_dict(self, fake_basescan):
+        fake_basescan["blocknum"] = "junk"
+        assert alerts._current_block_height() == 0
+
+    def test_no_result_string(self, fake_basescan):
+        fake_basescan["blocknum"] = {"result": 123}
+        assert alerts._current_block_height() == 0
+
+    def test_bad_hex(self, fake_basescan):
+        fake_basescan["blocknum"] = {"result": "0xZZZ"}
+        assert alerts._current_block_height() == 0
+
+    def test_success(self, fake_basescan):
+        fake_basescan["blocknum"] = {"result": "0x3e8"}
+        assert alerts._current_block_height() == 1000
+
+    def test_api_key(self, monkeypatch):
+        captured = {}
+
+        def _spy(url, *, params=None, timeout=None):  # noqa: ARG001
+            captured.update(params)
+            return {"result": "0x0"}
+
+        monkeypatch.setattr(alerts, "http_get", _spy)
+        monkeypatch.setenv("BASESCAN_API_KEY", "MYKEY")
+        alerts._current_block_height()
+        assert captured.get("apikey") == "MYKEY"
+
+
+# ── _check_alert dispatch ──────────────────────────────────────────
+
+
+class TestCheckAlertDispatch:
+    def test_unknown_type(self):
+        assert alerts._check_alert({"type": "garbage"}) is None
+
+    def test_price_dispatch(self, fake_defi_price):
+        fake_defi_price["payload"] = {
+            "isError": False,
+            "details": {"price_usd": 1.0},
+        }
+        alert = {"type": "price", "token": "X", "direction": "above", "threshold_usd": 0.5}
+        out = alerts._check_alert(alert)
+        assert out["status"] == "fired"
+
+    def test_wallet_dispatch(self, fake_basescan):
+        fake_basescan["tokentx"] = {"status": "0"}
+        alert = {"type": "wallet", "wallet": "0x" + "a" * 40, "last_seen_block": 0}
+        assert alerts._check_alert(alert) is None
+
+
+# ── tick / runner ──────────────────────────────────────────────────
+
+
+class TestRunner:
+    def test_no_active_alerts(self, tmp_state):
+        assert alerts._run_due_sync() == 0
+
+    def test_paused_skipped(self, tmp_state, fake_defi_price):
+        fake_defi_price["payload"] = {
+            "isError": False,
+            "details": {"price_usd": 1.0},
+        }
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        alerts._cmd_mutate("u", [aid], status="paused", verb="paused")
+        assert alerts._run_due_sync() == 0
+
+    def test_price_fires_and_auto_deactivates(self, tmp_state, fake_defi_price):
+        fake_defi_price["payload"] = {
+            "isError": False,
+            "details": {"price_usd": 1.0},
+        }
+        _add_price()
+        n = alerts._run_due_sync()
+        assert n == 1
+        s = alerts._load_state()
+        # Auto-deactivated after firing.
+        assert s["alerts"][0]["status"] == "fired"
+        assert len(s["alerts"][0]["fires"]) == 1
+
+    def test_wallet_fire_does_not_deactivate(self, tmp_state, fake_basescan, monkeypatch):
+        _add_wallet(monkeypatch=monkeypatch)
+        wallet = alerts._load_state()["alerts"][0]["wallet"]
+        fake_basescan["tokentx"] = {
+            "status": "1",
+            "result": [{"to": wallet, "contractAddress": "0x" + "T" * 40, "blockNumber": "2000"}],
+        }
+        n = alerts._run_due_sync()
+        assert n == 1
+        s = alerts._load_state()
+        # Wallet alert stays active so it keeps firing on new txs.
+        assert s["alerts"][0]["status"] == "active"
+        assert s["alerts"][0]["last_seen_block"] == 2000
+
+    def test_runner_swallows_exceptions(self, tmp_state, monkeypatch):
+        _add_price()
+
+        def _boom(_alert):
+            raise RuntimeError("price service down")
+
+        monkeypatch.setattr(alerts, "_check_alert", _boom)
+        n, lines = alerts._run_due_with_lines()
+        assert n == 0
+        assert any("error" in line for line in lines)
+
+
+class TestManualTick:
+    async def test_no_fires(self, tmp_state):
+        out = await alerts._cmd_tick()
+        assert "No alerts fired" in out
+
+    async def test_with_fires(self, tmp_state, fake_defi_price):
+        fake_defi_price["payload"] = {
+            "isError": False,
+            "details": {"price_usd": 1.0},
+        }
+        _add_price()
+        out = await alerts._cmd_tick()
+        assert "Fired 1" in out
+
+
+# ── /alerts status ─────────────────────────────────────────────────
+
+
+class TestStatus:
+    def test_empty(self, tmp_state):
+        assert "idle" in alerts._cmd_status("u")
+
+    def test_summarizes(self, tmp_state, monkeypatch):
+        _add_price("alice")
+        _add_wallet("bob", monkeypatch=monkeypatch)
+        s = alerts._load_state()
+        s["alerts"][0]["fires"] = [{"at": "x", "detail": "y"}]
+        alerts._save_state(s)
+        out = alerts._cmd_status("u")
+        assert "2 alert(s)" in out
+        assert "price=1" in out
+        assert "wallet=1" in out
+        assert "Total fires:  1" in out
+
+    def test_service_health_swallowed(self, monkeypatch, tmp_state):
+        import clawmes.services.alerts_scheduler as svc_mod
+
+        monkeypatch.setattr(
+            svc_mod,
+            "get_alerts_scheduler_service",
+            lambda: (_ for _ in ()).throw(RuntimeError("svc down")),
+        )
+        _add_price()
+        out = alerts._cmd_status("u")
+        assert "Service:" not in out
+
+    def test_service_health_present(self, tmp_state):
+        from clawmes.services import alerts_scheduler as svc_mod
+
+        svc_mod._reset_for_tests()
+        svc = svc_mod.get_alerts_scheduler_service()
+        svc.start()
+        try:
+            _add_price()
+            out = alerts._cmd_status("u")
+            assert "Service:" in out
+            assert "running" in out
+        finally:
+            svc.stop()
+            svc_mod._reset_for_tests()
+
+
+# ── /alerts history ────────────────────────────────────────────────
+
+
+class TestHistory:
+    def test_usage(self, tmp_state):
+        assert "Usage:" in alerts._cmd_history("u", [])
+
+    def test_not_found(self, tmp_state):
+        assert "No alert" in alerts._cmd_history("u", ["alert_xxx"])
+
+    def test_no_fires(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        assert "no fires" in alerts._cmd_history("u", [aid])
+
+    def test_with_fires(self, tmp_state):
+        out = _add_price()
+        aid = next(w for w in out.split() if w.startswith("alert_"))
+        s = alerts._load_state()
+        s["alerts"][0]["fires"] = [
+            {"at": "2026-05-27T01:00:00Z", "detail": "x crossed y"},
+            {"at": "2026-05-27T02:00:00Z", "detail": "z"},
+        ]
+        alerts._save_state(s)
+        result = alerts._cmd_history("u", [aid])
+        assert "Fires for" in result
+        assert "crossed y" in result
+
+
+# ── handle_alerts (dispatch) ───────────────────────────────────────
+
+
+class TestHandle:
+    async def test_empty(self, tmp_state):
+        out = await alerts.handle_alerts("")
+        assert "Price + wallet alerts" in out
+
+    async def test_unknown(self, tmp_state):
+        out = await alerts.handle_alerts("garbage")
+        assert "Unknown subcommand" in out
+
+    async def test_add(self, tmp_state):
+        out = await alerts.handle_alerts("add price CLAWNCH above 0.0001")
+        assert "Alert added" in out
+
+    async def test_list(self, tmp_state):
+        out = await alerts.handle_alerts("list")
+        assert "No alerts" in out
+
+    async def test_ls_alias(self, tmp_state):
+        out = await alerts.handle_alerts("ls")
+        assert "No alerts" in out
+
+    async def test_pause(self, tmp_state):
+        out = await alerts.handle_alerts("pause alert_xxx")
+        assert "No alert" in out
+
+    async def test_resume(self, tmp_state):
+        out = await alerts.handle_alerts("resume alert_xxx")
+        assert "No alert" in out
+
+    async def test_cancel(self, tmp_state):
+        out = await alerts.handle_alerts("cancel alert_xxx")
+        assert "No alert" in out
+
+    async def test_rm_alias(self, tmp_state):
+        out = await alerts.handle_alerts("rm alert_xxx")
+        assert "No alert" in out
+
+    async def test_remove_alias(self, tmp_state):
+        out = await alerts.handle_alerts("remove alert_xxx")
+        assert "No alert" in out
+
+    async def test_edit(self, tmp_state):
+        out = await alerts.handle_alerts("edit alert_xxx direction below")
+        assert "No alert" in out
+
+    async def test_tick(self, tmp_state):
+        out = await alerts.handle_alerts("tick")
+        assert "No alerts" in out
+
+    async def test_status(self, tmp_state):
+        out = await alerts.handle_alerts("status")
+        assert "idle" in out
+
+    async def test_history(self, tmp_state):
+        out = await alerts.handle_alerts("history alert_xxx")
+        assert "No alert" in out
+
+    async def test_record_swallows(self, monkeypatch, tmp_state):
+        import clawmes.services.command_history as ch
+
+        def _boom(*a, **k):
+            raise RuntimeError("hist broken")
+
+        monkeypatch.setattr(ch, "record_command_call", _boom)
+        out = await alerts.handle_alerts("")
+        assert "Price" in out
+
+
+# ── register ───────────────────────────────────────────────────────
+
+
+class TestRegister:
+    def test_register(self):
+        registered: list[dict] = []
+
+        class Ctx:
+            def register_command(self, **kwargs):
+                registered.append(kwargs)
+
+        alerts.register(Ctx())
+        assert len(registered) == 1
+        assert registered[0]["name"] == "alerts"

--- a/tests/commands/test_token_gating.py
+++ b/tests/commands/test_token_gating.py
@@ -1,0 +1,132 @@
+"""Tests that exercise the v0.9.0 token-gating branches in
+``/dca``, ``/copy``, and ``/agent``.
+
+The conftest autouse fixture patches the gate helpers to always-pass
+for the existing test suite. These tests selectively patch them to
+return errors so we exercise the rejection branches in each command's
+``_cmd_add`` (or, for ``/agent``, ``_cmd_parse``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.commands import agent_plan, copy, dca
+
+
+@pytest.fixture(autouse=True)
+def _clear_drafts():
+    agent_plan._reset_for_tests()
+    yield
+    agent_plan._reset_for_tests()
+
+
+@pytest.fixture
+def tmp_dca_state(tmp_path, monkeypatch):
+    p = tmp_path / "schedules.json"
+    monkeypatch.setattr(dca, "_schedules_path", lambda: p)
+    return p
+
+
+@pytest.fixture
+def tmp_copy_state(tmp_path, monkeypatch):
+    p = tmp_path / "follows.json"
+    monkeypatch.setattr(copy, "_follows_path", lambda: p)
+    return p
+
+
+# ── /dca rejection paths ───────────────────────────────────────────
+
+
+class TestDcaCapRejection:
+    def test_cap_blocks_add(self, tmp_dca_state, monkeypatch):
+        """When check_cap_or_error returns a string, /dca add bails."""
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(
+            tg,
+            "check_cap_or_error",
+            lambda *a, **k: "Free tier allows 1 active DCA schedule(s).",
+        )
+        out = dca._cmd_add("u", ["0x" + "a" * 40, "0.01", "1h"])
+        assert "Free tier allows" in out
+
+
+class TestDcaSafeguardGate:
+    def test_safeguard_flag_blocks_free_tier(self, tmp_dca_state, monkeypatch):
+        """Passing --slippage on free tier triggers the HOLDER gate."""
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(
+            tg,
+            "check_tier_or_error",
+            lambda *a, **k: "feature requires holding at least 10,000 $CLAWNCH.",
+        )
+        out = dca._cmd_add("u", ["0x" + "a" * 40, "0.01", "1h", "--slippage", "50"])
+        assert "requires holding at least" in out
+
+    def test_no_safeguard_flags_bypasses_gate(self, tmp_dca_state, monkeypatch):
+        """A free-tier add without safeguard flags should NOT call the tier gate."""
+        import clawmes.services.token_gate as tg
+
+        called = {"n": 0}
+
+        def _spy(*a, **k):
+            called["n"] += 1
+            return "should not be hit"
+
+        monkeypatch.setattr(tg, "check_tier_or_error", _spy)
+        out = dca._cmd_add("u", ["0x" + "a" * 40, "0.01", "1h"])
+        assert "Schedule added" in out
+        assert called["n"] == 0
+
+
+# ── /copy rejection paths ──────────────────────────────────────────
+
+
+class TestCopyCapRejection:
+    def test_cap_blocks_add(self, tmp_copy_state, monkeypatch):
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(
+            tg,
+            "check_cap_or_error",
+            lambda *a, **k: "Free tier allows 1 active copy follow(s).",
+        )
+        monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
+        out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001"])
+        assert "Free tier allows" in out
+
+
+# ── /agent rejection paths ─────────────────────────────────────────
+
+
+class TestAgentMultiStepGate:
+    def test_multi_step_blocks_free_tier(self, monkeypatch):
+        """A 2-step prompt on free tier returns the gate error."""
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(
+            tg,
+            "check_tier_or_error",
+            lambda *a, **k: "/agent multi-step requires holding at least 10,000 $CLAWNCH.",
+        )
+        out = agent_plan._cmd_parse("u", "claim my fees then burn 1000000")
+        assert "requires holding" in out
+        # Draft NOT stored since the gate rejected.
+        assert "u" not in agent_plan._DRAFTS
+
+    def test_single_step_bypasses_gate(self, monkeypatch):
+        """Single-step prompts on free tier don't call the gate."""
+        import clawmes.services.token_gate as tg
+
+        called = {"n": 0}
+
+        def _spy(*a, **k):
+            called["n"] += 1
+            return "should not be hit"
+
+        monkeypatch.setattr(tg, "check_tier_or_error", _spy)
+        out = agent_plan._cmd_parse("u", "claim my fees")
+        assert "Plan parsed" in out
+        assert called["n"] == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,3 +54,21 @@ class FakePluginContext:
 @pytest.fixture
 def mock_ctx() -> FakePluginContext:
     return FakePluginContext()
+
+
+@pytest.fixture(autouse=True)
+def _default_holder_tier(monkeypatch):
+    """Default every test to HOLDER tier with no caps.
+
+    Token gating landed in v0.9.0 — most existing tests pre-date it and
+    don't care about the gate, so the autouse fixture short-circuits both
+    check helpers. Tests that specifically want to exercise the gate
+    re-patch these (or call ``token_gate._reset_for_tests()``) themselves.
+    """
+    try:
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(tg, "check_tier_or_error", lambda *a, **k: None)
+        monkeypatch.setattr(tg, "check_cap_or_error", lambda *a, **k: None)
+    except ImportError:
+        pass

--- a/tests/services/test_alerts_scheduler.py
+++ b/tests/services/test_alerts_scheduler.py
@@ -1,0 +1,102 @@
+"""Tests for the alerts-scheduler service."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.services import alerts_scheduler
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    alerts_scheduler._reset_for_tests()
+    yield
+    alerts_scheduler._reset_for_tests()
+
+
+class TestSingleton:
+    def test_same_instance(self):
+        a = alerts_scheduler.get_alerts_scheduler_service()
+        b = alerts_scheduler.get_alerts_scheduler_service()
+        assert a is b
+
+    def test_reset(self):
+        a = alerts_scheduler.get_alerts_scheduler_service()
+        alerts_scheduler._reset_for_tests()
+        b = alerts_scheduler.get_alerts_scheduler_service()
+        assert a is not b
+
+
+class TestLifecycle:
+    def test_start_stop(self):
+        svc = alerts_scheduler.get_alerts_scheduler_service()
+        assert svc._running is False
+        svc.start()
+        assert svc._running is True
+        svc.stop()
+        assert svc._running is False
+
+    def test_health_shape(self):
+        svc = alerts_scheduler.get_alerts_scheduler_service()
+        h = svc.health()
+        assert h["id"] == "clawmes.alerts_scheduler"
+        assert h["status"] == "stopped"
+        assert h["ticks"] == 0
+
+    def test_health_running(self):
+        svc = alerts_scheduler.get_alerts_scheduler_service()
+        svc.start()
+        assert svc.health()["status"] == "running"
+
+
+class TestTick:
+    def test_skipped_when_not_running(self, monkeypatch):
+        from clawmes.commands import alerts as alerts_mod
+
+        called = {"n": 0}
+
+        def _spy():
+            called["n"] += 1
+            return 0
+
+        monkeypatch.setattr(alerts_mod, "_run_due_sync", _spy)
+        svc = alerts_scheduler.get_alerts_scheduler_service()
+        svc.tick()
+        assert called["n"] == 0
+
+    def test_runs_when_started(self, monkeypatch):
+        from clawmes.commands import alerts as alerts_mod
+
+        monkeypatch.setattr(alerts_mod, "_run_due_sync", lambda: 2)
+        svc = alerts_scheduler.get_alerts_scheduler_service()
+        svc.start()
+        svc.tick()
+        assert svc._ticks == 1
+        assert svc._last_runs == 2
+        assert svc._total_runs == 2
+
+    def test_swallows_errors(self, monkeypatch):
+        from clawmes.commands import alerts as alerts_mod
+
+        def _boom():
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(alerts_mod, "_run_due_sync", _boom)
+        svc = alerts_scheduler.get_alerts_scheduler_service()
+        svc.start()
+        svc.tick()
+        assert svc._ticks == 1
+        assert svc._last_runs == 0
+        assert svc._total_runs == 0
+
+    def test_accumulates(self, monkeypatch):
+        from clawmes.commands import alerts as alerts_mod
+
+        runs = iter([1, 0, 3])
+        monkeypatch.setattr(alerts_mod, "_run_due_sync", lambda: next(runs))
+        svc = alerts_scheduler.get_alerts_scheduler_service()
+        svc.start()
+        for _ in range(3):
+            svc.tick()
+        assert svc._total_runs == 4
+        assert svc._last_runs == 3

--- a/tests/services/test_token_gate.py
+++ b/tests/services/test_token_gate.py
@@ -1,0 +1,257 @@
+"""Tests for the token-gate service."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.services import token_gate
+
+
+@pytest.fixture(autouse=True)
+def _disable_default_holder_fixture(monkeypatch):
+    """Opt OUT of the conftest autouse HOLDER-tier patch for these tests.
+
+    The conftest fixture monkeypatches ``check_tier_or_error`` and
+    ``check_cap_or_error`` to always-pass for the existing test suite.
+    These tests specifically want to exercise the real gate, so we
+    restore the originals.
+    """
+    # The conftest fixture has already run by the time we get here — undo it.
+    monkeypatch.undo()
+    token_gate._reset_for_tests()
+    yield
+    token_gate._reset_for_tests()
+
+
+# ── singleton + lifecycle ──────────────────────────────────────────
+
+
+class TestSingleton:
+    def test_same_instance(self):
+        a = token_gate.get_token_gate_service()
+        b = token_gate.get_token_gate_service()
+        assert a is b
+
+    def test_reset(self):
+        a = token_gate.get_token_gate_service()
+        token_gate._reset_for_tests()
+        b = token_gate.get_token_gate_service()
+        assert a is not b
+
+
+class TestLifecycle:
+    def test_start_stop(self):
+        svc = token_gate.get_token_gate_service()
+        assert svc._running is False
+        svc.start()
+        assert svc._running is True
+        svc.stop()
+        assert svc._running is False
+
+    def test_health(self):
+        svc = token_gate.get_token_gate_service()
+        h = svc.health()
+        assert h["id"] == "clawmes.token_gate"
+        assert h["threshold_clawnch"] == token_gate.HOLDER_THRESHOLD
+        assert h["status"] == "stopped"
+        svc.start()
+        assert svc.health()["status"] == "running"
+
+
+# ── resolve_tier ────────────────────────────────────────────────────
+
+
+class TestResolveTier:
+    def test_no_address_is_free(self):
+        svc = token_gate.get_token_gate_service()
+        tier, bal = svc.resolve_tier(None)
+        assert tier == token_gate.Tier.FREE
+        assert bal == 0
+
+    def test_empty_address_is_free(self):
+        svc = token_gate.get_token_gate_service()
+        tier, bal = svc.resolve_tier("")
+        assert tier == token_gate.Tier.FREE
+
+    def test_holder_above_threshold(self, monkeypatch):
+        # Mock balance reader to return 11k $CLAWNCH (above the 10k threshold).
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 11_000 * (10**18))
+        svc = token_gate.get_token_gate_service()
+        tier, bal = svc.resolve_tier("0x" + "a" * 40)
+        assert tier == token_gate.Tier.HOLDER
+        assert bal == 11_000 * (10**18)
+
+    def test_free_below_threshold(self, monkeypatch):
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 5_000 * (10**18))
+        svc = token_gate.get_token_gate_service()
+        tier, _ = svc.resolve_tier("0x" + "a" * 40)
+        assert tier == token_gate.Tier.FREE
+
+    def test_cache_hit_skips_rpc(self, monkeypatch):
+        calls = {"n": 0}
+
+        def _spy(_addr):
+            calls["n"] += 1
+            return 11_000 * (10**18)
+
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", _spy)
+        svc = token_gate.get_token_gate_service()
+        svc.resolve_tier("0x" + "a" * 40)
+        svc.resolve_tier("0x" + "A" * 40)  # different casing, same key
+        assert calls["n"] == 1
+
+    def test_invalidate_drops_cache(self, monkeypatch):
+        balances = iter([11_000 * (10**18), 9_000 * (10**18)])
+
+        def _read(_addr):
+            return next(balances)
+
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", _read)
+        svc = token_gate.get_token_gate_service()
+        tier1, _ = svc.resolve_tier("0x" + "a" * 40)
+        svc.invalidate("0x" + "A" * 40)
+        tier2, _ = svc.resolve_tier("0x" + "a" * 40)
+        assert tier1 == token_gate.Tier.HOLDER
+        assert tier2 == token_gate.Tier.FREE
+
+    def test_invalidate_none_address_is_noop(self):
+        svc = token_gate.get_token_gate_service()
+        # Should not raise.
+        svc.invalidate(None)
+        svc.invalidate("")
+
+
+# ── _read_clawnch_balance ──────────────────────────────────────────
+
+
+class TestReadBalance:
+    def test_rpc_error_returns_zero(self, monkeypatch):
+        import clawmes.services.rpc as rpc_mod
+
+        class _Boom:
+            def eth_call(self, **kw):
+                raise RuntimeError("rpc down")
+
+        monkeypatch.setattr(rpc_mod, "get_rpc_service", lambda: _Boom())
+        assert token_gate._read_clawnch_balance("0x" + "a" * 40) == 0
+
+    def test_success(self, monkeypatch):
+        import clawmes.services.rpc as rpc_mod
+        from clawmes.lib.abi import encode_uint
+
+        class _Fake:
+            def eth_call(self, **kw):
+                # 100 tokens at 18 decimals.
+                return "0x" + encode_uint(100 * (10**18))
+
+        monkeypatch.setattr(rpc_mod, "get_rpc_service", lambda: _Fake())
+        assert token_gate._read_clawnch_balance("0x" + "a" * 40) == 100 * (10**18)
+
+    def test_bad_response_returns_zero(self, monkeypatch):
+        import clawmes.services.rpc as rpc_mod
+
+        class _Bad:
+            def eth_call(self, **kw):
+                return "not-a-hex-uint"
+
+        monkeypatch.setattr(rpc_mod, "get_rpc_service", lambda: _Bad())
+        assert token_gate._read_clawnch_balance("0x" + "a" * 40) == 0
+
+
+# ── check_tier_or_error ────────────────────────────────────────────
+
+
+class TestCheckTierOrError:
+    def test_free_tier_always_passes(self):
+        assert token_gate.check_tier_or_error(token_gate.Tier.FREE, feature="x") is None
+
+    def test_holder_required_no_wallet(self, monkeypatch):
+        # No wallet → free → error with the "no wallet" hint.
+        monkeypatch.setattr(token_gate, "_active_wallet_address", lambda: None)
+        out = token_gate.check_tier_or_error(token_gate.Tier.HOLDER, feature="thing")
+        assert "thing requires" in out
+        assert "No wallet connected" in out
+        assert "/connect" in out
+
+    def test_holder_required_below_threshold(self, monkeypatch):
+        monkeypatch.setattr(token_gate, "_active_wallet_address", lambda: "0x" + "a" * 40)
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 5_000 * (10**18))
+        out = token_gate.check_tier_or_error(token_gate.Tier.HOLDER, feature="thing")
+        assert "5,000 $CLAWNCH" in out
+        assert "5,000 more" in out
+
+    def test_holder_above_threshold_passes(self, monkeypatch):
+        monkeypatch.setattr(token_gate, "_active_wallet_address", lambda: "0x" + "a" * 40)
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 50_000 * (10**18))
+        assert token_gate.check_tier_or_error(token_gate.Tier.HOLDER, feature="thing") is None
+
+
+# ── check_cap_or_error ─────────────────────────────────────────────
+
+
+class TestCheckCapOrError:
+    def test_unknown_command_passes(self):
+        out = token_gate.check_cap_or_error("garbage", active_count=99, feature="x")
+        assert out is None
+
+    def test_below_cap_passes(self):
+        out = token_gate.check_cap_or_error("dca", active_count=0, feature="schedule")
+        assert out is None
+
+    def test_at_cap_holder_passes(self, monkeypatch):
+        monkeypatch.setattr(token_gate, "_active_wallet_address", lambda: "0x" + "a" * 40)
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 11_000 * (10**18))
+        assert token_gate.check_cap_or_error("dca", active_count=1, feature="schedule") is None
+
+    def test_at_cap_free_blocked(self, monkeypatch):
+        monkeypatch.setattr(token_gate, "_active_wallet_address", lambda: None)
+        out = token_gate.check_cap_or_error("dca", active_count=1, feature="schedule")
+        assert "Free tier allows 1 active schedule" in out
+        assert "10,000+ $CLAWNCH" in out
+
+
+# ── free_tier_cap ──────────────────────────────────────────────────
+
+
+class TestFreeTierCap:
+    def test_known(self):
+        assert token_gate.free_tier_cap("dca") == 1
+        assert token_gate.free_tier_cap("copy") == 1
+        assert token_gate.free_tier_cap("alerts") == 3
+
+    def test_unknown(self):
+        assert token_gate.free_tier_cap("garbage") is None
+
+
+# ── _active_wallet_address ─────────────────────────────────────────
+
+
+class TestActiveWalletAddress:
+    def test_no_wallet_returns_none(self, monkeypatch):
+        import clawmes.services.wallet as wallet_mod
+
+        class _Disc:
+            connected = False
+            address = ""
+
+        monkeypatch.setattr(wallet_mod, "get_wallet_state", lambda: _Disc())
+        assert token_gate._active_wallet_address() is None
+
+    def test_connected_returns_address(self, monkeypatch):
+        import clawmes.services.wallet as wallet_mod
+
+        class _Conn:
+            connected = True
+            address = "0xabc"
+
+        monkeypatch.setattr(wallet_mod, "get_wallet_state", lambda: _Conn())
+        assert token_gate._active_wallet_address() == "0xabc"
+
+    def test_exception_returns_none(self, monkeypatch):
+        import clawmes.services.wallet as wallet_mod
+
+        def _boom():
+            raise RuntimeError("wallet service down")
+
+        monkeypatch.setattr(wallet_mod, "get_wallet_state", _boom)
+        assert token_gate._active_wallet_address() is None


### PR DESCRIPTION
## Summary

Two surfaces shipping together:

### Token gating (`clawmes/services/token_gate.py`)

Power features unlock at HOLDER tier — any wallet holding **10,000+ \$CLAWNCH** (~\$0.10).

| Feature | Free | Holder |
|---|---|---|
| `/dca` schedules | 1 active | unlimited |
| `/dca` safeguard flags (\`--slippage\`, \`--daily-cap\`, \`--max-total\`, \`--max-failures\`) | blocked | unlocked |
| `/copy` follows | 1 active | unlimited |
| `/agent` prompts | single-step only | multi-step with \`then\` |
| `/alerts` | 3 active | unlimited |

- Lazy `eth_call` to `balanceOf`, 60s cache to avoid hammering RPC.
- Never crashes on RPC blip — transient failures fall back to free tier.
- `check_tier_or_error` + `check_cap_or_error` helpers return human-readable error strings with exact balance shortfall + how-to-buy hints.

### `/alerts`

Price + wallet activity alerts. **Notification-only** — no transactions submitted, no wallet required.

- `/alerts add price <token> <above|below> <usd>` — polls \`defi_price\` on registry tick; auto-deactivates after firing.
- `/alerts add wallet <address>` — polls Basescan \`tokentx\` like \`/copy\`; stays active and re-fires on each new tx.
- Full mutation surface: \`list\` \`pause\` \`resume\` \`cancel\` \`edit\` \`tick\` \`status\` \`history\` — same as \`/dca\` + \`/copy\`.
- \`AlertsSchedulerService\` (id \`clawmes.alerts_scheduler\`) ticks on registry cadence (~60s). Per-alert errors caught internally so one bad alert can't crash the loop.

## Why this combo

- **Token gating drives \$CLAWNCH demand from clawmes users.** Must hold 10k to unlock the good stuff. Direct buy pressure on the token, no treasury cost.
- **`/alerts` is a no-tx free-tier hook.** Free users get 3 active alerts — meaningful enough to come back for, capped enough that upgrading to holder feels worth it.
- **Both share the safeguard / mutation pattern.** Same vocabulary as `/dca` v2 and `/copy` — predictable UX across the recurring-features family.

## Testing

- 3660 tests pass (was 3513) — 147 new tests across token-gate service, alerts command, alerts-scheduler, plus targeted rejection-path tests for the new gates in \`/dca\` \`/copy\` \`/agent\`.
- 100% line coverage maintained on every file and on the project overall.
- \`ruff check\` + \`ruff format --check\` clean.
- Plugin yamls byte-identical.
- Version: \`_version.py\`, \`pyproject.toml\`, both \`plugin.yaml\` → 0.9.0.
- \`tests/conftest.py\` autouse fixture patches the gate helpers to always-pass for the existing test suite; new tests selectively override to exercise rejection branches.

## What's NOT in this PR (per instruction)

- Phase 1 buy-burn cron — defers treasury → \$CLAWNCH conversion.
- Burner leaderboard aggregator — backend work, queued.