### PR TITLE
feat(desktop): surface crypto capabilities in the Hermes Desktop UI (v0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.16.0 — 2026-06-02
+
+### Added — Hermes Desktop UI integration
+
+Surface clawmes crypto capabilities natively in the Hermes Desktop app
+(`apps/desktop`). The desktop has no plugin-UI API — it renders tool
+output through generic systems (Artifacts view, structured tool-card
+summary, and an auto-opening side preview pane). This release shapes
+clawmes output to light those systems up.
+
+- **`clawmes/lib/ui_artifacts.py`** — canonical link builders
+  (`explorer_tx_url`, `explorer_address_url`, `explorer_token_url`,
+  `dexscreener_url`, `clanker_url`) plus `enrich_tx_links` /
+  `enrich_token_links` helpers. Links are emitted under descriptive
+  keys (`explorer_url`, `dexscreener_url`, `clanker_url`) so they
+  become clickable **Link artifacts** in the desktop without hijacking
+  the preview pane. `attach_preview` / `will_auto_open` give precise
+  control over the desktop's preview auto-open (`url/target/path/
+  file/filepath/preview` trigger keys).
+
+- **`clawmes/lib/ui_cards.py`** — self-contained, offline,
+  HTML-escaped preview cards rendered to `${HERMES_HOME}/clawmes/cards/`
+  and surfaced under the `preview` key so the desktop auto-opens them in
+  the side rail: `portfolio_card`, `research_card`, `receipt_card`,
+  `connect_card`, plus the `render_card` / `kv_section` / `links_section`
+  primitives.
+
+- **Link enrichment** threaded into `defi_swap`, `bridge`, and
+  `clawnch_launch` — every swap/bridge/launch now surfaces a clickable
+  explorer link (and DexScreener / Clanker / token-explorer links for
+  the relevant token). Safe for scheduler-driven calls (no I/O, passive
+  keys, never auto-opens).
+
+- **Auto-opening cards** wired into `defi_balance` (summary →
+  portfolio dashboard) and `clawnch_launch` (→ launch receipt), and a
+  pairing card surfaced by `/connect`. Card rendering is best-effort —
+  a UI failure never breaks the underlying read or transaction.
+
+- Test isolation: an autouse fixture points `HERMES_HOME` at a per-test
+  temp dir so card/state writes never touch the developer's real
+  `~/.hermes`.
+
 ## 0.15.0 — 2026-05-29
 
 ### Added — trader-focused features

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/clawmes/commands/wallet.py
+++ b/clawmes/commands/wallet.py
@@ -191,9 +191,20 @@ async def handle_connect(raw_args: str) -> str:
     uri = state.balances.get("_pair_uri", "")
     if not uri:
         return "WalletConnect pairing started but no URI was returned."
+    # Desktop UI: write a pairing card (URI shown large + copyable) and surface
+    # its path so it appears as a clickable artifact in the desktop. Best-effort.
+    card_line = ""
+    try:
+        from clawmes.lib.ui_cards import connect_card, write_card
+
+        card_path = write_card(connect_card(uri=uri), "connect")
+        card_line = f"Pairing card: {card_path}\n\n"
+    except Exception:  # noqa: BLE001 — UI is best-effort
+        card_line = ""
     return (
         "Scan this QR / open the link on your phone wallet to pair:\n\n"
         f"```\n{uri}\n```\n\n"
+        f"{card_line}"
         "Once you approve in your wallet, your address and chain will "
         "appear automatically. Run /wallet to confirm."
     )

--- a/clawmes/lib/ui_artifacts.py
+++ b/clawmes/lib/ui_artifacts.py
@@ -1,0 +1,201 @@
+"""UI artifact enrichment for the Hermes Desktop app.
+
+The Hermes Desktop renderer (``apps/desktop`` in NousResearch/hermes-agent)
+surfaces tool output through three generic systems, all driven by the *shape*
+of a tool's ``details`` dict — there is no plugin-UI API, so a Python plugin
+injects UI purely by emitting the right keys:
+
+1. **Artifacts view** scrapes every string value in the result; any value that
+   looks like an ``http(s)://`` URL or a file path is collected into the
+   Images / Files / Links tabs. So *any* link we put in ``details`` becomes a
+   clickable artifact regardless of its key name.
+
+2. **Structured tool-card summary** renders ``details`` keys as bullet lines,
+   prioritising ``title / name / path / url / status / …``.
+
+3. **Auto-opening side preview pane** inspects, in order, the keys
+   ``url, target, path, file, filepath, preview`` and *auto-opens the first one
+   that looks like a URL or path* in the right-rail webview.
+
+This module centralises the link construction + the precise key discipline:
+
+* Explorer / DexScreener / Clanker links go under **descriptive keys**
+  (``explorer_url``, ``dexscreener_url``, ``clanker_url``) so they become
+  passive clickable Link artifacts **without** hijacking the preview pane on
+  every call.
+* A generated HTML card is attached under the **``preview``** key (via
+  :func:`attach_preview`) so — and only so — the desktop auto-opens it.
+
+Everything here is pure (no I/O, no network) so it is cheap to unit-test and
+safe to call from inside any tool handler.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawmes.lib.chains import get_chain
+
+# DexScreener addresses chains by a URL slug rather than chain id. Only the
+# chains DexScreener actually indexes are mapped; everything else yields no
+# DexScreener link (we never emit a URL that would 404).
+_DEXSCREENER_SLUGS: dict[int, str] = {
+    1: "ethereum",
+    8453: "base",
+    42161: "arbitrum",
+    10: "optimism",
+    137: "polygon",
+    324: "zksync",
+    534352: "scroll",
+    81457: "blast",
+}
+
+# Clanker (the launchpad token explorer clawmes deploys through) is Base-only.
+_CLANKER_CHAIN_ID = 8453
+_CLANKER_BASE_URL = "https://clanker.world/clanker"
+_DEXSCREENER_BASE_URL = "https://dexscreener.com"
+
+# Keys the desktop's preview router inspects, in priority order, to decide what
+# to auto-open in the side rail. Exposed for tests + callers that need to reason
+# about whether a details dict will trigger an auto-open.
+PREVIEW_TRIGGER_KEYS: tuple[str, ...] = ("url", "target", "path", "file", "filepath", "preview")
+
+
+def _is_tx_hash(value: str) -> bool:
+    """True for a ``0x`` + 64 hex-char transaction hash."""
+    if not isinstance(value, str) or not value.startswith("0x"):
+        return False
+    body = value[2:]
+    return len(body) == 64 and all(c in "0123456789abcdefABCDEF" for c in body)
+
+
+def _is_address(value: str) -> bool:
+    """True for a ``0x`` + 40 hex-char EVM address."""
+    if not isinstance(value, str) or not value.startswith("0x"):
+        return False
+    body = value[2:]
+    return len(body) == 40 and all(c in "0123456789abcdefABCDEF" for c in body)
+
+
+def _explorer_base(chain_id: int) -> str | None:
+    """Return the block-explorer base URL for ``chain_id``, or None if unknown."""
+    try:
+        return get_chain(chain_id).block_explorer_url
+    except KeyError:
+        return None
+
+
+def explorer_tx_url(tx_hash: str, chain_id: int) -> str | None:
+    """Block-explorer URL for a transaction, or None if inputs are invalid."""
+    if not _is_tx_hash(tx_hash):
+        return None
+    base = _explorer_base(chain_id)
+    return f"{base}/tx/{tx_hash}" if base else None
+
+
+def explorer_address_url(address: str, chain_id: int) -> str | None:
+    """Block-explorer URL for an address, or None if inputs are invalid."""
+    if not _is_address(address):
+        return None
+    base = _explorer_base(chain_id)
+    return f"{base}/address/{address}" if base else None
+
+
+def explorer_token_url(token: str, chain_id: int) -> str | None:
+    """Block-explorer token page URL, or None if inputs are invalid."""
+    if not _is_address(token):
+        return None
+    base = _explorer_base(chain_id)
+    return f"{base}/token/{token}" if base else None
+
+
+def dexscreener_url(token: str, chain_id: int) -> str | None:
+    """DexScreener token page URL, or None if the chain isn't indexed."""
+    if not _is_address(token):
+        return None
+    slug = _DEXSCREENER_SLUGS.get(chain_id)
+    return f"{_DEXSCREENER_BASE_URL}/{slug}/{token}" if slug else None
+
+
+def clanker_url(token: str, chain_id: int = _CLANKER_CHAIN_ID) -> str | None:
+    """Clanker token page URL (Base only), or None otherwise."""
+    if chain_id != _CLANKER_CHAIN_ID or not _is_address(token):
+        return None
+    return f"{_CLANKER_BASE_URL}/{token}"
+
+
+def enrich_tx_links(details: dict[str, Any], *, tx_hash: str, chain_id: int) -> dict[str, Any]:
+    """Add an ``explorer_url`` for ``tx_hash`` to ``details`` (in place).
+
+    No-op when the hash/chain can't produce a valid link, and never overwrites
+    an ``explorer_url`` a tool already set. Returns ``details`` for chaining.
+    """
+    if "explorer_url" not in details:
+        url = explorer_tx_url(tx_hash, chain_id)
+        if url:
+            details["explorer_url"] = url
+    return details
+
+
+def enrich_token_links(
+    details: dict[str, Any],
+    *,
+    token: str,
+    chain_id: int,
+    include_clanker: bool = True,
+) -> dict[str, Any]:
+    """Add market/explorer links for a token to ``details`` (in place).
+
+    Adds ``dexscreener_url`` and ``token_explorer_url`` (and ``clanker_url`` on
+    Base when ``include_clanker``). Existing keys are preserved. Returns
+    ``details`` for chaining.
+    """
+    dex = dexscreener_url(token, chain_id)
+    if dex and "dexscreener_url" not in details:
+        details["dexscreener_url"] = dex
+
+    tok = explorer_token_url(token, chain_id)
+    if tok and "token_explorer_url" not in details:
+        details["token_explorer_url"] = tok
+
+    if include_clanker:
+        clank = clanker_url(token, chain_id)
+        if clank and "clanker_url" not in details:
+            details["clanker_url"] = clank
+
+    return details
+
+
+def attach_preview(details: dict[str, Any], path: str) -> dict[str, Any]:
+    """Set ``details['preview']`` so the desktop auto-opens ``path`` in the rail.
+
+    Use this ONLY for genuinely panel-worthy output (a generated HTML card,
+    a report). ``path`` should be an absolute filesystem path or an
+    ``http(s)://`` URL — anything the desktop's ``normalizePreviewTarget`` can
+    resolve. Returns ``details`` for chaining.
+    """
+    if path:
+        details["preview"] = str(path)
+    return details
+
+
+def will_auto_open(details: dict[str, Any]) -> bool:
+    """True if ``details`` would trigger the desktop to auto-open a preview.
+
+    Mirrors the desktop's ``structuredPreviewCandidate`` logic: the first of
+    :data:`PREVIEW_TRIGGER_KEYS` whose value looks like a URL or path wins.
+    Useful in tests to assert a read-only tool won't spam the preview pane.
+    """
+    for key in PREVIEW_TRIGGER_KEYS:
+        value = details.get(key)
+        if isinstance(value, str) and _looks_like_target(value):
+            return True
+    return False
+
+
+def _looks_like_target(value: str) -> bool:
+    """Match the desktop's ``looksLikePreviewTarget`` heuristic."""
+    v = value.strip()
+    if v.startswith(("http://", "https://", "file://", "/", "./", "../", "~/")):
+        return True
+    return False

--- a/clawmes/lib/ui_cards.py
+++ b/clawmes/lib/ui_cards.py
@@ -1,0 +1,243 @@
+"""HTML preview cards for the Hermes Desktop side rail.
+
+The desktop's preview pane renders a local ``.html`` file in an Electron
+webview when a tool result carries the path under the ``preview`` key (see
+:func:`clawmes.lib.ui_artifacts.attach_preview`). This module builds small,
+self-contained, **offline** HTML cards — all CSS is inline, no external
+resources, every interpolated value is HTML-escaped — so crypto capabilities
+get a real visual panel beside the chat instead of a wall of JSON.
+
+Cards are written under ``${HERMES_HOME}/clawmes/cards/`` by
+:func:`write_card`, which returns the absolute path to hand to
+``attach_preview``.
+
+Builders provided:
+
+* :func:`render_card`     — the branded shell (title + body).
+* :func:`kv_section`      — a labelled key/value table.
+* :func:`links_section`   — a list of external links.
+* :func:`portfolio_card`  — holdings table + total.
+* :func:`research_card`   — token research panel.
+* :func:`receipt_card`    — a transaction receipt (swap / launch / transfer).
+* :func:`connect_card`    — a wallet-pairing card (URI shown big + copyable).
+
+The visual language is intentionally terminal/crypto: near-black surface,
+warm clay accent (Clawnch), monospace for addresses and numbers.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from clawmes.lib.paths import state_dir
+
+# Warm clay accent (Clawnch brand) on a near-black surface.
+_ACCENT = "#d97757"
+_BG = "#0d0d0f"
+_SURFACE = "#161618"
+_STROKE = "#2a2a2e"
+_TEXT = "#ededed"
+_MUTED = "#8a8a8a"
+
+_CSS = f"""
+* {{ box-sizing: border-box; margin: 0; padding: 0; }}
+body {{
+  background: {_BG}; color: {_TEXT};
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-size: 13px; line-height: 1.5; padding: 16px;
+}}
+.card {{
+  background: {_SURFACE}; border: 1px solid {_STROKE};
+  border-radius: 12px; overflow: hidden;
+  max-width: 560px; margin: 0 auto;
+}}
+.card-head {{
+  padding: 14px 16px; border-bottom: 1px solid {_STROKE};
+  display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
+}}
+.card-title {{ font-size: 15px; font-weight: 650; letter-spacing: -0.01em; }}
+.card-sub {{ color: {_MUTED}; font-size: 11px; }}
+.card-body {{ padding: 8px 16px 16px; }}
+.section {{ margin-top: 14px; }}
+.section-h {{
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.09em;
+  color: {_MUTED}; margin-bottom: 6px;
+}}
+table.kv {{ width: 100%; border-collapse: collapse; }}
+table.kv td {{ padding: 5px 0; vertical-align: top; border-bottom: 1px solid {_STROKE}; }}
+table.kv tr:last-child td {{ border-bottom: none; }}
+table.kv td.k {{ color: {_MUTED}; width: 42%; }}
+table.kv td.v {{ text-align: right; font-variant-numeric: tabular-nums; }}
+.mono {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }}
+.pos {{ color: #5cba7d; }}
+.neg {{ color: #e0686a; }}
+.accent {{ color: {_ACCENT}; }}
+a {{ color: {_ACCENT}; text-decoration: none; }}
+a:hover {{ text-decoration: underline; }}
+.links a {{ display: block; padding: 6px 0; border-bottom: 1px solid {_STROKE}; }}
+.links a:last-child {{ border-bottom: none; }}
+.uri {{
+  background: {_BG}; border: 1px solid {_STROKE}; border-radius: 8px;
+  padding: 12px; word-break: break-all; font-size: 11px; margin-top: 4px;
+}}
+.copy {{
+  margin-top: 10px; background: {_ACCENT}; color: #1a1a1a; border: none;
+  border-radius: 8px; padding: 8px 14px; font-weight: 650; cursor: pointer;
+}}
+.foot {{ color: {_MUTED}; font-size: 10px; padding: 10px 16px; border-top: 1px solid {_STROKE}; }}
+"""
+
+
+def _esc(value: Any) -> str:
+    """HTML-escape any value for safe interpolation into a webview."""
+    return html.escape(str(value), quote=True)
+
+
+def render_card(title: str, body_html: str, *, subtitle: str = "", footer: str = "") -> str:
+    """Wrap ``body_html`` in the branded card shell. Returns a full HTML doc."""
+    sub = f'<span class="card-sub">{_esc(subtitle)}</span>' if subtitle else ""
+    foot = f'<div class="foot">{_esc(footer)}</div>' if footer else ""
+    return (
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+        f"<title>{_esc(title)}</title><style>{_CSS}</style></head><body>"
+        f'<div class="card"><div class="card-head">'
+        f'<span class="card-title">{_esc(title)}</span>{sub}</div>'
+        f'<div class="card-body">{body_html}</div>{foot}</div>'
+        "</body></html>"
+    )
+
+
+def kv_section(heading: str, rows: list[tuple[str, str]]) -> str:
+    """A labelled key/value table. ``value`` cells may contain pre-built HTML.
+
+    Keys are escaped; values are NOT (so callers can pass ``mono``/colour spans)
+    — callers must escape any untrusted value text themselves, or use
+    :func:`kv_text_row` style escaping at the call site.
+    """
+    if not rows:
+        return ""
+    body = "".join(f'<tr><td class="k">{_esc(k)}</td><td class="v">{v}</td></tr>' for k, v in rows)
+    return (
+        f'<div class="section"><div class="section-h">{_esc(heading)}</div>'
+        f'<table class="kv">{body}</table></div>'
+    )
+
+
+def links_section(heading: str, links: list[tuple[str, str]]) -> str:
+    """A list of external links: ``[(label, url), …]``. Empty links are dropped."""
+    valid = [(label, url) for label, url in links if url]
+    if not valid:
+        return ""
+    body = "".join(f'<a href="{_esc(url)}">{_esc(label)} \u2192</a>' for label, url in valid)
+    return (
+        f'<div class="section"><div class="section-h">{_esc(heading)}</div>'
+        f'<div class="links">{body}</div></div>'
+    )
+
+
+def _mono(value: Any) -> str:
+    """Escaped monospace span."""
+    return f'<span class="mono">{_esc(value)}</span>'
+
+
+def portfolio_card(
+    *,
+    address: str,
+    chain: str,
+    total_usd: float | None,
+    holdings: list[dict[str, Any]],
+) -> str:
+    """Render a portfolio dashboard card.
+
+    ``holdings`` items use keys ``symbol``, ``amount`` and optional ``usd``.
+    """
+    total = f"${total_usd:,.2f}" if total_usd is not None else "\u2014"
+    rows = [("Total value", f'<span class="accent">{_esc(total)}</span>')]
+    for h in holdings:
+        sym = _esc(h.get("symbol", "?"))
+        amt = _esc(h.get("amount", ""))
+        usd = h.get("usd")
+        usd_str = f" · ${usd:,.2f}" if isinstance(usd, (int, float)) else ""
+        rows.append((sym, f"{_mono(amt)}{_esc(usd_str)}"))
+    body = kv_section("Holdings", rows)
+    return render_card(
+        "Portfolio",
+        body,
+        subtitle=f"{_esc(chain)} · {address[:6]}\u2026{address[-4:]}"
+        if len(address) >= 10
+        else _esc(address),
+        footer="Generated by clawmes",
+    )
+
+
+def research_card(
+    *,
+    symbol: str,
+    rows: list[tuple[str, str]],
+    links: list[tuple[str, str]],
+) -> str:
+    """Render a token research panel: stats table + market links."""
+    safe_rows = [(k, _mono(v)) for k, v in rows]
+    body = kv_section("Overview", safe_rows) + links_section("Markets", links)
+    return render_card(
+        f"Research: {symbol}",
+        body,
+        subtitle="token analysis",
+        footer="Not financial advice · generated by clawmes",
+    )
+
+
+def receipt_card(
+    *,
+    title: str,
+    rows: list[tuple[str, str]],
+    links: list[tuple[str, str]],
+) -> str:
+    """Render a transaction receipt card (swap / launch / transfer)."""
+    safe_rows = [(k, _mono(v)) for k, v in rows]
+    body = kv_section("Details", safe_rows) + links_section("Links", links)
+    return render_card(title, body, subtitle="transaction", footer="generated by clawmes")
+
+
+def connect_card(*, uri: str) -> str:
+    """Render a wallet-pairing card.
+
+    Shows the WalletConnect URI in a large copyable block with a copy button.
+    (A scannable QR is a planned follow-up that needs a QR dependency; the URI
+    paste path works in every WalletConnect-compatible wallet today.)
+    """
+    safe_uri = _esc(uri)
+    body = (
+        '<div class="section"><div class="section-h">WalletConnect URI</div>'
+        f'<div class="uri mono" id="uri">{safe_uri}</div>'
+        '<button class="copy" onclick="navigator.clipboard&&navigator.clipboard.writeText('
+        "document.getElementById('uri').textContent)\">Copy URI</button>"
+        "</div>"
+        '<div class="section"><div class="section-h">How to connect</div>'
+        "<div>Open your wallet \u2192 WalletConnect \u2192 paste this URI. "
+        "The pairing request appears in your wallet.</div></div>"
+    )
+    return render_card(
+        "Connect wallet",
+        body,
+        subtitle="WalletConnect v2",
+        footer="URI is single-use and expires shortly",
+    )
+
+
+def write_card(html_str: str, name: str) -> Path:
+    """Write a card to ``${HERMES_HOME}/clawmes/cards/`` and return its path.
+
+    The filename is slugified from ``name`` and suffixed with a timestamp so
+    repeated renders don't clobber each other (the desktop reads the path
+    once at preview time). Returns the absolute path for ``attach_preview``.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "card"
+    path = state_dir("cards") / f"{slug}-{int(time.time() * 1000)}.html"
+    path.write_text(html_str, encoding="utf-8")
+    return path

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.15.0
+version: 0.16.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/tools/bridge.py
+++ b/clawmes/tools/bridge.py
@@ -199,19 +199,26 @@ def _handle_bridge(args, state) -> str:
         return error_result(f"Bridge broadcast failed: {exc}", code="send_failed")
 
     estimate = quote.get("estimate") or {}
+    result = {
+        "tx_hash": tx_hash,
+        "from_chain": inputs["from_chain"],
+        "to_chain": inputs["to_chain"],
+        "from_token": inputs["from_token"],
+        "to_token": inputs["to_token"],
+        "from_amount": str(estimate.get("fromAmount", "")),
+        "to_amount_min": str(estimate.get("toAmountMin", "")),
+        "execution_duration_seconds": estimate.get("executionDuration"),
+        "tool": quote.get("tool"),
+        "router": to,
+    }
+    # Desktop UI: clickable explorer link for the source-chain tx. get_chain
+    # accepts an int id or short name, so this is robust to either form of
+    # from_chain; an unknown chain simply yields no link.
+    from clawmes.lib.ui_artifacts import enrich_tx_links
+
+    enrich_tx_links(result, tx_hash=tx_hash, chain_id=inputs["from_chain"])
     return json_result(
-        {
-            "tx_hash": tx_hash,
-            "from_chain": inputs["from_chain"],
-            "to_chain": inputs["to_chain"],
-            "from_token": inputs["from_token"],
-            "to_token": inputs["to_token"],
-            "from_amount": str(estimate.get("fromAmount", "")),
-            "to_amount_min": str(estimate.get("toAmountMin", "")),
-            "execution_duration_seconds": estimate.get("executionDuration"),
-            "tool": quote.get("tool"),
-            "router": to,
-        },
+        result,
         summary=(
             f"Bridge submitted on chain {inputs['from_chain']}: {tx_hash}\n"
             f"  → chain {inputs['to_chain']}, expected ≈ "

--- a/clawmes/tools/clawnch_launch.py
+++ b/clawmes/tools/clawnch_launch.py
@@ -197,6 +197,38 @@ def _handle_deploy(args: dict[str, Any]) -> str:
 
     tx_hash = result.get("txHash") or result.get("tx_hash")
     token_address = result.get("tokenAddress") or result.get("token_address")
+    # Desktop UI: Clawnch launches are Base-only, so surface the tx explorer
+    # link plus Clanker / DexScreener / token-explorer links for the brand-new
+    # token as clickable Link artifacts. The enrich helpers no-op on missing or
+    # malformed values, so we call them unconditionally (passive descriptive
+    # keys — no preview auto-open from the tool itself).
+    from clawmes.lib.ui_artifacts import enrich_token_links, enrich_tx_links
+
+    enrich_tx_links(result, tx_hash=tx_hash or "", chain_id=8453)
+    enrich_token_links(result, token=token_address or "", chain_id=8453)
+
+    # Desktop UI: render a launch-receipt card and auto-open it in the side
+    # rail. clawnch_launch is user/LLM-invoked (never scheduler-driven), so a
+    # card-per-call is fine. Best-effort: never fail the launch on UI errors.
+    try:
+        from clawmes.lib.ui_artifacts import attach_preview
+        from clawmes.lib.ui_cards import receipt_card, write_card
+
+        rows = [("Symbol", symbol)]
+        if token_address:
+            rows.append(("Token", token_address))
+        if tx_hash:
+            rows.append(("Tx", tx_hash))
+        links = [
+            ("Clanker", result.get("clanker_url", "")),
+            ("DexScreener", result.get("dexscreener_url", "")),
+            ("Explorer", result.get("explorer_url", "")),
+        ]
+        card_html = receipt_card(title=f"Launched {symbol}", rows=rows, links=links)
+        attach_preview(result, str(write_card(card_html, f"launch-{symbol}")))
+    except Exception:  # noqa: BLE001 — UI is best-effort
+        pass
+
     summary_parts = [f"Launched {symbol} via Clawnch."]
     if token_address:
         summary_parts.append(f"Token: {token_address}")

--- a/clawmes/tools/defi_balance.py
+++ b/clawmes/tools/defi_balance.py
@@ -229,15 +229,30 @@ def _handle_summary(address: str, chain) -> str:
     if len(rows) == 1 and rows[0][1] == 0:
         lines.append("  (no balances)")
 
-    return json_result(
-        {
-            "address": address,
-            "chain_id": chain.chain_id,
-            "chain": chain.short_name,
-            "balances": payload,
-        },
-        summary="\n".join(lines),
-    )
+    result: dict[str, Any] = {
+        "address": address,
+        "chain_id": chain.chain_id,
+        "chain": chain.short_name,
+        "balances": payload,
+    }
+    # Desktop UI: render a portfolio card and auto-open it in the side rail via
+    # the ``preview`` key. defi_balance is never on a scheduler path, so this
+    # only fires on user/LLM-invoked balance summaries. UI enrichment must
+    # never break the underlying read, so failures are swallowed.
+    try:
+        from clawmes.lib.ui_artifacts import attach_preview
+        from clawmes.lib.ui_cards import portfolio_card, write_card
+
+        holdings = [{"symbol": p["symbol"], "amount": p["human"]} for p in payload]
+        card_html = portfolio_card(
+            address=address, chain=chain.name, total_usd=None, holdings=holdings
+        )
+        card_path = write_card(card_html, f"portfolio-{chain.short_name}")
+        attach_preview(result, str(card_path))
+    except Exception:  # noqa: BLE001 — UI is best-effort, never fail the read
+        pass
+
+    return json_result(result, summary="\n".join(lines))
 
 
 def register(ctx) -> None:

--- a/clawmes/tools/defi_swap.py
+++ b/clawmes/tools/defi_swap.py
@@ -342,17 +342,28 @@ def _handle_swap(
     except Exception as exc:  # noqa: BLE001 — surface signing/broadcast errors
         return error_result(f"Swap broadcast failed: {exc}", code="send_failed")
 
+    result = {
+        "tx_hash": tx_hash,
+        "chain_id": chain_id,
+        "sell_token": sell_token,
+        "buy_token": buy_token,
+        "sell_amount": str(quote.get("sellAmount", "")),
+        "buy_amount": str(quote.get("buyAmount", "")),
+        "min_buy_amount": str(quote.get("minBuyAmount", "")),
+        "router": to,
+    }
+    # Desktop UI: surface a clickable explorer link for the tx and market
+    # links for the bought token. These are passive Link artifacts (descriptive
+    # keys, not preview-trigger keys) so they never auto-open the side rail —
+    # safe to emit even from scheduler-driven swaps.
+    from clawmes.lib.ui_artifacts import enrich_token_links, enrich_tx_links
+
+    enrich_tx_links(result, tx_hash=tx_hash, chain_id=chain_id)
+    if buy_token and buy_token.lower() != _NATIVE_ADDRESS:
+        enrich_token_links(result, token=buy_token, chain_id=chain_id)
+
     return json_result(
-        {
-            "tx_hash": tx_hash,
-            "chain_id": chain_id,
-            "sell_token": sell_token,
-            "buy_token": buy_token,
-            "sell_amount": str(quote.get("sellAmount", "")),
-            "buy_amount": str(quote.get("buyAmount", "")),
-            "min_buy_amount": str(quote.get("minBuyAmount", "")),
-            "router": to,
-        },
+        result,
         summary=(
             f"Swap submitted: {tx_hash}\n"
             f"  {quote.get('sellAmount', '?')} {sell_token} → "

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.15.0
+version: 0.16.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.15.0"
+version = "0.16.0"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_wallet.py
+++ b/tests/commands/test_wallet.py
@@ -75,6 +75,37 @@ class TestConnect:
         out = await wallet_cmd.handle_connect("")
         assert "wc:abc@2" in out
         assert "phone wallet" in out
+        # Desktop UI: a pairing card path is surfaced as a clickable artifact.
+        assert "Pairing card:" in out
+        assert ".html" in out
+
+    @pytest.mark.asyncio
+    async def test_connect_card_failure_is_swallowed(self, monkeypatch, tmp_path):
+        from clawmes.services import wallet as wallet_svc
+        from clawmes.wallet.state import WalletState
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(wallet_svc, "_instance", None)
+        svc = wallet_svc.get_wallet_service()
+        monkeypatch.setattr(
+            svc,
+            "connect_walletconnect",
+            lambda: WalletState(
+                connected=False,
+                mode="walletconnect",
+                balances={"_pair_uri": "wc:abc@2"},
+            ),
+        )
+        import clawmes.lib.ui_cards as ui_cards
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("render failed")
+
+        monkeypatch.setattr(ui_cards, "write_card", _boom)
+        out = await wallet_cmd.handle_connect("")
+        # URI still surfaced; card line simply omitted.
+        assert "wc:abc@2" in out
+        assert "Pairing card:" not in out
 
     @pytest.mark.asyncio
     async def test_connect_no_uri_returned(self, monkeypatch, tmp_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,18 @@ def mock_ctx() -> FakePluginContext:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_hermes_home(monkeypatch, tmp_path):
+    """Point ``HERMES_HOME`` at a per-test temp dir.
+
+    Anything that writes under ``clawmes.lib.paths.state_dir`` (UI cards,
+    schedules, ledgers, …) must never touch the developer's real ``~/.hermes``
+    during a test run. Tests that need a specific home still override this with
+    their own ``monkeypatch.setenv`` afterwards (their call wins).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+@pytest.fixture(autouse=True)
 def _default_holder_tier(monkeypatch):
     """Default every test to HOLDER tier with no caps.
 

--- a/tests/lib/test_ui_artifacts.py
+++ b/tests/lib/test_ui_artifacts.py
@@ -1,0 +1,232 @@
+"""Tests for clawmes.lib.ui_artifacts."""
+
+from __future__ import annotations
+
+from clawmes.lib.ui_artifacts import (
+    PREVIEW_TRIGGER_KEYS,
+    attach_preview,
+    clanker_url,
+    dexscreener_url,
+    enrich_token_links,
+    enrich_tx_links,
+    explorer_address_url,
+    explorer_token_url,
+    explorer_tx_url,
+    will_auto_open,
+)
+
+_TX = "0x" + "a" * 64
+_ADDR = "0x" + "b" * 40
+_BAD = "0xnothex"
+# Correct length but contains a non-hex character — exercises the per-char
+# validation branch (not just the length short-circuit).
+_TX_NONHEX = "0x" + "g" * 64
+_ADDR_NONHEX = "0x" + "g" * 40
+
+
+class TestExplorerTxUrl:
+    def test_base(self):
+        assert explorer_tx_url(_TX, 8453) == f"https://basescan.org/tx/{_TX}"
+
+    def test_ethereum(self):
+        assert explorer_tx_url(_TX, 1) == f"https://etherscan.io/tx/{_TX}"
+
+    def test_bad_hash_returns_none(self):
+        assert explorer_tx_url(_BAD, 8453) is None
+
+    def test_address_is_not_a_tx_hash(self):
+        # 40-hex address is not a 64-hex tx hash.
+        assert explorer_tx_url(_ADDR, 8453) is None
+
+    def test_unknown_chain_returns_none(self):
+        assert explorer_tx_url(_TX, 999999) is None
+
+    def test_non_string_returns_none(self):
+        assert explorer_tx_url(None, 8453) is None  # type: ignore[arg-type]
+
+    def test_correct_length_nonhex_returns_none(self):
+        assert explorer_tx_url(_TX_NONHEX, 8453) is None
+
+
+class TestExplorerAddressUrl:
+    def test_base(self):
+        assert explorer_address_url(_ADDR, 8453) == f"https://basescan.org/address/{_ADDR}"
+
+    def test_bad_addr_returns_none(self):
+        assert explorer_address_url(_BAD, 8453) is None
+
+    def test_unknown_chain_returns_none(self):
+        assert explorer_address_url(_ADDR, 999999) is None
+
+    def test_correct_length_nonhex_returns_none(self):
+        assert explorer_address_url(_ADDR_NONHEX, 8453) is None
+
+
+class TestExplorerTokenUrl:
+    def test_base(self):
+        assert explorer_token_url(_ADDR, 8453) == f"https://basescan.org/token/{_ADDR}"
+
+    def test_bad_returns_none(self):
+        assert explorer_token_url(_BAD, 8453) is None
+
+    def test_unknown_chain_returns_none(self):
+        assert explorer_token_url(_ADDR, 999999) is None
+
+
+class TestDexscreenerUrl:
+    def test_base(self):
+        assert dexscreener_url(_ADDR, 8453) == f"https://dexscreener.com/base/{_ADDR}"
+
+    def test_ethereum(self):
+        assert dexscreener_url(_ADDR, 1) == f"https://dexscreener.com/ethereum/{_ADDR}"
+
+    def test_unindexed_chain_returns_none(self):
+        # A real chain id that DexScreener doesn't have a slug for here.
+        assert dexscreener_url(_ADDR, 999999) is None
+
+    def test_bad_addr_returns_none(self):
+        assert dexscreener_url(_BAD, 8453) is None
+
+    def test_non_0x_value_returns_none(self):
+        # Exercises the not-startswith-0x guard in _is_address.
+        assert dexscreener_url("notanaddress", 8453) is None
+
+
+class TestClankerUrl:
+    def test_base(self):
+        assert clanker_url(_ADDR, 8453) == f"https://clanker.world/clanker/{_ADDR}"
+
+    def test_default_chain_is_base(self):
+        assert clanker_url(_ADDR) == f"https://clanker.world/clanker/{_ADDR}"
+
+    def test_non_base_returns_none(self):
+        assert clanker_url(_ADDR, 1) is None
+
+    def test_bad_addr_returns_none(self):
+        assert clanker_url(_BAD, 8453) is None
+
+
+class TestEnrichTxLinks:
+    def test_adds_explorer_url(self):
+        details: dict = {"tx_hash": _TX}
+        enrich_tx_links(details, tx_hash=_TX, chain_id=8453)
+        assert details["explorer_url"] == f"https://basescan.org/tx/{_TX}"
+
+    def test_returns_same_dict(self):
+        details: dict = {}
+        assert enrich_tx_links(details, tx_hash=_TX, chain_id=8453) is details
+
+    def test_does_not_overwrite_existing(self):
+        details = {"explorer_url": "https://custom.example/tx"}
+        enrich_tx_links(details, tx_hash=_TX, chain_id=8453)
+        assert details["explorer_url"] == "https://custom.example/tx"
+
+    def test_noop_on_bad_hash(self):
+        details: dict = {}
+        enrich_tx_links(details, tx_hash=_BAD, chain_id=8453)
+        assert "explorer_url" not in details
+
+    def test_explorer_url_does_not_auto_open(self):
+        # explorer_url is NOT a preview-trigger key, so it must not auto-open.
+        details: dict = {}
+        enrich_tx_links(details, tx_hash=_TX, chain_id=8453)
+        assert will_auto_open(details) is False
+
+
+class TestEnrichTokenLinks:
+    def test_adds_all_base_links(self):
+        details: dict = {}
+        enrich_token_links(details, token=_ADDR, chain_id=8453)
+        assert details["dexscreener_url"] == f"https://dexscreener.com/base/{_ADDR}"
+        assert details["token_explorer_url"] == f"https://basescan.org/token/{_ADDR}"
+        assert details["clanker_url"] == f"https://clanker.world/clanker/{_ADDR}"
+
+    def test_no_clanker_off_base(self):
+        details: dict = {}
+        enrich_token_links(details, token=_ADDR, chain_id=1)
+        assert "clanker_url" not in details
+        assert details["dexscreener_url"] == f"https://dexscreener.com/ethereum/{_ADDR}"
+
+    def test_include_clanker_false(self):
+        details: dict = {}
+        enrich_token_links(details, token=_ADDR, chain_id=8453, include_clanker=False)
+        assert "clanker_url" not in details
+
+    def test_preserves_existing(self):
+        details = {
+            "dexscreener_url": "x",
+            "token_explorer_url": "y",
+            "clanker_url": "z",
+        }
+        enrich_token_links(details, token=_ADDR, chain_id=8453)
+        assert details == {"dexscreener_url": "x", "token_explorer_url": "y", "clanker_url": "z"}
+
+    def test_noop_on_bad_token(self):
+        details: dict = {}
+        enrich_token_links(details, token=_BAD, chain_id=8453)
+        assert details == {}
+
+    def test_returns_same_dict(self):
+        details: dict = {}
+        assert enrich_token_links(details, token=_ADDR, chain_id=8453) is details
+
+    def test_token_links_do_not_auto_open(self):
+        details: dict = {}
+        enrich_token_links(details, token=_ADDR, chain_id=8453)
+        assert will_auto_open(details) is False
+
+
+class TestAttachPreview:
+    def test_sets_preview(self):
+        details: dict = {}
+        attach_preview(details, "/tmp/card.html")
+        assert details["preview"] == "/tmp/card.html"
+
+    def test_empty_path_noop(self):
+        details: dict = {}
+        attach_preview(details, "")
+        assert "preview" not in details
+
+    def test_coerces_to_str(self, tmp_path):
+        details: dict = {}
+        card = tmp_path / "card.html"
+        attach_preview(details, card)  # type: ignore[arg-type]
+        assert details["preview"] == str(card)
+
+    def test_returns_same_dict(self):
+        details: dict = {}
+        assert attach_preview(details, "/x.html") is details
+
+    def test_preview_triggers_auto_open(self):
+        details: dict = {}
+        attach_preview(details, "/tmp/card.html")
+        assert will_auto_open(details) is True
+
+
+class TestWillAutoOpen:
+    def test_url_key_triggers(self):
+        assert will_auto_open({"url": "https://example.com"}) is True
+
+    def test_http_target(self):
+        assert will_auto_open({"target": "http://x.io"}) is True
+
+    def test_file_uri(self):
+        assert will_auto_open({"path": "file:///tmp/x"}) is True
+
+    def test_relative_path(self):
+        assert will_auto_open({"file": "./out.html"}) is True
+
+    def test_home_path(self):
+        assert will_auto_open({"filepath": "~/out.html"}) is True
+
+    def test_non_target_value(self):
+        assert will_auto_open({"url": "just a string"}) is False
+
+    def test_non_string_value(self):
+        assert will_auto_open({"url": 123}) is False
+
+    def test_empty(self):
+        assert will_auto_open({}) is False
+
+    def test_trigger_keys_constant(self):
+        assert PREVIEW_TRIGGER_KEYS == ("url", "target", "path", "file", "filepath", "preview")

--- a/tests/lib/test_ui_cards.py
+++ b/tests/lib/test_ui_cards.py
@@ -1,0 +1,206 @@
+"""Tests for clawmes.lib.ui_cards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clawmes.lib import ui_cards
+
+
+class TestRenderCard:
+    def test_includes_title_and_body(self):
+        out = ui_cards.render_card("My Title", "<p>hi</p>")
+        assert "My Title" in out
+        assert "<p>hi</p>" in out
+        assert out.startswith("<!doctype html>")
+
+    def test_subtitle_rendered_when_set(self):
+        out = ui_cards.render_card("T", "b", subtitle="sub here")
+        assert "sub here" in out
+        assert '<span class="card-sub">' in out
+
+    def test_subtitle_absent_when_empty(self):
+        out = ui_cards.render_card("T", "b")
+        # the .card-sub CSS rule is always present; the span is not
+        assert '<span class="card-sub">' not in out
+
+    def test_footer_rendered_when_set(self):
+        out = ui_cards.render_card("T", "b", footer="foot text")
+        assert "foot text" in out
+        assert "foot" in out
+
+    def test_footer_absent_when_empty(self):
+        out = ui_cards.render_card("T", "b")
+        assert 'class="foot"' not in out
+
+    def test_title_is_escaped(self):
+        out = ui_cards.render_card("<script>alert(1)</script>", "b")
+        assert "<script>alert(1)</script>" not in out
+        assert "&lt;script&gt;" in out
+
+    def test_subtitle_and_footer_escaped(self):
+        out = ui_cards.render_card("T", "b", subtitle="<i>s</i>", footer="<i>f</i>")
+        assert "<i>s</i>" not in out
+        assert "<i>f</i>" not in out
+
+
+class TestKvSection:
+    def test_renders_rows(self):
+        out = ui_cards.kv_section("Heading", [("Key", "Val")])
+        assert "Heading" in out
+        assert "Key" in out
+        assert "Val" in out
+
+    def test_empty_rows_returns_empty(self):
+        assert ui_cards.kv_section("H", []) == ""
+
+    def test_key_is_escaped(self):
+        out = ui_cards.kv_section("H", [("<b>k</b>", "v")])
+        assert "<b>k</b>" not in out
+
+    def test_value_html_passthrough(self):
+        # values may contain pre-built HTML (mono spans, colour) by design
+        out = ui_cards.kv_section("H", [("k", '<span class="mono">0xabc</span>')])
+        assert '<span class="mono">0xabc</span>' in out
+
+
+class TestLinksSection:
+    def test_renders_links(self):
+        out = ui_cards.links_section("Markets", [("DexScreener", "https://d.com")])
+        assert "DexScreener" in out
+        assert "https://d.com" in out
+
+    def test_drops_blank_urls(self):
+        out = ui_cards.links_section("M", [("A", ""), ("B", "https://b.com")])
+        assert "B" in out
+        assert ">A " not in out
+
+    def test_all_blank_returns_empty(self):
+        assert ui_cards.links_section("M", [("A", ""), ("B", "")]) == ""
+
+    def test_empty_returns_empty(self):
+        assert ui_cards.links_section("M", []) == ""
+
+    def test_url_escaped(self):
+        out = ui_cards.links_section("M", [("L", 'https://x.com/"onmouseover')])
+        assert '"onmouseover' not in out.split("href=")[1][:40]
+
+
+class TestPortfolioCard:
+    def test_total_formatted(self):
+        out = ui_cards.portfolio_card(
+            address="0x" + "a" * 40, chain="Base", total_usd=1234.5, holdings=[]
+        )
+        assert "$1,234.50" in out
+        assert "Portfolio" in out
+
+    def test_total_none_renders_dash(self):
+        out = ui_cards.portfolio_card(
+            address="0x" + "a" * 40, chain="Base", total_usd=None, holdings=[]
+        )
+        assert "\u2014" in out
+
+    def test_holding_with_usd(self):
+        out = ui_cards.portfolio_card(
+            address="0x" + "a" * 40,
+            chain="Base",
+            total_usd=None,
+            holdings=[{"symbol": "WETH", "amount": "1.5", "usd": 5000.0}],
+        )
+        assert "WETH" in out
+        assert "1.5" in out
+        assert "$5,000.00" in out
+
+    def test_holding_without_usd(self):
+        out = ui_cards.portfolio_card(
+            address="0x" + "a" * 40,
+            chain="Base",
+            total_usd=None,
+            holdings=[{"symbol": "FOO", "amount": "10"}],
+        )
+        assert "FOO" in out
+        assert "10" in out
+
+    def test_address_truncated_when_long(self):
+        addr = "0x" + "a" * 40
+        out = ui_cards.portfolio_card(address=addr, chain="Base", total_usd=None, holdings=[])
+        assert f"{addr[:6]}\u2026{addr[-4:]}" in out
+
+    def test_short_address_not_truncated(self):
+        out = ui_cards.portfolio_card(address="0xabc", chain="Base", total_usd=None, holdings=[])
+        assert "0xabc" in out
+
+    def test_holding_symbol_escaped(self):
+        out = ui_cards.portfolio_card(
+            address="0xabc",
+            chain="Base",
+            total_usd=None,
+            holdings=[{"symbol": "<x>", "amount": "1"}],
+        )
+        assert "<x>" not in out
+
+
+class TestResearchCard:
+    def test_rows_and_links(self):
+        out = ui_cards.research_card(
+            symbol="MNEME",
+            rows=[("Price", "$0.01"), ("Liquidity", "$5k")],
+            links=[("DexScreener", "https://d.com")],
+        )
+        assert "MNEME" in out
+        assert "Price" in out
+        assert "$0.01" in out
+        assert "DexScreener" in out
+
+    def test_value_escaped(self):
+        out = ui_cards.research_card(symbol="X", rows=[("k", "<b>v</b>")], links=[])
+        assert "<b>v</b>" not in out
+
+
+class TestReceiptCard:
+    def test_rows_and_links(self):
+        out = ui_cards.receipt_card(
+            title="Swap submitted",
+            rows=[("Sold", "0.1 ETH"), ("Bought", "300 USDC")],
+            links=[("Explorer", "https://basescan.org/tx/0x")],
+        )
+        assert "Swap submitted" in out
+        assert "0.1 ETH" in out
+        assert "Explorer" in out
+
+
+class TestConnectCard:
+    def test_uri_present(self):
+        out = ui_cards.connect_card(uri="wc:abc123@2?relay=x")
+        assert "wc:abc123@2?relay=x" in out
+        assert "Copy URI" in out
+
+    def test_uri_escaped(self):
+        out = ui_cards.connect_card(uri="wc:<script>@2")
+        assert "wc:<script>@2" not in out
+
+
+class TestWriteCard:
+    def test_writes_file_and_returns_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        path = ui_cards.write_card("<html></html>", "Portfolio")
+        assert isinstance(path, Path)
+        assert path.exists()
+        assert path.read_text(encoding="utf-8") == "<html></html>"
+        assert path.parent == tmp_path / "clawmes" / "cards"
+
+    def test_slugifies_name(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        path = ui_cards.write_card("x", "Swap Receipt!")
+        assert path.name.startswith("swap-receipt-")
+        assert path.suffix == ".html"
+
+    def test_non_alnum_name_falls_back_to_card(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        path = ui_cards.write_card("x", "!!!")
+        assert path.name.startswith("card-")
+
+    def test_path_is_absolute(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        path = ui_cards.write_card("x", "p")
+        assert path.is_absolute()

--- a/tests/tools/test_clawnch_launch.py
+++ b/tests/tools/test_clawnch_launch.py
@@ -67,6 +67,24 @@ class TestDeploy:
         # source defaulted by service, not by tool
         assert fake_svc.deploys[0]["params"] == {"name": "Foo", "symbol": "FOO"}
 
+    def test_deploy_attaches_receipt_preview(self, fake_svc):
+        # Desktop UI: a launch-receipt card is written + surfaced for auto-open.
+        out = json.loads(clawnch_launch({"action": "deploy", "name": "Foo", "symbol": "FOO"}))
+        assert out["details"]["preview"].endswith(".html")
+        assert "launch-foo" in out["details"]["preview"].lower()
+
+    def test_deploy_card_failure_is_swallowed(self, fake_svc, monkeypatch):
+        # A UI rendering failure must never break the actual launch.
+        import clawmes.lib.ui_cards as ui_cards
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("render failed")
+
+        monkeypatch.setattr(ui_cards, "write_card", _boom)
+        out = json.loads(clawnch_launch({"action": "deploy", "name": "Foo", "symbol": "FOO"}))
+        assert out["details"]["txHash"] == "0xtx"
+        assert "preview" not in out["details"]
+
     def test_with_description_image(self, fake_svc):
         clawnch_launch(
             {

--- a/tests/tools/test_defi_balance.py
+++ b/tests/tools/test_defi_balance.py
@@ -132,6 +132,32 @@ class TestSummaryAction:
         text = out["content"][0]["text"]
         assert "no balances" in text.lower()
 
+    def test_summary_attaches_portfolio_preview(self, fake_rpc):
+        # Desktop UI: a portfolio card is written and surfaced under the
+        # ``preview`` key so the desktop auto-opens it in the side rail.
+        import os
+
+        fake_rpc.balance_responses[(HOLDER.lower(), 8453)] = 10**18
+        out = json.loads(defi_balance({"action": "summary", "address": HOLDER, "chain": "base"}))
+        preview = out["details"]["preview"]
+        assert preview.endswith(".html")
+        assert "portfolio" in preview
+        assert os.path.exists(preview)
+
+    def test_summary_card_failure_is_swallowed(self, fake_rpc, monkeypatch):
+        # If card rendering blows up, the balance read must still succeed and
+        # simply omit the preview (UI is best-effort).
+        import clawmes.lib.ui_cards as ui_cards
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(ui_cards, "write_card", _boom)
+        fake_rpc.balance_responses[(HOLDER.lower(), 8453)] = 10**18
+        out = json.loads(defi_balance({"action": "summary", "address": HOLDER, "chain": "base"}))
+        assert "preview" not in out["details"]
+        assert any(b["symbol"] == "ETH" for b in out["details"]["balances"])
+
     def test_native_rpc_error(self, fake_rpc):
         fake_rpc.failure_targets.add(HOLDER.lower())
         out = json.loads(defi_balance({"action": "summary", "address": HOLDER, "chain": "base"}))


### PR DESCRIPTION
## What & why

The [Hermes Desktop app](https://github.com/NousResearch/hermes-agent/tree/main/apps/desktop) is an Electron + React shell over the same agent runtime clawmes plugs into. It has **no plugin-UI API** — a Python plugin can only influence the UI through the *shape* of what its tools return. The desktop renders tool output through three generic systems:

1. **Artifacts view** — scrapes every result string for image/file/link values → Images / Files / Links tabs.
2. **Structured tool-card summary** — prioritised key/value rendering in chat.
3. **Auto-opening side preview pane** — opens the first of `url/target/path/file/filepath/preview` that looks like a URL or path, in an Electron webview (HTML supported).

Today clawmes emits almost nothing renderable (only `transfer`/`block_explorer` had an explorer link), so crypto capabilities appear as plain text. This PR shapes clawmes output to light those systems up — no fork of NousResearch needed; this is the intended extension model.

## New foundation libs (both 100% covered)

- **`clawmes/lib/ui_artifacts.py`** — link builders (`explorer_tx_url`, `explorer_address_url`, `explorer_token_url`, `dexscreener_url`, `clanker_url`) + `enrich_tx_links` / `enrich_token_links`. Links use **descriptive keys** (`explorer_url`, `dexscreener_url`, `clanker_url`) so they become clickable **Link artifacts** without auto-opening the pane. `attach_preview` / `will_auto_open` precisely control the preview trigger keys.
- **`clawmes/lib/ui_cards.py`** — self-contained, offline, HTML-escaped preview **cards** written to `${HERMES_HOME}/clawmes/cards/` and surfaced under `preview` so the desktop auto-opens them in the side rail: `portfolio_card`, `research_card`, `receipt_card`, `connect_card` + `render_card`/`kv_section`/`links_section` primitives.

## Wiring

| Surface | UI result |
|---|---|
| `defi_swap`, `bridge`, `clawnch_launch` | clickable Explorer + DexScreener/Clanker/token links (passive, no I/O — safe for schedulers) |
| `defi_balance` (summary) | **auto-opens a portfolio dashboard** in the side rail (read tool, never scheduler-driven) |
| `clawnch_launch` | **auto-opens a launch-receipt card** (user/LLM-invoked only) |
| `/connect` | WalletConnect **pairing card** (URI large + copyable) |

Card rendering is **best-effort** — a UI failure never breaks the underlying read or transaction (covered by explicit swallowed-failure tests).

## Design decisions

- **Links vs auto-open** is deliberate: read/price/scheduler tools emit links under descriptive keys so they're clickable artifacts but **never** spam the preview pane; only genuinely panel-worthy actions set `preview`.
- **Cards on tools, not on automation** — `defi_balance` summary and `clawnch_launch` are not on any scheduler path, so card-per-call is fine. `defi_swap` (called by DCA/copy/sniper/limit_order schedulers) gets **links only**, no card, to avoid file-spam.
- **QR**: `connect_card` shows the URI large + copyable now; a scannable QR needs a QR dependency and is a flagged follow-up (kept this PR dependency-free).

## Test isolation

New autouse fixture points `HERMES_HOME` at a per-test temp dir so card/state writes never touch the developer's real `~/.hermes`. Coverage measures `clawmes/` source only, so conftest additions are coverage-free.

## Verification

- **4568 passed, 8 skipped**
- **100% line coverage** (16,175 statements, 0 missing) — the gate
- `ruff check` + `ruff format` clean
- `plugin.yaml` byte-identical (root + `clawmes/`)
- Tool count unchanged (new modules are libraries, not registered tools)

## Follow-ups (mechanical)

- Thread link enrichment through remaining tx/token tools (`defi_lend`, `defi_stake`, `nft`, `liquidity`, `permit2`, `defi_price`, `market_intel`, `cost_basis`).
- Wire `research_card` into `/research`; add a scannable QR to `connect_card`.
- Per-toolset descriptions for the desktop Settings → toolset panel.