### PR TITLE
feat(commands): Clawmes Unlimited tier + /sniper + /agent --ai (v0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,58 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.11.0 — 2026-05-27
+
+### Added — Clawmes Unlimited: autopilot tier + `/sniper` + `/agent --ai`
+
+A new top tier and two extreme features that live behind it.
+
+- **`UNLIMITED` tier** — any wallet holding **100,000,000+ $CLAWNCH**
+  (~$1,050 at session-time price). Sits above `HOLDER` (10M+) and
+  unlocks autopilot features that go beyond what a normal trader
+  needs. The Tier enum is now ordered (FREE=0 < HOLDER=1 <
+  UNLIMITED=2); checks use `tier.value >= required.value` so an
+  UNLIMITED holder automatically passes any HOLDER gate.
+
+- **`/sniper`** — auto-buy newly-launched Clawnch tokens.
+  - `/sniper add <eth_amount> [--max-buys N] [--source X]
+    [--symbol-filter <regex>] [--max-mcap <usd>] [--max-age <seconds>]
+    [--slippage <bps>]`
+  - Watches `/api/launches` on the registry tick. Any new launch
+    matching the filters triggers a `defi_swap` buy at the configured
+    ETH amount.
+  - Filters compose: source attribution (`clawmes` / `clawncher` /
+    `4claw` / `moltbook`), symbol regex, max market cap, max age
+    (default 10min — older launches are presumed already sniped).
+  - Auto-exhausts after `--max-buys` snipes (default 10). Per-snipe
+    slippage cap. Per-config errors caught internally.
+  - `SniperSchedulerService` (id `clawmes.sniper_scheduler`) drives
+    the loop. UNLIMITED tier required to `/sniper add`.
+
+- **`/agent --ai`** — LLM fallback for prompts the regex parser can't
+  understand. Layered on top of the existing intent matcher: regex
+  runs first, the LLM only sees segments that didn't match.
+  - The LLM is constrained to rewrite each segment as one of the
+    supported phrasings; rewrites are re-validated through `_parse_one`
+    so the LLM can't invent new commands.
+  - Powered by the existing OpenGateway service. Falls back gracefully
+    when OpenGateway is unreachable / errors — original "couldn't
+    parse" message displays.
+  - UNLIMITED tier required.
+
+### Internal
+
+- `clawmes/services/token_gate.py` — `UNLIMITED_THRESHOLD =
+  100_000_000` constant added. Tier enum reordered (now numeric values
+  for ranked comparison). `_TIER_THRESHOLD_TOKENS` + `_TIER_LABELS`
+  internal maps so error messages mention "Holder tier" vs "Clawmes
+  Unlimited" correctly.
+- `clawmes/commands/sniper.py` + `clawmes/services/sniper_scheduler.py`.
+- `clawmes/commands/agent_plan.py` extended with `_llm_extract` +
+  `_extract_llm_text` helpers and `use_ai` parameter on `_cmd_parse`.
+- 3984 tests pass at 100% coverage (was 3831). README counts: 88 →
+  89 commands, 28 → 29 services.
+
 ## 0.10.1 — 2026-05-27
 
 ### Changed — HOLDER tier threshold raised 10k → 10M $CLAWNCH

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Clawmes is a [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin. Wallets, DEX trading, lending and staking, governance, on-chain automation. Python rewrite of [`@clawnch/openclaw-crypto`](https://github.com/clawnchdev/openclawnch) targeting Hermes.
 
-52 tools. 88 commands. 28 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
+52 tools. 89 commands. 29 services. 11 hooks. Runs on Telegram, Discord, Slack, Signal, WhatsApp, iMessage, and LINE.
 
 ## Quick start
 
@@ -68,7 +68,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 
 ## Commands
 
-88 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
+89 slash commands across 16 categories. Commands run synchronously without invoking the LLM, so they're cheap and predictable.
 
 | Category | Commands |
 |---|---|
@@ -79,7 +79,7 @@ Releases publish to PyPI automatically via [Trusted Publishing](https://docs.pyp
 | **Plans & triggers** (10) | `/plans` `/plan` `/plan_logs` `/interrupt_plan` `/pause_plan` `/resume_plan` `/triggers` `/watch` `/unwatch` `/cron` |
 | **Onboarding** (19) | `/welcome`, 5 personas (`/professional` `/degen` `/chill` `/technical` `/mentor`), 10 capability toggles (`/cap_wallet` `/cap_prices` `/cap_portfolio` `/cap_trading` `/cap_liquidity` `/cap_launchpad` `/cap_bridge` `/cap_routing` `/cap_clawnx` `/cap_hummingbot`), `/skip` `/back` `/reonboard` |
 | **Balance & portfolio** (2) | `/balance` `/portfolio` |
-| **Trading & discovery** (12) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` `/leaderboard` `/claim` `/dca` `/copy` `/agent` `/alerts` `/limit_order` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link, top tokens/launchers/burners, sweep accumulated LP fees, dollar-cost averaging, copy-trade a wallet's buys, NL plan compiler, price + wallet activity alerts, limit buys + take-profit sells |
+| **Trading & discovery** (13) | `/buy` `/trending` `/my_launches` `/burn` `/onramp` `/leaderboard` `/claim` `/dca` `/copy` `/agent` `/alerts` `/limit_order` `/sniper` — quote-then-confirm swaps via 0x, hot tokens on Base, list your launches, burn $CLAWNCH for Clanker vault %, Coinbase Onramp deep link, top tokens/launchers/burners, sweep accumulated LP fees, dollar-cost averaging, copy-trade a wallet's buys, NL plan compiler, price + wallet activity alerts, limit buys + take-profit sells, auto-buy newly-launched tokens (Clawmes Unlimited) |
 | **Self-evolution** (3) | `/evolve` `/stable` `/evolution` — gates `agent_memory` and `skill_evolve` write actions; OFF by default |
 | **Endpoint allowlist** (3) | `/allowlist` `/allow` `/disallow` — session-scoped host allowlist + 100-entry block audit ring |
 | **Discoverability** (5) | `/skills` `/persona` `/chains` `/tools_list` `/safety_status` |
@@ -349,6 +349,25 @@ Multi-step prompts join with `then` (bare commas would split numbers like `1,000
 - `/agent` single-step prompts (HOLDER: multi-step with `then` chains)
 
 The gate reads your active wallet's $CLAWNCH balance via `eth_call`, caches the result for 60s, and never crashes a command on RPC error (transient failures fall back to free tier). Implementation in `clawmes/services/token_gate.py`.
+
+### Clawmes Unlimited (v0.11.0)
+
+A third tier above HOLDER for the most aggressive features. Hold **100,000,000+ $CLAWNCH** (~$1,050 at session-time price) to unlock:
+
+```
+/sniper add 0.005 --max-buys 5 --source clawmes --symbol-filter DOG|CAT
+                            # auto-buy new Clawnch launches matching filters
+/sniper add 0.01 --max-age 60 --slippage 200
+                            # snipe any launch < 60s old at 2% slippage
+/sniper list / pause / resume / cancel / edit / history / status
+
+/agent --ai sweep my LP rewards then buy some clawnch
+                            # LLM fallback when the regex parser can't match
+                            # (regex runs first; LLM only sees what didn't parse)
+```
+
+- **`/sniper`** watches `/api/launches` on the registry tick and fires `defi_swap` buys for any newly-detected launch matching the configured filters. Filters compose: `--source` attribution, `--symbol-filter` regex, `--max-mcap` skip threshold, `--max-age` recency window (default 10min — older launches are presumed already sniped). Auto-exhausts after `--max-buys` (default 10) so a runaway launchpad can't drain your wallet. `SniperSchedulerService` drives the loop.
+- **`/agent --ai`** layers on top of the existing intent matcher. The regex parser runs first; the LLM only sees segments that didn't match. Rewrites are re-validated through the same `_parse_one` path so the LLM can't smuggle invented commands. Powered by OpenGateway; falls back gracefully when OpenGateway errors.
 
 ### Trader power-pack (v0.10.0)
 

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"

--- a/clawmes/commands/__init__.py
+++ b/clawmes/commands/__init__.py
@@ -37,6 +37,7 @@ from clawmes.commands import (
     onramp,
     plans,
     policy,
+    sniper,
     trending,
     tx,
     wallet,
@@ -83,6 +84,7 @@ def register_all(ctx) -> None:
     agent_plan.register(ctx)
     alerts.register(ctx)
     limit_order.register(ctx)
+    sniper.register(ctx)
     # TODO(v0.1.0+): model, topup, bankr, delegation, webhook,
     # api_keys, usage, update, reports, interrupts, profile, upgrades,
     # forum, fiat, agents, skills (now /skills), channel

--- a/clawmes/commands/agent_plan.py
+++ b/clawmes/commands/agent_plan.py
@@ -208,6 +208,95 @@ def _parse_one(text: str) -> dict[str, Any] | None:
     return None
 
 
+def _llm_extract(
+    failed_segments: list[str],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """LLM fallback for segments the regex parser couldn't understand.
+
+    Sends the failed segments to OpenGateway with a strict-JSON
+    extraction prompt. The LLM returns either a slash-command-equivalent
+    intent or ``null`` for "can't extract." Returns ``(extra_steps,
+    still_failed)``.
+
+    Defensively narrow surface: we never let the LLM invent commands
+    outside the known set, and we re-validate every emitted intent
+    through the same ``_parse_one`` path so the LLM can't smuggle
+    state through a fabricated arg shape.
+    """
+    try:
+        from clawmes.services.opengateway import (
+            OpenGatewayError,
+            get_opengateway_service,
+        )
+    except Exception:  # noqa: BLE001
+        return [], failed_segments
+
+    system_prompt = (
+        "You are a strict intent extractor for clawmes. Given one short "
+        "trading prompt, output a single slash-command equivalent on one "
+        "line, matching one of the supported phrasings exactly, or output "
+        "the literal word `null` if the prompt is not a trading intent.\n\n"
+        "Supported phrasings (output one of these exact shapes):\n"
+        "  dca <amount> eth of <token> every <interval>\n"
+        "  buy <amount> eth of <token>\n"
+        "  copy <0xWallet>\n"
+        "  follow <0xWallet> at <amount> eth\n"
+        "  claim my fees\n"
+        "  claim all\n"
+        "  claim <token>\n"
+        "  burn <amount>\n"
+        "  leaderboard\n"
+        "  top tokens\n"
+        "  top launchers\n"
+        "  show my launches\n"
+        "  balance\n\n"
+        "Output exactly one line. No JSON. No commentary. No quotes."
+    )
+
+    svc = get_opengateway_service()
+    extra: list[dict[str, Any]] = []
+    still_failed: list[str] = []
+    for segment in failed_segments:
+        try:
+            resp = svc.chat_completion(
+                [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": segment},
+                ],
+                temperature=0.0,
+                max_tokens=80,
+            )
+        except OpenGatewayError:
+            still_failed.append(segment)
+            continue
+        except Exception:  # noqa: BLE001
+            still_failed.append(segment)
+            continue
+
+        rewritten = _extract_llm_text(resp).strip().strip("`'\"")
+        if not rewritten or rewritten.lower() == "null":
+            still_failed.append(segment)
+            continue
+        step = _parse_one(rewritten)
+        if step is None:
+            still_failed.append(segment)
+            continue
+        extra.append(step)
+    return extra, still_failed
+
+
+def _extract_llm_text(resp: dict[str, Any]) -> str:
+    """Pull the first text content out of an OpenAI-style chat completion."""
+    choices = resp.get("choices") or []
+    if not choices:
+        return ""
+    msg = choices[0].get("message") or {}
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    return ""
+
+
 def _parse_prompt(prompt: str) -> tuple[list[dict[str, Any]], list[str]]:
     """Split on ``then`` (and ``, then``) and parse each segment.
 
@@ -246,7 +335,13 @@ async def handle_agent(raw_args: str, *, sender_id: str = "default", **_kwargs: 
     if not raw:
         out = _render_usage()
     else:
-        sub = raw.split()[0].lower()
+        # Extract --ai flag if present. It's a power-tier feature that
+        # lets the LLM take over when the regex parser doesn't match.
+        use_ai = False
+        if "--ai" in raw.split():
+            use_ai = True
+            raw = " ".join(tok for tok in raw.split() if tok != "--ai")
+        sub = raw.split()[0].lower() if raw else ""
         if sub == "show":
             out = _cmd_show(sender_id)
         elif sub == "confirm":
@@ -255,9 +350,11 @@ async def handle_agent(raw_args: str, *, sender_id: str = "default", **_kwargs: 
             out = _cmd_cancel(sender_id)
         elif sub == "examples":
             out = _render_examples()
+        elif not raw:
+            out = _render_usage()
         else:
             # Treat the whole input as the prompt to parse.
-            out = _cmd_parse(sender_id, raw)
+            out = _cmd_parse(sender_id, raw, use_ai=use_ai)
     _record("agent", raw_args, out)
     return out
 
@@ -267,6 +364,8 @@ def _render_usage() -> str:
         "Natural-language plan compiler.\n"
         "\n"
         "  /agent <prompt>         Parse the prompt, store as draft, show plan\n"
+        "  /agent --ai <prompt>    Same, with LLM fallback for off-template\n"
+        "                          phrasings (Clawmes Unlimited tier)\n"
         "  /agent show             Re-print the current draft\n"
         "  /agent confirm          Execute every step in the draft\n"
         "  /agent cancel           Drop the draft without executing\n"
@@ -315,13 +414,29 @@ def _render_examples() -> str:
     )
 
 
-def _cmd_parse(sender_id: str, prompt: str) -> str:
+def _cmd_parse(sender_id: str, prompt: str, *, use_ai: bool = False) -> str:
     plan, errors = _parse_prompt(prompt)
+
+    # If --ai is set and the regex parser missed any segment, try the
+    # LLM fallback. UNLIMITED tier (Clawmes Unlimited) required.
+    if use_ai:
+        from clawmes.services.token_gate import Tier, check_tier_or_error
+
+        gate_err = check_tier_or_error(Tier.UNLIMITED, feature="/agent --ai")
+        if gate_err:
+            return gate_err
+        if errors:
+            ai_plan, ai_failures = _llm_extract(errors)
+            if ai_plan:
+                plan = plan + ai_plan
+                errors = ai_failures
+
     if not plan and errors:
         return (
             "Couldn't parse the prompt. Segments not understood:\n"
             + "\n".join(f"  - {seg!r}" for seg in errors)
-            + "\n\nTry /agent examples for supported phrasings."
+            + "\n\nTry /agent examples for supported phrasings, "
+            "or /agent --ai <prompt> (Clawmes Unlimited) for LLM-backed parsing."
         )
 
     # Multi-step prompts (2+ parsed steps) require HOLDER tier. Single-

--- a/clawmes/commands/sniper.py
+++ b/clawmes/commands/sniper.py
@@ -1,0 +1,710 @@
+"""``/sniper`` — auto-buy newly-launched Clawnch tokens.
+
+Watches the Clawnch launches feed on the registry tick. When a new
+token appears that matches the configured filters, submits an ETH-
+funded buy at the configured size via ``defi_swap``.
+
+UNLIMITED tier feature (Clawmes Unlimited — 100M+ $CLAWNCH).
+
+Surface:
+
+  * ``/sniper add <eth_amount> [--max-buys N] [--source X]
+    [--symbol-filter regex] [--max-mcap <usd>] [--max-age <seconds>]
+    [--slippage <bps>]``
+  * ``/sniper list`` / ``pause`` / ``resume`` / ``cancel`` / ``edit``
+  * ``/sniper tick`` — manual evaluation (testing)
+  * ``/sniper status``
+  * ``/sniper history <id>``
+
+Filters (all optional; absent ⇒ no filter):
+
+  * ``--source <name>`` — only snipe launches with this source
+    attribution (``clawmes``, ``clawncher``, ``4claw``, ``moltbook``).
+  * ``--symbol-filter <regex>`` — case-insensitive regex applied to
+    the launch's symbol. Use this to target specific themes
+    (``"DOG|CAT"``) or avoid noise (``"^(?!.*scam).*"``).
+  * ``--max-mcap <usd>`` — skip if launch's reported market cap
+    exceeds this value. Defends against sniping pump'n'dumps.
+  * ``--max-age <seconds>`` — ignore launches older than this when
+    the sniper first sees them. Default 600 (10 min) — anything
+    older was probably caught by someone else already.
+
+Safety:
+
+  * Per-snipe ``slippage_bps`` (default 100 = 1%).
+  * ``--max-buys`` (default 10) — auto-cancels after N snipes so a
+    runaway launchpad doesn't drain your wallet.
+  * Each snipe records on history; failures don't auto-pause the
+    config (the user can /sniper pause manually).
+
+Storage: ``${HERMES_HOME}/clawmes/sniper/configs.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from clawmes.lib.http import http_get
+
+_CLAWNCH_API_BASE = "https://www.clawn.ch"
+_DEFAULT_SLIPPAGE_BPS = 100
+_DEFAULT_MAX_BUYS = 10
+_DEFAULT_MAX_AGE_SECONDS = 600  # ignore launches older than 10 minutes
+
+
+# ── state I/O ───────────────────────────────────────────────────────
+
+
+def _configs_path() -> Path:
+    from clawmes.lib.paths import state_dir
+
+    return state_dir("sniper") / "configs.json"
+
+
+def _load_state() -> dict[str, Any]:
+    path = _configs_path()
+    if not path.exists():
+        return {"configs": []}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {"configs": []}
+    if not isinstance(data, dict) or not isinstance(data.get("configs"), list):
+        return {"configs": []}
+    return data
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    path = _configs_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _now_epoch() -> int:
+    return int(time.time())
+
+
+def _new_id() -> str:
+    return f"snipe_{uuid.uuid4().hex[:10]}"
+
+
+def _short(value: str) -> str:
+    if not isinstance(value, str) or len(value) <= 12:
+        return str(value)
+    return f"{value[:6]}…{value[-4:]}"
+
+
+def _record(name: str, args: str, result: str) -> None:
+    try:
+        from clawmes.services.command_history import record_command_call
+
+        record_command_call(name, args, result)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _split_flags(parts: list[str]) -> tuple[list[str], dict[str, str]]:
+    positional: list[str] = []
+    flags: dict[str, str] = {}
+    i = 0
+    while i < len(parts):
+        tok = parts[i]
+        if tok.startswith("--"):
+            name = tok[2:]
+            value = parts[i + 1] if i + 1 < len(parts) else ""
+            flags[name] = value
+            i += 2
+        else:
+            positional.append(tok)
+            i += 1
+    return positional, flags
+
+
+# ── dispatch ────────────────────────────────────────────────────────
+
+
+async def handle_sniper(raw_args: str, *, sender_id: str = "default", **_kwargs: Any) -> str:
+    raw = (raw_args or "").strip()
+    if not raw:
+        out = _render_usage()
+    else:
+        parts = raw.split()
+        sub = parts[0].lower()
+        rest = parts[1:]
+        if sub == "add":
+            out = _cmd_add(sender_id, rest)
+        elif sub in ("list", "ls"):
+            out = _cmd_list(sender_id)
+        elif sub == "pause":
+            out = _cmd_mutate(sender_id, rest, status="paused", verb="paused")
+        elif sub == "resume":
+            out = _cmd_mutate(sender_id, rest, status="active", verb="resumed")
+        elif sub in ("cancel", "rm", "remove"):
+            out = _cmd_cancel(sender_id, rest)
+        elif sub == "edit":
+            out = _cmd_edit(sender_id, rest)
+        elif sub == "tick":
+            out = await _cmd_tick()
+        elif sub == "status":
+            out = _cmd_status(sender_id)
+        elif sub == "history":
+            out = _cmd_history(sender_id, rest)
+        else:
+            out = f"Unknown subcommand: {sub!r}\n\n" + _render_usage()
+    _record("sniper", raw_args, out)
+    return out
+
+
+def _render_usage() -> str:
+    return (
+        "Sniper — auto-buy newly-launched Clawnch tokens.\n"
+        "  (Clawmes Unlimited tier — hold 100M+ $CLAWNCH to /sniper add.)\n"
+        "\n"
+        "  /sniper add <eth_amount>\n"
+        "      [--max-buys <n>] [--source <name>]\n"
+        "      [--symbol-filter <regex>] [--max-mcap <usd>]\n"
+        "      [--max-age <seconds>] [--slippage <bps>]\n"
+        "                          Configure a new sniper\n"
+        "  /sniper list            Show your configs + snipe count\n"
+        "  /sniper pause <id>      Suspend a config\n"
+        "  /sniper resume <id>     Re-arm a paused config\n"
+        "  /sniper cancel <id>     Remove a config entirely\n"
+        "  /sniper edit <id> <field> <value>\n"
+        "                          Change one field on a config\n"
+        "  /sniper tick            Manually poll launches (testing)\n"
+        "  /sniper status          Global summary + service health\n"
+        "  /sniper history <id>    Past snipes for one config\n"
+        "\n"
+        "Filters (--source / --symbol-filter / --max-mcap / --max-age) are\n"
+        "optional. The default config snipes any new launch within the past\n"
+        "10 minutes at the configured ETH amount.\n"
+        "\n"
+        "Example:\n"
+        "  /sniper add 0.005 --max-buys 5 --source clawmes --symbol-filter DOG|CAT"
+    )
+
+
+# ── /sniper add ─────────────────────────────────────────────────────
+
+
+def _cmd_add(sender_id: str, parts: list[str]) -> str:
+    # UNLIMITED gate — required to configure a sniper at all.
+    from clawmes.services.token_gate import Tier, check_tier_or_error
+
+    gate_err = check_tier_or_error(Tier.UNLIMITED, feature="/sniper")
+    if gate_err:
+        return gate_err
+
+    pos, flags = _split_flags(parts)
+    if not pos:
+        return "Usage: /sniper add <eth_amount> [--max-buys N] [--source X] ..."
+
+    try:
+        eth_amount = float(pos[0])
+    except ValueError:
+        return f"eth_amount must be a number (got {pos[0]!r})."
+    if eth_amount <= 0:
+        return f"eth_amount must be positive (got {eth_amount})."
+
+    max_buys = _DEFAULT_MAX_BUYS
+    if "max-buys" in flags:
+        try:
+            max_buys = int(flags["max-buys"])
+        except ValueError:
+            return f"--max-buys must be an integer (got {flags['max-buys']!r})."
+        if max_buys < 1:
+            return f"--max-buys must be >= 1 (got {max_buys})."
+
+    slippage_bps = _DEFAULT_SLIPPAGE_BPS
+    if "slippage" in flags:
+        try:
+            slippage_bps = int(flags["slippage"])
+        except ValueError:
+            return f"--slippage must be an integer (got {flags['slippage']!r})."
+        if slippage_bps < 0 or slippage_bps > 10_000:
+            return f"--slippage must be 0–10000 (got {slippage_bps})."
+
+    max_age = _DEFAULT_MAX_AGE_SECONDS
+    if "max-age" in flags:
+        try:
+            max_age = int(flags["max-age"])
+        except ValueError:
+            return f"--max-age must be an integer (got {flags['max-age']!r})."
+        if max_age < 1:
+            return f"--max-age must be >= 1 (got {max_age})."
+
+    max_mcap: float | None = None
+    if "max-mcap" in flags:
+        try:
+            max_mcap = float(flags["max-mcap"])
+        except ValueError:
+            return f"--max-mcap must be a number (got {flags['max-mcap']!r})."
+        if max_mcap <= 0:
+            return f"--max-mcap must be positive (got {max_mcap})."
+
+    source = flags.get("source", "").strip() or None
+    symbol_filter = flags.get("symbol-filter", "").strip() or None
+    # Validate the regex at config time so we don't silently no-op later.
+    if symbol_filter:
+        try:
+            re.compile(symbol_filter, re.IGNORECASE)
+        except re.error as exc:
+            return f"--symbol-filter is not a valid regex: {exc}"
+
+    state = _load_state()
+    config_id = _new_id()
+    config = {
+        "id": config_id,
+        "sender_id": sender_id,
+        "eth_amount": eth_amount,
+        "max_buys": max_buys,
+        "buys_made": 0,
+        "slippage_bps": slippage_bps,
+        "source_filter": source,
+        "symbol_filter": symbol_filter,
+        "max_mcap_usd": max_mcap,
+        "max_age_seconds": max_age,
+        "status": "active",
+        "created_at": _now_iso(),
+        "last_seen_epoch": _now_epoch(),
+        "snipes": [],
+    }
+    state["configs"].append(config)
+    _save_state(state)
+
+    return (
+        f"Sniper added: {config_id}\n"
+        f"  Per snipe:      {eth_amount} ETH\n"
+        f"  Max buys:       {max_buys}\n"
+        f"  Slippage:       {slippage_bps} bps\n"
+        f"  Source filter:  {source or 'any'}\n"
+        f"  Symbol filter:  {symbol_filter or 'any'}\n"
+        f"  Max mcap:       {f'${max_mcap}' if max_mcap is not None else 'any'}\n"
+        f"  Max age:        {max_age}s (ignore launches older than this)\n"
+        "\n"
+        "The sniper service polls /api/launches on the registry tick (~60s)\n"
+        "and fires a buy on each newly-detected launch that matches the\n"
+        "filters. Auto-cancels after max-buys is reached."
+    )
+
+
+# ── /sniper list / mutate / cancel / edit ──────────────────────────
+
+
+def _cmd_list(sender_id: str) -> str:
+    state = _load_state()
+    mine = [c for c in state["configs"] if c.get("sender_id") == sender_id]
+    if not mine:
+        return "No sniper configs. Add one with /sniper add <eth_amount>."
+    lines = [f"Sniper configs for {sender_id} ({len(mine)}):", ""]
+    for c in mine:
+        src = c.get("source_filter") or "any"
+        sym = c.get("symbol_filter") or "any"
+        buys = c.get("buys_made", 0)
+        max_b = c.get("max_buys", _DEFAULT_MAX_BUYS)
+        lines.append(
+            f"  {c['id']}  {c.get('status'):<10s}"
+            f"  {c['eth_amount']} ETH/snipe"
+            f"  src={src}  sym={sym}"
+            f"  ({buys}/{max_b} snipes)"
+        )
+    return "\n".join(lines)
+
+
+def _cmd_mutate(sender_id: str, parts: list[str], *, status: str, verb: str) -> str:
+    if not parts:
+        return f"Usage: /sniper {verb.removesuffix('d')} <id>"
+    cid = parts[0]
+    state = _load_state()
+    for c in state["configs"]:
+        if c.get("id") == cid and c.get("sender_id") == sender_id:
+            c["status"] = status
+            _save_state(state)
+            return f"Sniper {cid} {verb}."
+    return f"No sniper config found with id {cid!r}."
+
+
+def _cmd_cancel(sender_id: str, parts: list[str]) -> str:
+    if not parts:
+        return "Usage: /sniper cancel <id>"
+    cid = parts[0]
+    state = _load_state()
+    before = len(state["configs"])
+    state["configs"] = [
+        c for c in state["configs"] if not (c.get("id") == cid and c.get("sender_id") == sender_id)
+    ]
+    if len(state["configs"]) == before:
+        return f"No sniper config found with id {cid!r}."
+    _save_state(state)
+    return f"Cancelled sniper {cid}."
+
+
+_EDITABLE = {
+    "eth_amount",
+    "max_buys",
+    "slippage_bps",
+    "source_filter",
+    "symbol_filter",
+    "max_mcap_usd",
+    "max_age_seconds",
+}
+
+
+def _cmd_edit(sender_id: str, parts: list[str]) -> str:
+    if len(parts) < 3:
+        return (
+            "Usage: /sniper edit <id> <field> <value>\n"
+            f"Editable fields: {', '.join(sorted(_EDITABLE))}"
+        )
+    cid, field, value = parts[0], parts[1], parts[2]
+    if field not in _EDITABLE:
+        return f"Unknown field {field!r}. Editable: {', '.join(sorted(_EDITABLE))}"
+
+    state = _load_state()
+    config = _find(state, cid, sender_id)
+    if config is None:
+        return f"No sniper config found with id {cid!r}."
+
+    if field == "eth_amount":
+        try:
+            v = float(value)
+        except ValueError:
+            return f"eth_amount must be a number (got {value!r})."
+        if v <= 0:
+            return f"eth_amount must be positive (got {v})."
+        config["eth_amount"] = v
+    elif field == "max_buys":
+        try:
+            v = int(value)
+        except ValueError:
+            return f"max_buys must be an integer (got {value!r})."
+        if v < 1:
+            return f"max_buys must be >= 1 (got {v})."
+        config["max_buys"] = v
+    elif field == "slippage_bps":
+        try:
+            v = int(value)
+        except ValueError:
+            return f"slippage_bps must be an integer (got {value!r})."
+        if v < 0 or v > 10_000:
+            return f"slippage_bps must be 0–10000 (got {v})."
+        config["slippage_bps"] = v
+    elif field == "source_filter":
+        config["source_filter"] = value if value.lower() != "none" else None
+    elif field == "symbol_filter":
+        if value.lower() == "none":
+            config["symbol_filter"] = None
+        else:
+            try:
+                re.compile(value, re.IGNORECASE)
+            except re.error as exc:
+                return f"symbol_filter is not a valid regex: {exc}"
+            config["symbol_filter"] = value
+    elif field == "max_mcap_usd":
+        if value.lower() == "none":
+            config["max_mcap_usd"] = None
+        else:
+            try:
+                v = float(value)
+            except ValueError:
+                return f"max_mcap_usd must be a number or 'none' (got {value!r})."
+            if v <= 0:
+                return f"max_mcap_usd must be positive (got {v})."
+            config["max_mcap_usd"] = v
+    else:  # max_age_seconds
+        try:
+            v = int(value)
+        except ValueError:
+            return f"max_age_seconds must be an integer (got {value!r})."
+        if v < 1:
+            return f"max_age_seconds must be >= 1 (got {v})."
+        config["max_age_seconds"] = v
+
+    _save_state(state)
+    return f"Sniper {cid}: {field} = {value}."
+
+
+def _find(state: dict[str, Any], cid: str, sender_id: str) -> dict[str, Any] | None:
+    for c in state["configs"]:
+        if c.get("id") == cid and c.get("sender_id") == sender_id:
+            return c
+    return None
+
+
+# ── /sniper tick — the engine ──────────────────────────────────────
+
+
+async def _cmd_tick() -> str:
+    n, lines = _run_due_with_lines()
+    if n == 0:
+        return "No new launches matched any active sniper config."
+    return "\n".join([f"Fired {n} snipe(s):"] + lines)
+
+
+def _run_due_sync() -> int:
+    n, _ = _run_due_with_lines()
+    return n
+
+
+def _run_due_with_lines() -> tuple[int, list[str]]:
+    state = _load_state()
+    active = [c for c in state["configs"] if c.get("status") == "active"]
+    if not active:
+        return 0, []
+
+    # Fetch the launches feed once per tick — every active config reuses
+    # the same response. /api/launches returns recent-first; we filter
+    # client-side per config.
+    try:
+        body = http_get(
+            f"{_CLAWNCH_API_BASE}/api/launches",
+            params={"limit": "50"},
+            timeout=15.0,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return 0, [f"  fetch error: {exc}"]
+    launches = _extract_launches(body)
+    if not launches:
+        # Even with no launches, advance last_seen_epoch on each config
+        # so the next tick doesn't replay anything.
+        now = _now_epoch()
+        for config in active:
+            config["last_seen_epoch"] = now
+        _save_state(state)
+        return 0, []
+
+    now = _now_epoch()
+    total_fired = 0
+    lines: list[str] = []
+    for config in active:
+        try:
+            count = _process_config(config, launches, now, lines)
+        except Exception as exc:  # noqa: BLE001
+            lines.append(f"  {config['id']}  error: {exc}")
+            continue
+        total_fired += count
+        config["last_seen_epoch"] = now
+        # Auto-exhaust when max_buys is reached.
+        if config["buys_made"] >= int(config.get("max_buys") or _DEFAULT_MAX_BUYS):
+            config["status"] = "exhausted"
+
+    if total_fired > 0 or any(lines):
+        _save_state(state)
+    return total_fired, lines
+
+
+def _process_config(
+    config: dict[str, Any],
+    launches: list[dict[str, Any]],
+    now_epoch: int,
+    lines: list[str],
+) -> int:
+    """Match launches against config filters and submit snipes."""
+    last_seen = int(config.get("last_seen_epoch", 0))
+    source_filter = config.get("source_filter")
+    symbol_filter = config.get("symbol_filter")
+    max_mcap = config.get("max_mcap_usd")
+    max_age = int(config.get("max_age_seconds") or _DEFAULT_MAX_AGE_SECONDS)
+    max_buys = int(config.get("max_buys") or _DEFAULT_MAX_BUYS)
+    sym_pat = re.compile(symbol_filter, re.IGNORECASE) if symbol_filter else None
+    count = 0
+
+    for launch in launches:
+        if config["buys_made"] >= max_buys:
+            break
+
+        addr = launch.get("contractAddress") or launch.get("tokenAddress") or launch.get("address")
+        if not isinstance(addr, str) or not addr.startswith("0x"):
+            continue
+
+        # Parse launch timestamp. Accept epoch ints or ISO strings.
+        launch_epoch = _parse_launch_epoch(launch)
+        if launch_epoch <= last_seen:
+            continue  # already-processed launch
+        if now_epoch - launch_epoch > max_age:
+            continue  # too old
+
+        source = launch.get("source") or ""
+        if source_filter and source.lower() != source_filter.lower():
+            continue
+
+        symbol = launch.get("symbol") or launch.get("ticker") or ""
+        if sym_pat and not sym_pat.search(symbol):
+            continue
+
+        if max_mcap is not None:
+            mcap = launch.get("marketCap") or launch.get("fdv") or 0
+            try:
+                if float(mcap) > float(max_mcap):
+                    continue
+            except (TypeError, ValueError):
+                pass  # missing/unparsable mcap → don't reject
+
+        # All filters passed → snipe.
+        result = _submit_snipe(config, addr.lower())
+        config["snipes"].append(
+            {
+                "at": _now_iso(),
+                "token": addr.lower(),
+                "symbol": symbol,
+                "result": result,
+            }
+        )
+        if result.get("status") == "ok":
+            config["buys_made"] += 1
+            count += 1
+        lines.append(
+            f"  {config['id']}  {result.get('status')}  "
+            f"{_short(addr)} ({symbol})  {result.get('detail', '')}"
+        )
+    return count
+
+
+def _parse_launch_epoch(launch: dict[str, Any]) -> int:
+    """Best-effort parse of a launch's timestamp into epoch seconds."""
+    for key in ("timestamp", "createdAt", "deployedAt", "ts"):
+        raw = launch.get(key)
+        if isinstance(raw, int):
+            # Heuristic: ms vs seconds. Anything > 10^11 is likely ms.
+            return raw // 1000 if raw > 10**11 else raw
+        if isinstance(raw, str):
+            try:
+                dt = datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+                return int(dt.timestamp())
+            except ValueError:
+                try:
+                    dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+                    return int(dt.timestamp())
+                except ValueError:
+                    continue
+    return 0  # unparseable → treated as old; max-age filter will skip
+
+
+def _submit_snipe(config: dict[str, Any], token: str) -> dict[str, Any]:
+    """Submit one swap for a sniped launch."""
+    from clawmes.services.wallet import get_wallet_state
+
+    wstate = get_wallet_state()
+    if not wstate.connected:
+        return {"status": "no_wallet", "detail": "no wallet connected", "tx_hash": ""}
+
+    try:
+        from clawmes.tools.defi_swap import defi_swap
+
+        raw = defi_swap(
+            {
+                "action": "swap",
+                "sell_token": "ETH",
+                "buy_token": token,
+                "sell_amount": str(config["eth_amount"]),
+                "slippage_bps": int(config.get("slippage_bps") or _DEFAULT_SLIPPAGE_BPS),
+            }
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"status": "error", "detail": str(exc), "tx_hash": ""}
+
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return {"status": "error", "detail": f"bad swap response: {raw}", "tx_hash": ""}
+    if payload.get("isError"):
+        msg = payload.get("content", [{}])[0].get("text", "swap failed")
+        return {"status": "error", "detail": msg, "tx_hash": ""}
+
+    details = payload.get("details") or {}
+    tx_hash = details.get("tx_hash") or details.get("txHash") or ""
+    return {"status": "ok", "detail": f"tx {tx_hash[:14]}…", "tx_hash": tx_hash}
+
+
+def _extract_launches(body: Any) -> list[dict[str, Any]]:
+    if isinstance(body, list):
+        return [x for x in body if isinstance(x, dict)]
+    if isinstance(body, dict):
+        for key in ("launches", "data", "results"):
+            inner = body.get(key)
+            if isinstance(inner, list):
+                return [x for x in inner if isinstance(x, dict)]
+    return []
+
+
+# ── /sniper status / history ───────────────────────────────────────
+
+
+def _cmd_status(_sender_id: str) -> str:
+    state = _load_state()
+    configs = state.get("configs", [])
+    if not configs:
+        return "No sniper configs exist. The scheduler service is idle."
+
+    by_status: dict[str, int] = {}
+    total_snipes = 0
+    successful = 0
+    for c in configs:
+        s = c.get("status", "?")
+        by_status[s] = by_status.get(s, 0) + 1
+        for snipe in c.get("snipes", []):
+            total_snipes += 1
+            if (snipe.get("result") or {}).get("status") == "ok":
+                successful += 1
+
+    lines = [
+        f"/sniper status ({len(configs)} config(s)):",
+        "",
+        f"  By status:   {', '.join(f'{k}={v}' for k, v in sorted(by_status.items()))}",
+        f"  Total snipes: {total_snipes} attempted, {successful} successful",
+    ]
+    try:
+        from clawmes.services.sniper_scheduler import get_sniper_scheduler_service
+
+        svc = get_sniper_scheduler_service()
+        h = svc.health()
+        lines.append(
+            f"  Service:     {h.get('status')} "
+            f"(ticks={h.get('ticks')}, total_fired={h.get('total_runs')})"
+        )
+    except Exception:  # noqa: BLE001
+        pass
+    return "\n".join(lines)
+
+
+def _cmd_history(sender_id: str, parts: list[str]) -> str:
+    if not parts:
+        return "Usage: /sniper history <id>"
+    cid = parts[0]
+    state = _load_state()
+    config = _find(state, cid, sender_id)
+    if config is None:
+        return f"No sniper config found with id {cid!r}."
+    snipes = config.get("snipes", [])
+    if not snipes:
+        return f"Sniper {cid}: no snipes yet."
+    lines = [f"Snipes for {cid} ({len(snipes)}):", ""]
+    for snipe in snipes[-25:]:
+        result = snipe.get("result") or {}
+        status = result.get("status", "?")
+        token = snipe.get("token", "")
+        symbol = snipe.get("symbol", "")
+        when = snipe.get("at", "")
+        lines.append(f"  {when}  {status:<10s}  {symbol:<10s}  {_short(token)}")
+    return "\n".join(lines)
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        name="sniper",
+        handler=handle_sniper,
+        description="Auto-buy newly-launched Clawnch tokens (Clawmes Unlimited tier)",
+        args_hint="add <eth> | list | pause | resume | cancel | edit | tick | status | history",
+    )

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.10.1
+version: 0.11.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/services/__init__.py
+++ b/clawmes/services/__init__.py
@@ -61,6 +61,7 @@ def start_all() -> None:
     from clawmes.services.persona_service import get_persona_service
     from clawmes.services.price import get_price_service
     from clawmes.services.rpc import get_rpc_service
+    from clawmes.services.sniper_scheduler import get_sniper_scheduler_service
     from clawmes.services.token_decimals import get_token_decimals_service
     from clawmes.services.token_gate import get_token_gate_service
     from clawmes.services.wallet import get_wallet_service
@@ -154,6 +155,10 @@ def start_all() -> None:
         #     orders against current USD prices and fires swaps via
         #     defi_swap when thresholds are crossed.
         get_limit_order_scheduler_service,
+        # 7e. Sniper scheduler — ticking=True. Polls /api/launches and
+        #     fires defi_swap buys for new launches matching each
+        #     UNLIMITED-tier config's filters.
+        get_sniper_scheduler_service,
         get_wc_notification_consumer,  # threaded; routes WC bridge notifs
     ]
     for factory in factories:

--- a/clawmes/services/sniper_scheduler.py
+++ b/clawmes/services/sniper_scheduler.py
@@ -1,0 +1,80 @@
+"""Sniper scheduler service — drives ``/sniper tick`` automatically.
+
+Same shape as the DCA / copy / alerts / limit-order schedulers. Each
+service tick pulls the Clawnch launches feed, matches each active
+sniper config against the latest launches, and fires swaps via
+``defi_swap`` for any matches.
+
+Per-config errors caught internally so one bad config (e.g. a regex
+that never matches anything weird) can't crash the loop.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawmes.lib.logger import logger_for
+from clawmes.services._base import Service
+
+_log = logger_for("services.sniper_scheduler")
+
+_SERVICE: SniperSchedulerService | None = None
+
+
+class SniperSchedulerService(Service):
+    id = "clawmes.sniper_scheduler"
+    ticking = True
+
+    def __init__(self) -> None:
+        self._running = False
+        self._ticks = 0
+        self._last_runs = 0
+        self._total_runs = 0
+
+    def start(self) -> None:
+        self._running = True
+        _log.info("sniper scheduler started — tick cadence driven by registry")
+
+    def stop(self) -> None:
+        self._running = False
+        _log.info(
+            "sniper scheduler stopped (ticks=%d, total_fired=%d)",
+            self._ticks,
+            self._total_runs,
+        )
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": "running" if self._running else "stopped",
+            "ticks": self._ticks,
+            "last_runs": self._last_runs,
+            "total_runs": self._total_runs,
+        }
+
+    def tick(self) -> None:
+        if not self._running:
+            return
+        self._ticks += 1
+        try:
+            from clawmes.commands import sniper
+
+            n = sniper._run_due_sync()
+            self._last_runs = n
+            self._total_runs += n
+            if n > 0:
+                _log.info("sniper tick fired %d snipe(s)", n)
+        except Exception:  # noqa: BLE001
+            _log.exception("sniper scheduler tick raised; swallowing")
+
+
+def get_sniper_scheduler_service() -> SniperSchedulerService:
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = SniperSchedulerService()
+    return _SERVICE
+
+
+def _reset_for_tests() -> None:
+    global _SERVICE
+    _SERVICE = None

--- a/clawmes/services/token_gate.py
+++ b/clawmes/services/token_gate.py
@@ -1,6 +1,6 @@
 """Token gating — power features unlock based on $CLAWNCH balance.
 
-Two tiers in v1:
+Three tiers:
 
   * ``free`` — no balance required. Everything you need to onboard and
     play around: ``/buy`` ``/trending`` ``/balance`` ``/leaderboard``
@@ -16,13 +16,25 @@ Two tiers in v1:
       - Unlimited ``/copy`` follows + advanced flags (blocklist, etc.)
       - ``/agent`` multi-step prompts (``then`` chains)
       - Unlimited ``/alerts``
+      - ``/copy --pct`` percentage-based sizing
 
-The gate is intentionally minimal: a single 10M threshold rather than
-a 4-tier ladder. Easy to reason about, easy to test. The threshold
-is meaningful enough to signal real commitment to the ecosystem
-without being prohibitively expensive for serious users. Reviewable
-in one place (:data:`HOLDER_THRESHOLD_WEI`) so we can adjust as the
-price moves without scattering magic numbers.
+  * ``unlimited`` — any wallet holding **at least 100,000,000 $CLAWNCH**
+    (~$1,050 at session-time price). "Clawmes Unlimited" — autopilot
+    tier. Unlocks everything HOLDER gets, plus:
+      - ``/sniper`` — auto-buy newly-launched Clawnch tokens within
+        seconds of detection
+      - ``/agent --ai`` — LLM fallback for unparsed prompts via
+        OpenGateway. Free-form intent extraction layered on top of
+        the regex parser.
+      - Future: priority service tick cadence, mempool-tier ``/copy``
+        latency via Alchemy WS subscribe.
+
+The gate is reviewable in one place (:data:`HOLDER_THRESHOLD_WEI` /
+:data:`UNLIMITED_THRESHOLD_WEI`) so we can adjust as the price moves
+without scattering magic numbers. Tier ordering is intentional: FREE
+< HOLDER < UNLIMITED. ``Tier.value`` is the rank — checks use
+``tier.value >= required.value`` so adding a tier later doesn't
+require rewriting every call site.
 
 Implementation: each gated command imports
 :func:`check_tier_or_error` and calls it before touching state. The
@@ -49,24 +61,33 @@ _log = logger_for("services.token_gate")
 # as a tuple/list here and a "highest tier across all" resolution.
 CLAWNCH_ADDR = "0xa1F72459dfA10BAD200Ac160eCd78C6b77a747be"
 
-# Holder threshold: 10,000,000 $CLAWNCH at 18 decimals = 1e25 wei.
+# Holder threshold: 10,000,000 $CLAWNCH at 18 decimals.
 # At session-time price of ~$0.0000105 / $CLAWNCH, this is ~$105 USD —
 # meaningful enough to function as a real signal of commitment to the
 # ecosystem, accessible enough that any serious user can clear it.
 HOLDER_THRESHOLD = 10_000_000
 HOLDER_THRESHOLD_WEI = HOLDER_THRESHOLD * (10**18)
 
+# Unlimited threshold: 100,000,000 $CLAWNCH at 18 decimals.
+# ~$1,050 USD at session-time price. Power-user / pro-trader tier —
+# unlocks autopilot features (/sniper, /agent --ai). Meaningful jump
+# from HOLDER, but still accessible to anyone who's serious about
+# trading on the platform.
+UNLIMITED_THRESHOLD = 100_000_000
+UNLIMITED_THRESHOLD_WEI = UNLIMITED_THRESHOLD * (10**18)
+
 # Cache TTL — balance reads hit the RPC, which is slow + rate-limited.
 # A 60-second cache is fine because tier changes are rare (you bought
-# 10k $CLAWNCH; you don't immediately sell 9k of it).
+# 10M $CLAWNCH; you don't immediately sell 9M of it).
 _CACHE_TTL_SECONDS = 60
 
 
 class Tier(Enum):
-    """Resolved tier for a wallet."""
+    """Resolved tier for a wallet. Ordered FREE < HOLDER < UNLIMITED."""
 
-    FREE = "free"
-    HOLDER = "holder"
+    FREE = 0
+    HOLDER = 1
+    UNLIMITED = 2
 
 
 # Per-command free-tier caps. Keys are command names; values are the
@@ -105,7 +126,8 @@ class TokenGateService(Service):
         return {
             "id": self.id,
             "status": "running" if self._running else "stopped",
-            "threshold_clawnch": HOLDER_THRESHOLD,
+            "holder_threshold_clawnch": HOLDER_THRESHOLD,
+            "unlimited_threshold_clawnch": UNLIMITED_THRESHOLD,
             "cached_entries": len(self._cache),
         }
 
@@ -114,7 +136,9 @@ class TokenGateService(Service):
 
         No wallet → FREE with 0 balance. Cache hits return without
         touching RPC. Cache misses (or expired entries) make one
-        ``balanceOf`` eth_call.
+        ``balanceOf`` eth_call. Tier resolution checks UNLIMITED
+        threshold first so a wallet straddling both cutoffs lands in
+        the highest tier.
         """
         if not address:
             return Tier.FREE, 0
@@ -125,7 +149,12 @@ class TokenGateService(Service):
             return cached[0], cached[1]
 
         balance = _read_clawnch_balance(address)
-        tier = Tier.HOLDER if balance >= HOLDER_THRESHOLD_WEI else Tier.FREE
+        if balance >= UNLIMITED_THRESHOLD_WEI:
+            tier = Tier.UNLIMITED
+        elif balance >= HOLDER_THRESHOLD_WEI:
+            tier = Tier.HOLDER
+        else:
+            tier = Tier.FREE
         self._cache[key] = (tier, balance, now + _CACHE_TTL_SECONDS)
         return tier, balance
 
@@ -172,30 +201,46 @@ def _reset_for_tests() -> None:
 # ── high-level helpers used by gated command handlers ──────────────
 
 
+_TIER_THRESHOLD_TOKENS = {
+    Tier.HOLDER: HOLDER_THRESHOLD,
+    Tier.UNLIMITED: UNLIMITED_THRESHOLD,
+}
+
+_TIER_LABELS = {
+    Tier.HOLDER: "Holder",
+    Tier.UNLIMITED: "Clawmes Unlimited",
+}
+
+
 def check_tier_or_error(min_tier: Tier, *, feature: str) -> str | None:
     """Return ``None`` if the active wallet meets ``min_tier``, else an error.
 
     Reads the active wallet via :func:`clawmes.services.wallet.get_wallet_state`.
     If no wallet is connected, treats the user as free tier (so the
     error message tells them what they need to unlock the feature).
+
+    Tier comparison uses ``Tier.value`` so a wallet at a HIGHER tier
+    than required passes automatically — an UNLIMITED holder calling
+    a HOLDER-gated feature never gets blocked.
     """
     if min_tier == Tier.FREE:
         return None  # always allowed
 
     address = _active_wallet_address()
     tier, balance = get_token_gate_service().resolve_tier(address)
-    if tier == Tier.HOLDER:
+    if tier.value >= min_tier.value:
         return None
 
-    # User is free-tier; build a helpful error.
-    shortfall = HOLDER_THRESHOLD - (balance // (10**18))
+    required_tokens = _TIER_THRESHOLD_TOKENS[min_tier]
+    tier_label = _TIER_LABELS[min_tier]
+    held = balance // (10**18)
+    shortfall = required_tokens - held
     lines = [
-        f"{feature} requires holding at least {HOLDER_THRESHOLD:,} $CLAWNCH.",
+        f"{feature} requires {tier_label} tier: hold {required_tokens:,}+ $CLAWNCH.",
     ]
     if not address:
         lines.append("No wallet connected. Run /connect to read your balance.")
     else:
-        held = balance // (10**18)
         lines.append(f"Active wallet holds {held:,} $CLAWNCH (need {shortfall:,} more).")
     lines.extend(
         [
@@ -213,18 +258,18 @@ def free_tier_cap(command: str) -> int | None:
 
 
 def check_cap_or_error(command: str, *, active_count: int, feature: str) -> str | None:
-    """Return ``None`` if the user is under cap or a HOLDER, else error.
+    """Return ``None`` if the user is under cap or HOLDER+, else error.
 
-    Used by ``/dca add`` / ``/copy add`` / ``/alerts add`` to enforce
-    per-command active-item limits at the free tier. Holder tier has
-    no cap.
+    Used by ``/dca add`` / ``/copy add`` / ``/alerts add`` /
+    ``/limit_order add`` to enforce per-command active-item limits at
+    the free tier. HOLDER and UNLIMITED tiers have no cap.
     """
     cap = free_tier_cap(command)
     if cap is None or active_count < cap:
         return None
     address = _active_wallet_address()
     tier, _ = get_token_gate_service().resolve_tier(address)
-    if tier == Tier.HOLDER:
+    if tier.value >= Tier.HOLDER.value:
         return None
     return (
         f"Free tier allows {cap} active {feature}(s). "

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.10.1
+version: 0.11.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.10.1"
+version = "0.11.0"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_agent_ai.py
+++ b/tests/commands/test_agent_ai.py
@@ -1,0 +1,225 @@
+"""Tests for the v0.11.0 ``/agent --ai`` LLM fallback."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from clawmes.commands import agent_plan
+
+
+@pytest.fixture(autouse=True)
+def _clear_drafts():
+    agent_plan._reset_for_tests()
+    yield
+    agent_plan._reset_for_tests()
+
+
+@pytest.fixture
+def fake_opengateway(monkeypatch):
+    """Stub OpenGateway. Configure responses via ``state['response']``."""
+    state: dict[str, Any] = {"response": None, "raises": None, "calls": []}
+
+    class _FakeSvc:
+        def chat_completion(self, messages, **kw):
+            state["calls"].append(messages)
+            if state["raises"]:
+                raise state["raises"]
+            return state["response"]
+
+    import clawmes.services.opengateway as mod
+
+    monkeypatch.setattr(mod, "get_opengateway_service", lambda: _FakeSvc())
+    return state
+
+
+# ── --ai flag parsing in handle_agent ─────────────────────────────
+
+
+class TestAiFlagDispatch:
+    async def test_no_ai_flag_uses_regex_only(self):
+        # Without --ai, an off-template prompt fails with the standard
+        # "couldn't parse" message and NO LLM hint mention isn't needed.
+        out = await agent_plan.handle_agent("totally off-template gibberish")
+        assert "Couldn't parse" in out
+
+    async def test_ai_flag_strips_and_routes(self, fake_opengateway, monkeypatch):
+        """--ai is removed from the prompt before regex parsing runs."""
+        # Stub the gate so UNLIMITED passes.
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(tg, "check_tier_or_error", lambda *a, **k: None)
+        # Stub the OpenGateway error class so the except clause shape
+        # is correct even though we never raise here.
+        fake_opengateway["response"] = {"choices": [{"message": {"content": "claim my fees"}}]}
+        out = await agent_plan.handle_agent("--ai do my fee thing pls")
+        # The LLM "rewrote" the prompt to a known intent → parsed.
+        assert "Plan parsed" in out
+
+    async def test_ai_flag_blocked_when_not_unlimited(self, monkeypatch):
+        """When the gate returns an error, --ai bails before calling the LLM."""
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(
+            tg,
+            "check_tier_or_error",
+            lambda *a, **k: "Clawmes Unlimited required for /agent --ai",
+        )
+        out = await agent_plan.handle_agent("--ai some prompt")
+        assert "Clawmes Unlimited required" in out
+
+    async def test_ai_flag_only(self, monkeypatch):
+        """``/agent --ai`` with no prompt after stripping the flag → usage."""
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(tg, "check_tier_or_error", lambda *a, **k: None)
+        out = await agent_plan.handle_agent("--ai")
+        # After stripping --ai, raw is empty → usage path.
+        assert "Natural-language" in out
+
+
+# ── _llm_extract direct ────────────────────────────────────────────
+
+
+class TestLlmExtract:
+    def test_no_failed_segments(self, fake_opengateway):
+        out, still = agent_plan._llm_extract([])
+        assert out == []
+        assert still == []
+
+    def test_successful_extraction(self, fake_opengateway):
+        fake_opengateway["response"] = {"choices": [{"message": {"content": "claim my fees"}}]}
+        out, still = agent_plan._llm_extract(["sweep my LP rewards"])
+        assert len(out) == 1
+        assert out[0]["command"] == "claim"
+        assert still == []
+
+    def test_llm_returns_null(self, fake_opengateway):
+        fake_opengateway["response"] = {"choices": [{"message": {"content": "null"}}]}
+        out, still = agent_plan._llm_extract(["not a trading intent"])
+        assert out == []
+        assert still == ["not a trading intent"]
+
+    def test_llm_returns_empty(self, fake_opengateway):
+        fake_opengateway["response"] = {"choices": [{"message": {"content": ""}}]}
+        out, still = agent_plan._llm_extract(["x"])
+        assert still == ["x"]
+
+    def test_llm_returns_unparsable_intent(self, fake_opengateway):
+        """LLM rewrites to something that still doesn't match the regex parser."""
+        fake_opengateway["response"] = {
+            "choices": [{"message": {"content": "make me coffee please"}}]
+        }
+        out, still = agent_plan._llm_extract(["x"])
+        assert out == []
+        assert still == ["x"]
+
+    def test_llm_strips_quotes_and_backticks(self, fake_opengateway):
+        fake_opengateway["response"] = {"choices": [{"message": {"content": "`claim my fees`"}}]}
+        out, still = agent_plan._llm_extract(["sweep fees"])
+        assert len(out) == 1
+
+    def test_opengateway_raises(self, fake_opengateway):
+        from clawmes.services.opengateway import OpenGatewayError
+
+        fake_opengateway["raises"] = OpenGatewayError("upstream", "down")
+        out, still = agent_plan._llm_extract(["x"])
+        assert out == []
+        assert still == ["x"]
+
+    def test_generic_exception(self, fake_opengateway):
+        fake_opengateway["raises"] = RuntimeError("kaboom")
+        out, still = agent_plan._llm_extract(["x"])
+        assert out == []
+        assert still == ["x"]
+
+    def test_import_failure_returns_failed(self, monkeypatch):
+        """If the OpenGateway module can't be imported at all, return originals."""
+        import builtins
+
+        original_import = builtins.__import__
+
+        def _block(name, *args, **kw):
+            if name == "clawmes.services.opengateway":
+                raise ImportError("no opengateway")
+            return original_import(name, *args, **kw)
+
+        monkeypatch.setattr(builtins, "__import__", _block)
+        out, still = agent_plan._llm_extract(["x"])
+        assert out == []
+        assert still == ["x"]
+
+
+# ── _extract_llm_text ──────────────────────────────────────────────
+
+
+class TestExtractLlmText:
+    def test_no_choices(self):
+        assert agent_plan._extract_llm_text({}) == ""
+
+    def test_empty_choices(self):
+        assert agent_plan._extract_llm_text({"choices": []}) == ""
+
+    def test_message_no_content(self):
+        assert agent_plan._extract_llm_text({"choices": [{"message": {}}]}) == ""
+
+    def test_content_not_string(self):
+        assert agent_plan._extract_llm_text({"choices": [{"message": {"content": 123}}]}) == ""
+
+    def test_success(self):
+        out = agent_plan._extract_llm_text({"choices": [{"message": {"content": "hello"}}]})
+        assert out == "hello"
+
+
+# ── _cmd_parse with use_ai=True ────────────────────────────────────
+
+
+class TestParseWithAi:
+    def test_ai_recovers_unparsed_segment(self, fake_opengateway, monkeypatch):
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(tg, "check_tier_or_error", lambda *a, **k: None)
+        fake_opengateway["response"] = {"choices": [{"message": {"content": "claim my fees"}}]}
+        out = agent_plan._cmd_parse("u", "sweep my LP rewards", use_ai=True)
+        assert "Plan parsed" in out
+        assert "u" in agent_plan._DRAFTS
+
+    def test_ai_partial_recovery(self, fake_opengateway, monkeypatch):
+        """One segment parses via regex, one via LLM, one fails completely."""
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(tg, "check_tier_or_error", lambda *a, **k: None)
+
+        # The LLM returns "claim my fees" for any segment we send.
+        fake_opengateway["response"] = {"choices": [{"message": {"content": "claim my fees"}}]}
+        # Prompt: "claim CLAWNCH" parses via regex, "sweep my LP rewards"
+        # parses via LLM. Both succeed.
+        out = agent_plan._cmd_parse("u", "claim CLAWNCH then sweep my LP rewards", use_ai=True)
+        assert "Plan parsed" in out
+        plan = agent_plan._DRAFTS["u"]
+        assert len(plan) == 2
+
+    def test_ai_all_segments_fail(self, fake_opengateway, monkeypatch):
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(tg, "check_tier_or_error", lambda *a, **k: None)
+        fake_opengateway["response"] = {"choices": [{"message": {"content": "null"}}]}
+        out = agent_plan._cmd_parse("u", "completely random nonsense", use_ai=True)
+        assert "Couldn't parse" in out
+        assert "Clawmes Unlimited" in out  # hint mentions --ai path
+
+    def test_no_ai_keeps_old_behavior(self):
+        out = agent_plan._cmd_parse("u", "completely random nonsense", use_ai=False)
+        assert "Couldn't parse" in out
+
+    def test_ai_gate_blocks(self, monkeypatch):
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(
+            tg,
+            "check_tier_or_error",
+            lambda *a, **k: "Clawmes Unlimited required",
+        )
+        out = agent_plan._cmd_parse("u", "anything off-template", use_ai=True)
+        assert "Clawmes Unlimited required" in out

--- a/tests/commands/test_sniper.py
+++ b/tests/commands/test_sniper.py
@@ -1,0 +1,918 @@
+"""Tests for the /sniper slash command."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from clawmes.commands import sniper
+
+
+@dataclass
+class _FakeWalletState:
+    connected: bool = True
+    address: str = "0x" + "1" * 40
+
+
+@pytest.fixture
+def tmp_state(tmp_path, monkeypatch):
+    p = tmp_path / "configs.json"
+    monkeypatch.setattr(sniper, "_configs_path", lambda: p)
+    return p
+
+
+@pytest.fixture
+def fake_wallet(monkeypatch):
+    state = _FakeWalletState()
+
+    def _state():
+        return state
+
+    import clawmes.services.wallet as wallet_mod
+
+    monkeypatch.setattr(wallet_mod, "get_wallet_state", _state)
+    return state
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    """Patch ``http_get`` to return canned /api/launches bodies."""
+    state: dict[str, Any] = {"body": None, "raises": None}
+
+    def _fake(url, *, params=None, timeout=None):  # noqa: ARG001
+        if state["raises"] is not None:
+            raise state["raises"]
+        return state["body"]
+
+    monkeypatch.setattr(sniper, "http_get", _fake)
+    return state
+
+
+@pytest.fixture
+def fake_defi_swap(monkeypatch):
+    state: dict[str, Any] = {"payload": None, "raises": None}
+
+    def _fake(args):  # noqa: ARG001
+        if state["raises"] is not None:
+            raise state["raises"]
+        return json.dumps(state["payload"])
+
+    import clawmes.tools.defi_swap as mod
+
+    monkeypatch.setattr(mod, "defi_swap", _fake)
+    return state
+
+
+def _add_config(sender="u", eth="0.005"):
+    return sniper._cmd_add(sender, [eth])
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_short_unchanged(self):
+        assert sniper._short("0x123") == "0x123"
+
+    def test_short_truncated(self):
+        assert "…" in sniper._short("0x" + "a" * 40)
+
+    def test_short_non_str(self):
+        assert sniper._short(None) == "None"  # type: ignore[arg-type]
+
+    def test_now_iso(self):
+        assert sniper._now_iso().endswith("Z")
+
+    def test_new_id(self):
+        assert sniper._new_id().startswith("snipe_")
+
+    def test_now_epoch(self):
+        assert sniper._now_epoch() > 0
+
+    def test_split_flags(self):
+        pos, flags = sniper._split_flags(["a", "--x", "1"])
+        assert pos == ["a"]
+        assert flags == {"x": "1"}
+
+    def test_split_flags_trailing(self):
+        pos, flags = sniper._split_flags(["--bare"])
+        assert flags == {"bare": ""}
+
+
+class TestStateIO:
+    def test_load_missing(self, tmp_state):
+        assert sniper._load_state() == {"configs": []}
+
+    def test_load_bad_json(self, tmp_state):
+        tmp_state.write_text("not-json")
+        assert sniper._load_state() == {"configs": []}
+
+    def test_load_wrong_shape(self, tmp_state):
+        tmp_state.write_text(json.dumps({"configs": "not-list"}))
+        assert sniper._load_state() == {"configs": []}
+
+    def test_load_not_dict(self, tmp_state):
+        tmp_state.write_text(json.dumps([]))
+        assert sniper._load_state() == {"configs": []}
+
+    def test_roundtrip(self, tmp_state):
+        state = {"configs": [{"id": "x"}]}
+        sniper._save_state(state)
+        assert sniper._load_state() == state
+
+    def test_default_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert sniper._configs_path().name == "configs.json"
+
+
+# ── _extract_launches ──────────────────────────────────────────────
+
+
+class TestExtractLaunches:
+    def test_top_level_list(self):
+        assert sniper._extract_launches([{"a": 1}, "junk"]) == [{"a": 1}]
+
+    def test_dict_keys(self):
+        body = {"launches": [{"x": 1}]}
+        assert sniper._extract_launches(body) == [{"x": 1}]
+
+    def test_dict_fallback(self):
+        body = {"results": [{"x": 1}]}
+        assert sniper._extract_launches(body) == [{"x": 1}]
+
+    def test_empty(self):
+        assert sniper._extract_launches({}) == []
+        assert sniper._extract_launches("not-a-dict") == []
+        assert sniper._extract_launches({"launches": "not-list"}) == []
+
+
+# ── _parse_launch_epoch ────────────────────────────────────────────
+
+
+class TestParseLaunchEpoch:
+    def test_int_seconds(self):
+        assert sniper._parse_launch_epoch({"timestamp": 1700000000}) == 1700000000
+
+    def test_int_ms(self):
+        assert sniper._parse_launch_epoch({"timestamp": 1700000000000}) == 1700000000
+
+    def test_iso_string_z(self):
+        result = sniper._parse_launch_epoch({"createdAt": "2026-05-27T01:00:00Z"})
+        assert result > 0
+
+    def test_iso_string_offset(self):
+        result = sniper._parse_launch_epoch({"deployedAt": "2026-05-27T01:00:00+00:00"})
+        assert result > 0
+
+    def test_bad_string(self):
+        assert sniper._parse_launch_epoch({"timestamp": "garbage"}) == 0
+
+    def test_no_timestamp(self):
+        assert sniper._parse_launch_epoch({}) == 0
+
+    def test_fallback_keys(self):
+        # ts is the last key in the lookup order.
+        assert sniper._parse_launch_epoch({"ts": 1700000000}) == 1700000000
+
+
+# ── /sniper add ────────────────────────────────────────────────────
+
+
+class TestCmdAdd:
+    def test_gate_blocks_non_unlimited(self, tmp_state, monkeypatch):
+        """UNLIMITED tier required to /sniper add — gate stub returns error."""
+        import clawmes.services.token_gate as tg
+
+        monkeypatch.setattr(tg, "check_tier_or_error", lambda *a, **k: "Clawmes Unlimited required")
+        out = sniper._cmd_add("u", ["0.005"])
+        assert "Clawmes Unlimited required" in out
+
+    def test_usage(self, tmp_state):
+        out = sniper._cmd_add("u", [])
+        assert "Usage:" in out
+
+    def test_bad_eth(self, tmp_state):
+        out = sniper._cmd_add("u", ["abc"])
+        assert "must be a number" in out
+
+    def test_zero_eth(self, tmp_state):
+        out = sniper._cmd_add("u", ["0"])
+        assert "must be positive" in out
+
+    def test_bad_max_buys(self, tmp_state):
+        out = sniper._cmd_add("u", ["0.005", "--max-buys", "x"])
+        assert "integer" in out
+
+    def test_max_buys_zero(self, tmp_state):
+        out = sniper._cmd_add("u", ["0.005", "--max-buys", "0"])
+        assert ">= 1" in out
+
+    def test_bad_slippage(self, tmp_state):
+        out = sniper._cmd_add("u", ["0.005", "--slippage", "x"])
+        assert "integer" in out
+
+    def test_slippage_range(self, tmp_state):
+        out = sniper._cmd_add("u", ["0.005", "--slippage", "99999"])
+        assert "0–10000" in out
+
+    def test_bad_max_age(self, tmp_state):
+        out = sniper._cmd_add("u", ["0.005", "--max-age", "x"])
+        assert "integer" in out
+
+    def test_max_age_zero(self, tmp_state):
+        out = sniper._cmd_add("u", ["0.005", "--max-age", "0"])
+        assert ">= 1" in out
+
+    def test_bad_max_mcap(self, tmp_state):
+        out = sniper._cmd_add("u", ["0.005", "--max-mcap", "x"])
+        assert "must be a number" in out
+
+    def test_max_mcap_non_positive(self, tmp_state):
+        out = sniper._cmd_add("u", ["0.005", "--max-mcap", "0"])
+        assert "must be positive" in out
+
+    def test_invalid_regex(self, tmp_state):
+        out = sniper._cmd_add("u", ["0.005", "--symbol-filter", "[unclosed"])
+        assert "not a valid regex" in out
+
+    def test_minimal_success(self, tmp_state):
+        out = _add_config()
+        assert "Sniper added" in out
+        c = sniper._load_state()["configs"][0]
+        assert c["eth_amount"] == 0.005
+        assert c["source_filter"] is None
+        assert c["symbol_filter"] is None
+
+    def test_full_flag_set(self, tmp_state):
+        out = sniper._cmd_add(
+            "u",
+            [
+                "0.005",
+                "--max-buys",
+                "3",
+                "--source",
+                "clawmes",
+                "--symbol-filter",
+                "DOG|CAT",
+                "--max-mcap",
+                "100000",
+                "--max-age",
+                "300",
+                "--slippage",
+                "200",
+            ],
+        )
+        assert "Sniper added" in out
+        c = sniper._load_state()["configs"][0]
+        assert c["max_buys"] == 3
+        assert c["source_filter"] == "clawmes"
+        assert c["symbol_filter"] == "DOG|CAT"
+        assert c["max_mcap_usd"] == 100000.0
+        assert c["max_age_seconds"] == 300
+        assert c["slippage_bps"] == 200
+
+
+# ── /sniper list / mutate / cancel ─────────────────────────────────
+
+
+class TestList:
+    def test_empty(self, tmp_state):
+        assert "No sniper configs" in sniper._cmd_list("u")
+
+    def test_lists_mine(self, tmp_state):
+        _add_config("alice")
+        _add_config("bob")
+        out = sniper._cmd_list("alice")
+        # Each line in the output corresponds to one config; only alice's
+        # config should be present.
+        assert out.count("0.005 ETH/snipe") == 1
+
+
+class TestMutate:
+    def test_pause_usage(self, tmp_state):
+        out = sniper._cmd_mutate("u", [], status="paused", verb="paused")
+        assert "Usage:" in out
+
+    def test_pause_not_found(self, tmp_state):
+        out = sniper._cmd_mutate("u", ["snipe_xxx"], status="paused", verb="paused")
+        assert "No sniper config found" in out
+
+    def test_pause_resume(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_mutate("u", [cid], status="paused", verb="paused")
+        assert sniper._load_state()["configs"][0]["status"] == "paused"
+        sniper._cmd_mutate("u", [cid], status="active", verb="resumed")
+        assert sniper._load_state()["configs"][0]["status"] == "active"
+
+
+class TestCancel:
+    def test_usage(self, tmp_state):
+        assert "Usage:" in sniper._cmd_cancel("u", [])
+
+    def test_not_found(self, tmp_state):
+        assert "No sniper config" in sniper._cmd_cancel("u", ["snipe_xxx"])
+
+    def test_success(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_cancel("u", [cid])
+        assert sniper._load_state()["configs"] == []
+
+
+# ── /sniper edit ───────────────────────────────────────────────────
+
+
+class TestEdit:
+    def test_usage(self, tmp_state):
+        assert "Usage:" in sniper._cmd_edit("u", [])
+
+    def test_unknown_field(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "Unknown field" in sniper._cmd_edit("u", [cid, "garbage", "1"])
+
+    def test_not_found(self, tmp_state):
+        assert "No sniper config" in sniper._cmd_edit("u", ["snipe_xxx", "eth_amount", "0.01"])
+
+    def test_eth_amount(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_edit("u", [cid, "eth_amount", "0.01"])
+        assert sniper._load_state()["configs"][0]["eth_amount"] == 0.01
+
+    def test_eth_amount_bad(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "must be a number" in sniper._cmd_edit("u", [cid, "eth_amount", "x"])
+
+    def test_eth_amount_non_positive(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "must be positive" in sniper._cmd_edit("u", [cid, "eth_amount", "0"])
+
+    def test_max_buys(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_edit("u", [cid, "max_buys", "5"])
+        assert sniper._load_state()["configs"][0]["max_buys"] == 5
+
+    def test_max_buys_bad(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "integer" in sniper._cmd_edit("u", [cid, "max_buys", "x"])
+
+    def test_max_buys_zero(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert ">= 1" in sniper._cmd_edit("u", [cid, "max_buys", "0"])
+
+    def test_slippage_bps(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_edit("u", [cid, "slippage_bps", "200"])
+        assert sniper._load_state()["configs"][0]["slippage_bps"] == 200
+
+    def test_slippage_bps_bad(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "integer" in sniper._cmd_edit("u", [cid, "slippage_bps", "x"])
+
+    def test_slippage_bps_range(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "0–10000" in sniper._cmd_edit("u", [cid, "slippage_bps", "99999"])
+
+    def test_source_filter(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_edit("u", [cid, "source_filter", "clawmes"])
+        assert sniper._load_state()["configs"][0]["source_filter"] == "clawmes"
+
+    def test_source_filter_none(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_edit("u", [cid, "source_filter", "NONE"])
+        assert sniper._load_state()["configs"][0]["source_filter"] is None
+
+    def test_symbol_filter(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_edit("u", [cid, "symbol_filter", "DOG"])
+        assert sniper._load_state()["configs"][0]["symbol_filter"] == "DOG"
+
+    def test_symbol_filter_none(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_edit("u", [cid, "symbol_filter", "none"])
+        assert sniper._load_state()["configs"][0]["symbol_filter"] is None
+
+    def test_symbol_filter_invalid(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "not a valid regex" in sniper._cmd_edit("u", [cid, "symbol_filter", "[bad"])
+
+    def test_max_mcap_value(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_edit("u", [cid, "max_mcap_usd", "100000"])
+        assert sniper._load_state()["configs"][0]["max_mcap_usd"] == 100000.0
+
+    def test_max_mcap_none(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_edit("u", [cid, "max_mcap_usd", "none"])
+        assert sniper._load_state()["configs"][0]["max_mcap_usd"] is None
+
+    def test_max_mcap_bad(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "must be a number" in sniper._cmd_edit("u", [cid, "max_mcap_usd", "x"])
+
+    def test_max_mcap_non_positive(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "must be positive" in sniper._cmd_edit("u", [cid, "max_mcap_usd", "0"])
+
+    def test_max_age_seconds(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        sniper._cmd_edit("u", [cid, "max_age_seconds", "300"])
+        assert sniper._load_state()["configs"][0]["max_age_seconds"] == 300
+
+    def test_max_age_seconds_bad(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "integer" in sniper._cmd_edit("u", [cid, "max_age_seconds", "x"])
+
+    def test_max_age_seconds_zero(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert ">= 1" in sniper._cmd_edit("u", [cid, "max_age_seconds", "0"])
+
+
+# ── _find ───────────────────────────────────────────────────────────
+
+
+class TestFind:
+    def test_match(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert sniper._find(sniper._load_state(), cid, "u") is not None
+
+    def test_wrong_sender(self, tmp_state):
+        out = _add_config("alice")
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert sniper._find(sniper._load_state(), cid, "bob") is None
+
+    def test_missing(self, tmp_state):
+        assert sniper._find(sniper._load_state(), "snipe_xxx", "u") is None
+
+
+# ── _submit_snipe ───────────────────────────────────────────────────
+
+
+class TestSubmitSnipe:
+    def test_no_wallet(self, fake_wallet, fake_defi_swap):
+        fake_wallet.connected = False
+        config = {"eth_amount": 0.005, "slippage_bps": 100}
+        out = sniper._submit_snipe(config, "0x" + "1" * 40)
+        assert out["status"] == "no_wallet"
+
+    def test_success(self, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        config = {"eth_amount": 0.005, "slippage_bps": 100}
+        out = sniper._submit_snipe(config, "0x" + "1" * 40)
+        assert out["status"] == "ok"
+        assert "0xfeed" in out["tx_hash"]
+
+    def test_swap_raises(self, fake_wallet, fake_defi_swap):
+        fake_defi_swap["raises"] = RuntimeError("rpc down")
+        config = {"eth_amount": 0.005, "slippage_bps": 100}
+        out = sniper._submit_snipe(config, "0x" + "1" * 40)
+        assert out["status"] == "error"
+        assert "rpc down" in out["detail"]
+
+    def test_swap_bad_json(self, fake_wallet, monkeypatch):
+        import clawmes.tools.defi_swap as mod
+
+        monkeypatch.setattr(mod, "defi_swap", lambda *a, **k: "not-json")
+        config = {"eth_amount": 0.005, "slippage_bps": 100}
+        out = sniper._submit_snipe(config, "0x" + "1" * 40)
+        assert out["status"] == "error"
+
+    def test_swap_isError(self, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": True,
+            "content": [{"text": "no route"}],
+        }
+        config = {"eth_amount": 0.005, "slippage_bps": 100}
+        out = sniper._submit_snipe(config, "0x" + "1" * 40)
+        assert out["status"] == "error"
+        assert "no route" in out["detail"]
+
+    def test_swap_isError_no_content(self, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {"isError": True}
+        config = {"eth_amount": 0.005, "slippage_bps": 100}
+        out = sniper._submit_snipe(config, "0x" + "1" * 40)
+        assert out["status"] == "error"
+
+
+# ── _process_config + _run_due_sync ────────────────────────────────
+
+
+def _seed_config(sender="u", **overrides):
+    """Add a basic config then mutate fields in place via _save_state."""
+    _add_config(sender)
+    s = sniper._load_state()
+    s["configs"][0].update(overrides)
+    sniper._save_state(s)
+    return s["configs"][0]["id"]
+
+
+class TestRunDue:
+    def test_no_active_configs(self, tmp_state, fake_http):
+        # No configs at all → no fetch needed → no fires.
+        assert sniper._run_due_sync() == 0
+
+    def test_fetch_error(self, tmp_state, fake_http):
+        _seed_config()
+        fake_http["raises"] = RuntimeError("upstream down")
+        n, lines = sniper._run_due_with_lines()
+        assert n == 0
+        assert any("fetch error" in line for line in lines)
+
+    def test_no_launches(self, tmp_state, fake_http):
+        _seed_config()
+        fake_http["body"] = {"launches": []}
+        # last_seen_epoch in seed is now-ish; advance and confirm no fires.
+        n = sniper._run_due_sync()
+        assert n == 0
+        # last_seen_epoch should have advanced.
+        state = sniper._load_state()
+        assert state["configs"][0]["last_seen_epoch"] > 0
+
+    def test_paused_skipped(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        _seed_config(status="paused")
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + "T" * 40,
+                    "symbol": "TKN",
+                    "timestamp": sniper._now_epoch() - 10,
+                }
+            ]
+        }
+        assert sniper._run_due_sync() == 0
+
+    def test_too_old(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        _seed_config(last_seen_epoch=0, max_age_seconds=60)
+        # Launch is 10 minutes old, max_age is 60 sec → skipped.
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + "T" * 40,
+                    "symbol": "TKN",
+                    "timestamp": sniper._now_epoch() - 600,
+                }
+            ]
+        }
+        assert sniper._run_due_sync() == 0
+
+    def test_already_seen_skipped(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        now = sniper._now_epoch()
+        _seed_config(last_seen_epoch=now + 100, max_age_seconds=10_000)
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + "T" * 40,
+                    "symbol": "TKN",
+                    "timestamp": now,  # before last_seen
+                }
+            ]
+        }
+        assert sniper._run_due_sync() == 0
+
+    def test_bad_address_skipped(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        _seed_config(last_seen_epoch=0)
+        fake_http["body"] = {
+            "launches": [
+                {"contractAddress": "junk", "symbol": "TKN", "timestamp": sniper._now_epoch()}
+            ]
+        }
+        assert sniper._run_due_sync() == 0
+
+    def test_source_filter_mismatch(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        _seed_config(last_seen_epoch=0, source_filter="clawmes")
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + "T" * 40,
+                    "symbol": "TKN",
+                    "source": "4claw",
+                    "timestamp": sniper._now_epoch(),
+                }
+            ]
+        }
+        assert sniper._run_due_sync() == 0
+
+    def test_symbol_filter_mismatch(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        _seed_config(last_seen_epoch=0, symbol_filter="DOG")
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + "T" * 40,
+                    "symbol": "CAT",
+                    "timestamp": sniper._now_epoch(),
+                }
+            ]
+        }
+        assert sniper._run_due_sync() == 0
+
+    def test_mcap_too_high(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        _seed_config(last_seen_epoch=0, max_mcap_usd=10000)
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + "T" * 40,
+                    "symbol": "TKN",
+                    "marketCap": 1000000,
+                    "timestamp": sniper._now_epoch(),
+                }
+            ]
+        }
+        assert sniper._run_due_sync() == 0
+
+    def test_mcap_unparseable_passes(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        """Unparseable mcap should fall through to the next filter, not reject."""
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        _seed_config(last_seen_epoch=0, max_mcap_usd=10000)
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + "T" * 40,
+                    "symbol": "TKN",
+                    "marketCap": "not-a-number",
+                    "timestamp": sniper._now_epoch(),
+                }
+            ]
+        }
+        n = sniper._run_due_sync()
+        assert n == 1
+
+    def test_successful_snipe(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        _seed_config(last_seen_epoch=0)
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + "T" * 40,
+                    "symbol": "TKN",
+                    "timestamp": sniper._now_epoch(),
+                }
+            ]
+        }
+        n = sniper._run_due_sync()
+        assert n == 1
+        c = sniper._load_state()["configs"][0]
+        assert c["buys_made"] == 1
+
+    def test_max_buys_exhausts(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        """When max_buys is reached on the same tick, status flips to exhausted."""
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        _seed_config(last_seen_epoch=0, max_buys=1)
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + f"{i:040x}",
+                    "symbol": f"TKN{i}",
+                    "timestamp": sniper._now_epoch() + i,
+                }
+                for i in range(3)
+            ]
+        }
+        sniper._run_due_sync()
+        c = sniper._load_state()["configs"][0]
+        assert c["status"] == "exhausted"
+        assert c["buys_made"] == 1
+
+    def test_per_config_error_caught(self, tmp_state, fake_http, fake_wallet, monkeypatch):
+        _seed_config(last_seen_epoch=0)
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + "T" * 40,
+                    "symbol": "TKN",
+                    "timestamp": sniper._now_epoch(),
+                }
+            ]
+        }
+
+        def _boom(*a, **k):
+            raise RuntimeError("processing exploded")
+
+        monkeypatch.setattr(sniper, "_process_config", _boom)
+        n, lines = sniper._run_due_with_lines()
+        assert n == 0
+        assert any("error" in line for line in lines)
+
+
+class TestManualTick:
+    async def test_no_fires(self, tmp_state):
+        out = await sniper._cmd_tick()
+        assert "No new launches matched" in out
+
+    async def test_with_fires(self, tmp_state, fake_http, fake_wallet, fake_defi_swap):
+        fake_defi_swap["payload"] = {
+            "isError": False,
+            "details": {"tx_hash": "0xfeed"},
+        }
+        _seed_config(last_seen_epoch=0)
+        fake_http["body"] = {
+            "launches": [
+                {
+                    "contractAddress": "0x" + "T" * 40,
+                    "symbol": "TKN",
+                    "timestamp": sniper._now_epoch(),
+                }
+            ]
+        }
+        out = await sniper._cmd_tick()
+        assert "Fired 1" in out
+
+
+# ── /sniper status / history ───────────────────────────────────────
+
+
+class TestStatus:
+    def test_empty(self, tmp_state):
+        assert "idle" in sniper._cmd_status("u")
+
+    def test_summarizes(self, tmp_state):
+        _add_config("alice")
+        s = sniper._load_state()
+        s["configs"][0]["snipes"] = [
+            {"at": "x", "result": {"status": "ok"}},
+            {"at": "y", "result": {"status": "error"}},
+        ]
+        sniper._save_state(s)
+        out = sniper._cmd_status("alice")
+        assert "Total snipes: 2 attempted, 1 successful" in out
+
+    def test_service_health_swallowed(self, monkeypatch, tmp_state):
+        import clawmes.services.sniper_scheduler as svc_mod
+
+        monkeypatch.setattr(
+            svc_mod,
+            "get_sniper_scheduler_service",
+            lambda: (_ for _ in ()).throw(RuntimeError("svc")),
+        )
+        _add_config()
+        out = sniper._cmd_status("u")
+        assert "Service:" not in out
+
+    def test_service_health_present(self, tmp_state):
+        from clawmes.services import sniper_scheduler as svc_mod
+
+        svc_mod._reset_for_tests()
+        svc = svc_mod.get_sniper_scheduler_service()
+        svc.start()
+        try:
+            _add_config()
+            out = sniper._cmd_status("u")
+            assert "Service:" in out
+        finally:
+            svc.stop()
+            svc_mod._reset_for_tests()
+
+
+class TestHistory:
+    def test_usage(self, tmp_state):
+        assert "Usage:" in sniper._cmd_history("u", [])
+
+    def test_not_found(self, tmp_state):
+        assert "No sniper config" in sniper._cmd_history("u", ["snipe_xxx"])
+
+    def test_no_snipes(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        assert "no snipes yet" in sniper._cmd_history("u", [cid])
+
+    def test_with_snipes(self, tmp_state):
+        out = _add_config()
+        cid = next(w for w in out.split() if w.startswith("snipe_"))
+        s = sniper._load_state()
+        s["configs"][0]["snipes"] = [
+            {
+                "at": "2026-05-27T01:00:00Z",
+                "token": "0x" + "T" * 40,
+                "symbol": "TKN",
+                "result": {"status": "ok"},
+            }
+        ]
+        sniper._save_state(s)
+        out = sniper._cmd_history("u", [cid])
+        assert "Snipes for" in out
+        assert "TKN" in out
+
+
+# ── handle_sniper ──────────────────────────────────────────────────
+
+
+class TestHandle:
+    async def test_empty(self, tmp_state):
+        out = await sniper.handle_sniper("")
+        assert "Sniper" in out
+
+    async def test_unknown(self, tmp_state):
+        out = await sniper.handle_sniper("garbage")
+        assert "Unknown subcommand" in out
+
+    async def test_add(self, tmp_state):
+        out = await sniper.handle_sniper("add 0.005")
+        assert "Sniper added" in out
+
+    async def test_list(self, tmp_state):
+        out = await sniper.handle_sniper("list")
+        assert "No sniper configs" in out
+
+    async def test_ls(self, tmp_state):
+        out = await sniper.handle_sniper("ls")
+        assert "No sniper configs" in out
+
+    async def test_pause(self, tmp_state):
+        out = await sniper.handle_sniper("pause snipe_xxx")
+        assert "No sniper config" in out
+
+    async def test_resume(self, tmp_state):
+        out = await sniper.handle_sniper("resume snipe_xxx")
+        assert "No sniper config" in out
+
+    async def test_cancel(self, tmp_state):
+        out = await sniper.handle_sniper("cancel snipe_xxx")
+        assert "No sniper config" in out
+
+    async def test_rm_alias(self, tmp_state):
+        out = await sniper.handle_sniper("rm snipe_xxx")
+        assert "No sniper config" in out
+
+    async def test_remove_alias(self, tmp_state):
+        out = await sniper.handle_sniper("remove snipe_xxx")
+        assert "No sniper config" in out
+
+    async def test_edit(self, tmp_state):
+        out = await sniper.handle_sniper("edit snipe_xxx eth_amount 0.01")
+        assert "No sniper config" in out
+
+    async def test_tick(self, tmp_state):
+        out = await sniper.handle_sniper("tick")
+        assert "No new launches" in out
+
+    async def test_status(self, tmp_state):
+        out = await sniper.handle_sniper("status")
+        assert "idle" in out
+
+    async def test_history(self, tmp_state):
+        out = await sniper.handle_sniper("history snipe_xxx")
+        assert "No sniper config" in out
+
+    async def test_record_swallows(self, monkeypatch, tmp_state):
+        import clawmes.services.command_history as ch
+
+        def _boom(*a, **k):
+            raise RuntimeError("hist broken")
+
+        monkeypatch.setattr(ch, "record_command_call", _boom)
+        out = await sniper.handle_sniper("")
+        assert "Sniper" in out
+
+
+# ── register ───────────────────────────────────────────────────────
+
+
+class TestRegister:
+    def test_register(self):
+        registered: list[dict] = []
+
+        class Ctx:
+            def register_command(self, **kwargs):
+                registered.append(kwargs)
+
+        sniper.register(Ctx())
+        assert len(registered) == 1
+        assert registered[0]["name"] == "sniper"

--- a/tests/services/test_sniper_scheduler.py
+++ b/tests/services/test_sniper_scheduler.py
@@ -1,0 +1,95 @@
+"""Tests for the sniper scheduler service."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawmes.services import sniper_scheduler
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    sniper_scheduler._reset_for_tests()
+    yield
+    sniper_scheduler._reset_for_tests()
+
+
+class TestSingleton:
+    def test_same_instance(self):
+        a = sniper_scheduler.get_sniper_scheduler_service()
+        b = sniper_scheduler.get_sniper_scheduler_service()
+        assert a is b
+
+    def test_reset(self):
+        a = sniper_scheduler.get_sniper_scheduler_service()
+        sniper_scheduler._reset_for_tests()
+        b = sniper_scheduler.get_sniper_scheduler_service()
+        assert a is not b
+
+
+class TestLifecycle:
+    def test_start_stop(self):
+        svc = sniper_scheduler.get_sniper_scheduler_service()
+        assert svc._running is False
+        svc.start()
+        assert svc._running is True
+        svc.stop()
+        assert svc._running is False
+
+    def test_health(self):
+        svc = sniper_scheduler.get_sniper_scheduler_service()
+        h = svc.health()
+        assert h["id"] == "clawmes.sniper_scheduler"
+        assert h["status"] == "stopped"
+        svc.start()
+        assert svc.health()["status"] == "running"
+
+
+class TestTick:
+    def test_skipped_when_not_running(self, monkeypatch):
+        from clawmes.commands import sniper
+
+        called = {"n": 0}
+
+        def _spy():
+            called["n"] += 1
+            return 0
+
+        monkeypatch.setattr(sniper, "_run_due_sync", _spy)
+        svc = sniper_scheduler.get_sniper_scheduler_service()
+        svc.tick()
+        assert called["n"] == 0
+
+    def test_runs_when_started(self, monkeypatch):
+        from clawmes.commands import sniper
+
+        monkeypatch.setattr(sniper, "_run_due_sync", lambda: 4)
+        svc = sniper_scheduler.get_sniper_scheduler_service()
+        svc.start()
+        svc.tick()
+        assert svc._ticks == 1
+        assert svc._last_runs == 4
+
+    def test_swallows_errors(self, monkeypatch):
+        from clawmes.commands import sniper
+
+        def _boom():
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(sniper, "_run_due_sync", _boom)
+        svc = sniper_scheduler.get_sniper_scheduler_service()
+        svc.start()
+        svc.tick()
+        assert svc._ticks == 1
+        assert svc._last_runs == 0
+
+    def test_accumulates(self, monkeypatch):
+        from clawmes.commands import sniper
+
+        runs = iter([3, 1])
+        monkeypatch.setattr(sniper, "_run_due_sync", lambda: next(runs))
+        svc = sniper_scheduler.get_sniper_scheduler_service()
+        svc.start()
+        svc.tick()
+        svc.tick()
+        assert svc._total_runs == 4

--- a/tests/services/test_token_gate.py
+++ b/tests/services/test_token_gate.py
@@ -52,7 +52,8 @@ class TestLifecycle:
         svc = token_gate.get_token_gate_service()
         h = svc.health()
         assert h["id"] == "clawmes.token_gate"
-        assert h["threshold_clawnch"] == token_gate.HOLDER_THRESHOLD
+        assert h["holder_threshold_clawnch"] == token_gate.HOLDER_THRESHOLD
+        assert h["unlimited_threshold_clawnch"] == token_gate.UNLIMITED_THRESHOLD
         assert h["status"] == "stopped"
         svc.start()
         assert svc.health()["status"] == "running"
@@ -74,12 +75,20 @@ class TestResolveTier:
         assert tier == token_gate.Tier.FREE
 
     def test_holder_above_threshold(self, monkeypatch):
-        # Mock balance reader to return 11M $CLAWNCH (above the 10M threshold).
+        # Mock balance reader to return 11M $CLAWNCH (above the 10M threshold,
+        # below the 100M UNLIMITED threshold).
         monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 11_000_000 * (10**18))
         svc = token_gate.get_token_gate_service()
         tier, bal = svc.resolve_tier("0x" + "a" * 40)
         assert tier == token_gate.Tier.HOLDER
         assert bal == 11_000_000 * (10**18)
+
+    def test_unlimited_above_threshold(self, monkeypatch):
+        # Mock balance reader to return 150M $CLAWNCH (above UNLIMITED 100M).
+        monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 150_000_000 * (10**18))
+        svc = token_gate.get_token_gate_service()
+        tier, _ = svc.resolve_tier("0x" + "a" * 40)
+        assert tier == token_gate.Tier.UNLIMITED
 
     def test_free_below_threshold(self, monkeypatch):
         monkeypatch.setattr(token_gate, "_read_clawnch_balance", lambda a: 5_000_000 * (10**18))


### PR DESCRIPTION
## Summary

A new top tier and two extreme features that live behind it.

### `UNLIMITED` tier

- Any wallet holding **100,000,000+ \$CLAWNCH** (~\$1,050 at session-time price).
- Sits above `HOLDER` (10M+) and `FREE`. Power-trader autopilot tier.
- Tier enum reordered as numeric ranks (FREE=0 < HOLDER=1 < UNLIMITED=2). Checks use `tier.value >= required.value` so UNLIMITED holders automatically pass HOLDER gates without explicit casing.

### `/sniper`

Auto-buy newly-launched Clawnch tokens. UNLIMITED tier required.

- `/sniper add <eth_amount>` with composable filter flags:
  - `--max-buys N` (default 10) — auto-exhausts after N snipes
  - `--source <name>` — only snipe launches from `clawmes` / `clawncher` / `4claw` / `moltbook`
  - `--symbol-filter <regex>` — case-insensitive regex on symbol
  - `--max-mcap <usd>` — skip if launch's market cap exceeds
  - `--max-age <seconds>` (default 600) — ignore launches older than this
  - `--slippage <bps>` — per-snipe slippage cap
- Full mutation surface: `list` `pause` `resume` `cancel` `edit` `tick` `status` `history`.
- `SniperSchedulerService` (id `clawmes.sniper_scheduler`) polls `/api/launches` on the registry tick.
- Per-config errors caught internally so one bad regex / source filter can't crash the loop.

### `/agent --ai`

LLM fallback for prompts the regex parser can't understand. UNLIMITED tier required.

- Layered on top of the existing intent matcher: regex runs first, LLM only sees segments that didn't match.
- LLM is constrained to rewrite each segment as one of the supported phrasings. Rewrites are re-validated through `_parse_one` so the LLM can't smuggle invented commands outside the known set.
- Powered by the existing OpenGateway service. Graceful fallback when OpenGateway is unreachable — original "couldn't parse" message displays.

## Testing

- 3984 tests pass (was 3831) — 153 new tests across `/sniper`, the new scheduler service, the `--ai` flag, and `_llm_extract` helper.
- 100% line coverage maintained on every file and on the project overall.
- `ruff check` + `ruff format --check` clean.
- Plugin yamls byte-identical.
- Version: `_version.py`, `pyproject.toml`, both `plugin.yaml` → 0.11.0.

## Why these features

- **`/sniper`** — the marquee autopilot use case. New launches are the most predatory environment in crypto; an automated buyer that filters out junk (via source/symbol/mcap rules) is genuinely useful for power-traders. UNLIMITED-gated so it's not handed out cheap.
- **`/agent --ai`** — extends the natural-language compiler beyond the regex template surface. Lets users say "sweep my LP rewards" instead of "claim my fees". UNLIMITED-gated because LLM calls cost money on our side.
- **Three-tier system** — FREE → HOLDER → UNLIMITED maps cleanly to "trying it out" → "regular trader" → "power-trader running autopilot." Each tier adds direct \$CLAWNCH demand: 10M to unlock HOLDER, 100M to unlock UNLIMITED.

## Treasury-preserving

Nothing in this PR consumes ETH treasury or burns \$CLAWNCH on our dime. UNLIMITED tier requires holding 10x more \$CLAWNCH than HOLDER — direct demand pressure scales with feature ambition.