### PR TITLE
chore(token-gate): raise HOLDER threshold 10k → 10M $CLAWNCH (v0.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.10.1 — 2026-05-27
+
+### Changed — HOLDER tier threshold raised 10k → 10M $CLAWNCH
+
+The token-gating threshold moves from 10,000 $CLAWNCH (~$0.10) to
+**10,000,000 $CLAWNCH** (~$105 at session-time price). The previous
+threshold was too low to function as a meaningful commitment signal —
+anyone could clear it for less than a coffee. The 10M threshold puts
+the HOLDER tier in the same conviction range as actually deploying a
+token through the launchpad (which requires the same 1M+ burn).
+
+What this changes:
+- Wallets between 10k–10M $CLAWNCH that were previously HOLDER tier
+  are now free tier. They still get every command, just with the
+  documented free-tier caps: 1 active `/dca`, 1 active `/copy`, 3
+  active `/alerts`, 1 active `/limit_order`, no `/dca` safeguard
+  flags, no `/copy --pct`, no `/agent` multi-step.
+- Existing schedules / follows / orders on those wallets keep
+  running. Caps only bite on the next `add` attempt.
+
+Why now: the gate exists to drive $CLAWNCH demand from clawmes power
+users. At 10k it was symbolic. At 10M it's signal.
+
+### Internal
+
+- `clawmes/services/token_gate.py`: `HOLDER_THRESHOLD = 10_000_000`.
+- Tests updated to use 5M / 11M / 50M values straddling the new
+  threshold.
+- 3831 tests pass at 100% coverage (unchanged).
+
 ## 0.10.0 — 2026-05-27
 
 ### Added — trader power-pack: `/portfolio` v2 + `/limit_order` + multi-wallet + `/copy --pct`

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Multi-step prompts join with `then` (bare commas would split numbers like `1,000
 
 `/alerts` is notification-only — no transactions submitted, no wallet required. Price alerts auto-deactivate after firing (so a crossing doesn't repeatedly notify on every subsequent tick). Wallet alerts stay active and re-fire on each new tx because `last_seen_block` advances past the seen receipt. `AlertsSchedulerService` polls on the registry cadence (~60s).
 
-**Token gating.** Power features in `/dca`, `/copy`, `/agent`, and `/alerts` unlock at the `HOLDER` tier — any wallet holding 10,000+ $CLAWNCH (~$0.10). Free tier still gets each feature with these caps:
+**Token gating.** Power features in `/dca`, `/copy`, `/agent`, and `/alerts` unlock at the `HOLDER` tier — any wallet holding 10,000,000+ $CLAWNCH (~$105 at session-time price). Free tier still gets each feature with these caps:
 - 1 active `/dca` schedule (HOLDER: unlimited + safeguard flags)
 - 1 active `/copy` follow (HOLDER: unlimited)
 - 3 active `/alerts` (HOLDER: unlimited)

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.10.0
+version: 0.10.1
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/services/token_gate.py
+++ b/clawmes/services/token_gate.py
@@ -9,20 +9,20 @@ Two tiers in v1:
     schedule, 1 active ``/copy`` follow, 3 active ``/alerts``, no
     safeguard flags on ``/dca``.
 
-  * ``holder`` — any wallet holding **at least 10,000 $CLAWNCH**
-    (~$0.10 at session-time price). Unlocks:
+  * ``holder`` — any wallet holding **at least 10,000,000 $CLAWNCH**
+    (~$105 at session-time price). Unlocks:
       - Unlimited ``/dca`` schedules + safeguard flags (slippage,
         daily-cap, max-total, max-failures)
       - Unlimited ``/copy`` follows + advanced flags (blocklist, etc.)
       - ``/agent`` multi-step prompts (``then`` chains)
       - Unlimited ``/alerts``
 
-The gate is intentionally minimal: a single 10k threshold rather than
-a 4-tier ladder. Easy to reason about, easy to test, low barrier to
-becoming a holder so nobody who actually wants the power features is
-priced out. Threshold is reviewable in one place
-(:data:`HOLDER_THRESHOLD_WEI`) so we can adjust as the price moves
-without scattering magic numbers.
+The gate is intentionally minimal: a single 10M threshold rather than
+a 4-tier ladder. Easy to reason about, easy to test. The threshold
+is meaningful enough to signal real commitment to the ecosystem
+without being prohibitively expensive for serious users. Reviewable
+in one place (:data:`HOLDER_THRESHOLD_WEI`) so we can adjust as the
+price moves without scattering magic numbers.
 
 Implementation: each gated command imports
 :func:`check_tier_or_error` and calls it before touching state. The
@@ -49,11 +49,11 @@ _log = logger_for("services.token_gate")
 # as a tuple/list here and a "highest tier across all" resolution.
 CLAWNCH_ADDR = "0xa1F72459dfA10BAD200Ac160eCd78C6b77a747be"
 
-# Holder threshold: 10,000 $CLAWNCH at 18 decimals = 1e22 wei.
-# At session-time price of ~$0.0000105 / $CLAWNCH, this is ~$0.10 USD —
-# small enough to be aspirational for any actual user, large enough to
-# function as a real signal of "I'm in this ecosystem."
-HOLDER_THRESHOLD = 10_000
+# Holder threshold: 10,000,000 $CLAWNCH at 18 decimals = 1e25 wei.
+# At session-time price of ~$0.0000105 / $CLAWNCH, this is ~$105 USD —
+# meaningful enough to function as a real signal of commitment to the
+# ecosystem, accessible enough that any serious user can clear it.
+HOLDER_THRESHOLD = 10_000_000
 HOLDER_THRESHOLD_WEI = HOLDER_THRESHOLD * (10**18)
 
 # Cache TTL — balance reads hit the RPC, which is slow + rate-limited.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.10.0
+version: 0.10.1
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.10.0"
+version = "0.10.1"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_token_gating.py
+++ b/tests/commands/test_token_gating.py
@@ -60,7 +60,7 @@ class TestDcaSafeguardGate:
         monkeypatch.setattr(
             tg,
             "check_tier_or_error",
-            lambda *a, **k: "feature requires holding at least 10,000 $CLAWNCH.",
+            lambda *a, **k: "feature requires holding at least 10,000,000 $CLAWNCH.",
         )
         out = dca._cmd_add("u", ["0x" + "a" * 40, "0.01", "1h", "--slippage", "50"])
         assert "requires holding at least" in out
@@ -109,7 +109,7 @@ class TestAgentMultiStepGate:
         monkeypatch.setattr(
             tg,
             "check_tier_or_error",
-            lambda *a, **k: "/agent multi-step requires holding at least 10,000 $CLAWNCH.",
+            lambda *a, **k: "/agent multi-step requires holding at least 10,000,000 $CLAWNCH.",
         )
         out = agent_plan._cmd_parse("u", "claim my fees then burn 1000000")
         assert "requires holding" in out

--- a/tests/commands/test_v010_additions.py
+++ b/tests/commands/test_v010_additions.py
@@ -50,7 +50,7 @@ class TestCopyPctValidation:
         monkeypatch.setattr(
             tg,
             "check_tier_or_error",
-            lambda *a, **k: "/copy --pct requires holding at least 10,000 $CLAWNCH.",
+            lambda *a, **k: "/copy --pct requires holding at least 10,000,000 $CLAWNCH.",
         )
         monkeypatch.setattr(copy, "_current_block_height", lambda: 1000)
         out = copy._cmd_add("u", ["0x" + "a" * 40, "0.001", "--pct", "50"])

--- a/tests/services/test_token_gate.py
+++ b/tests/services/test_token_gate.py
@@ -74,15 +74,15 @@ class TestResolveTier:
         assert tier == token_gate.Tier.FREE
 
     def test_holder_above_threshold(self, monkeypatch):
-        # Mock balance reader to return 11k $CLAWNCH (above the 10k threshold).
-        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 11_000 * (10**18))
+        # Mock balance reader to return 11M $CLAWNCH (above the 10M threshold).
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 11_000_000 * (10**18))
         svc = token_gate.get_token_gate_service()
         tier, bal = svc.resolve_tier("0x" + "a" * 40)
         assert tier == token_gate.Tier.HOLDER
-        assert bal == 11_000 * (10**18)
+        assert bal == 11_000_000 * (10**18)
 
     def test_free_below_threshold(self, monkeypatch):
-        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 5_000 * (10**18))
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 5_000_000 * (10**18))
         svc = token_gate.get_token_gate_service()
         tier, _ = svc.resolve_tier("0x" + "a" * 40)
         assert tier == token_gate.Tier.FREE
@@ -92,7 +92,7 @@ class TestResolveTier:
 
         def _spy(_addr):
             calls["n"] += 1
-            return 11_000 * (10**18)
+            return 11_000_000 * (10**18)
 
         monkeypatch.setattr(token_gate, "_read_clawnch_balance", _spy)
         svc = token_gate.get_token_gate_service()
@@ -101,7 +101,7 @@ class TestResolveTier:
         assert calls["n"] == 1
 
     def test_invalidate_drops_cache(self, monkeypatch):
-        balances = iter([11_000 * (10**18), 9_000 * (10**18)])
+        balances = iter([11_000_000 * (10**18), 9_000_000 * (10**18)])
 
         def _read(_addr):
             return next(balances)
@@ -175,14 +175,14 @@ class TestCheckTierOrError:
 
     def test_holder_required_below_threshold(self, monkeypatch):
         monkeypatch.setattr(token_gate, "_active_wallet_address", lambda: "0x" + "a" * 40)
-        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 5_000 * (10**18))
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 5_000_000 * (10**18))
         out = token_gate.check_tier_or_error(token_gate.Tier.HOLDER, feature="thing")
-        assert "5,000 $CLAWNCH" in out
-        assert "5,000 more" in out
+        assert "5,000,000 $CLAWNCH" in out
+        assert "5,000,000 more" in out
 
     def test_holder_above_threshold_passes(self, monkeypatch):
         monkeypatch.setattr(token_gate, "_active_wallet_address", lambda: "0x" + "a" * 40)
-        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 50_000 * (10**18))
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 50_000_000 * (10**18))
         assert token_gate.check_tier_or_error(token_gate.Tier.HOLDER, feature="thing") is None
 
 
@@ -200,14 +200,14 @@ class TestCheckCapOrError:
 
     def test_at_cap_holder_passes(self, monkeypatch):
         monkeypatch.setattr(token_gate, "_active_wallet_address", lambda: "0x" + "a" * 40)
-        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 11_000 * (10**18))
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 11_000_000 * (10**18))
         assert token_gate.check_cap_or_error("dca", active_count=1, feature="schedule") is None
 
     def test_at_cap_free_blocked(self, monkeypatch):
         monkeypatch.setattr(token_gate, "_active_wallet_address", lambda: None)
         out = token_gate.check_cap_or_error("dca", active_count=1, feature="schedule")
         assert "Free tier allows 1 active schedule" in out
-        assert "10,000+ $CLAWNCH" in out
+        assert "10,000,000+ $CLAWNCH" in out
 
 
 # ── free_tier_cap ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The token-gating threshold for HOLDER tier moves from 10,000 \$CLAWNCH (~\$0.10 at session-time price) to **10,000,000 \$CLAWNCH** (~\$105).

## Why

10k was too low to function as a meaningful commitment signal. Anyone could clear it for less than a coffee. The 10M threshold puts the HOLDER tier in the same conviction range as actually deploying a token through the launchpad (which requires the same 1M+ burn for vault allocation).

The gate exists to drive \$CLAWNCH demand from clawmes power users. At 10k it was symbolic. At 10M it's signal.

## What changes

- Wallets between 10k–10M \$CLAWNCH that were previously HOLDER tier are now free tier.
- They still get every command, just with the documented free-tier caps:
  - 1 active `/dca`, 1 active `/copy`, 3 active `/alerts`, 1 active `/limit_order`
  - no `/dca` safeguard flags, no `/copy --pct`, no `/agent` multi-step prompts
- Existing schedules / follows / orders on those wallets keep running. Caps only bite on the next `add` attempt.

## Testing

- 3831 tests pass at 100% coverage (unchanged from v0.10.0).
- Test values updated to use 5M / 11M / 50M straddling the new threshold.
- `ruff check` + `ruff format --check` clean.
- Plugin yamls byte-identical.
- Version: `_version.py`, `pyproject.toml`, both `plugin.yaml` → 0.10.1.