### PR TITLE
feat(desktop): extend link enrichment + /research card (v0.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.16.1 — 2026-06-02
+
+### Added — Hermes Desktop UI follow-ups
+
+Continues the v0.16.0 desktop integration across more surfaces.
+
+- **Link enrichment** extended to `defi_lend` (Aave supply/withdraw/
+  borrow/repay), `defi_stake` (Lido/Rocket Pool), and `permit2` (revoke):
+  each now surfaces a clickable explorer link for the tx — and, for
+  `defi_lend`, DexScreener/Clanker/token-explorer links for the asset.
+  Passive descriptive keys (no preview auto-open), so they're safe on
+  any call path.
+
+- **`/research <token>`** now writes a research card
+  (`research_card`) — price, liquidity, volume, market cap, 24h change,
+  risk flags, plus DexScreener/Clanker/explorer links — and surfaces its
+  path as a clickable artifact beneath the text report. Best-effort: a
+  card failure never affects the report.
+
 ## 0.16.0 — 2026-06-02
 
 ### Added — Hermes Desktop UI integration

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"

--- a/clawmes/commands/research.py
+++ b/clawmes/commands/research.py
@@ -75,12 +75,61 @@ async def handle_research(raw_args: str, *, sender_id: str = "default", **_kwarg
         out = json.dumps(report, indent=2)
     elif use_narrative:
         narrative = _llm_synthesize(report)
-        out = _render_report(report) + ("\n\n" + narrative if narrative else "")
+        out = (
+            _render_report(report)
+            + ("\n\n" + narrative if narrative else "")
+            + _card_suffix(report, token)
+        )
     else:
-        out = _render_report(report)
+        out = _render_report(report) + _card_suffix(report, token)
 
     _record("research", raw_args, out)
     return out
+
+
+def _card_suffix(report: dict[str, Any], token: str) -> str:
+    """Build a Desktop research card and return a line pointing at it.
+
+    Returns ``""`` when there's nothing to show or anything fails — the card
+    is a best-effort UI nicety layered on top of the text report. The card
+    path surfaces as a clickable File artifact in the Hermes Desktop app.
+    """
+    try:
+        from clawmes.lib.ui_artifacts import clanker_url, dexscreener_url, explorer_token_url
+        from clawmes.lib.ui_cards import research_card, write_card
+
+        dex = report.get("dex") or {}
+        symbol = dex.get("symbol") or token
+        specs = [
+            ("Price", "price_usd"),
+            ("Liquidity", "liquidity_usd"),
+            ("Volume 24h", "volume_24h"),
+            ("Market cap", "market_cap"),
+            ("Change 24h", "price_change_24h"),
+        ]
+        rows: list[tuple[str, str]] = []
+        for label, key in specs:
+            value = dex.get(key)
+            if value is not None:
+                rows.append((label, str(value)))
+        flags = report.get("flags") or []
+        if flags:
+            rows.append(("Risk flags", ", ".join(str(f) for f in flags)))
+
+        addr = report.get("resolved_address") or ""
+        links = [
+            ("DexScreener", dexscreener_url(addr, 8453) or ""),
+            ("Clanker", clanker_url(addr, 8453) or ""),
+            ("Explorer", explorer_token_url(addr, 8453) or ""),
+        ]
+        if not rows:
+            return ""
+        card_path = write_card(
+            research_card(symbol=symbol, rows=rows, links=links), f"research-{symbol}"
+        )
+        return f"\n\nResearch card: {card_path}\n"
+    except Exception:  # noqa: BLE001 — UI is best-effort
+        return ""
 
 
 # ── data sources ───────────────────────────────────────────────────

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.16.0
+version: 0.16.1
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/tools/defi_lend.py
+++ b/clawmes/tools/defi_lend.py
@@ -260,16 +260,23 @@ def _send(*, state, pool, calldata, chain_id, action, asset, amount_base) -> str
     except Exception as exc:  # noqa: BLE001
         return error_result(f"{action} failed: {exc}", code="send_failed")
 
+    result = {
+        "tx_hash": tx_hash,
+        "chain_id": chain_id,
+        "pool": pool,
+        "action": action,
+        "asset": asset,
+        "amount": str(amount_base),
+        "is_full_balance": amount_base == UNLIMITED_ALLOWANCE,
+    }
+    # Desktop UI: clickable explorer link for the tx (+ market links for the
+    # asset). Passive descriptive keys — never auto-opens the preview pane.
+    from clawmes.lib.ui_artifacts import enrich_token_links, enrich_tx_links
+
+    enrich_tx_links(result, tx_hash=tx_hash, chain_id=chain_id)
+    enrich_token_links(result, token=asset, chain_id=chain_id)
     return json_result(
-        {
-            "tx_hash": tx_hash,
-            "chain_id": chain_id,
-            "pool": pool,
-            "action": action,
-            "asset": asset,
-            "amount": str(amount_base),
-            "is_full_balance": amount_base == UNLIMITED_ALLOWANCE,
-        },
+        result,
         summary=(f"Aave {action}: {tx_hash}\n  asset={asset}\n  amount={amount_base}"),
     )
 

--- a/clawmes/tools/defi_stake.py
+++ b/clawmes/tools/defi_stake.py
@@ -191,16 +191,21 @@ def _handle_stake(state, protocol: str, chain_id: int, args) -> str:
     except Exception as exc:  # noqa: BLE001
         return error_result(f"Stake failed: {exc}", code="send_failed")
 
+    result = {
+        "tx_hash": tx_hash,
+        "protocol": protocol,
+        "name": protocol_name(protocol),
+        "chain_id": chain_id,
+        "amount_eth": amount_raw,
+        "amount_wei": str(value_wei),
+        "contract": contract,
+    }
+    # Desktop UI: clickable explorer link for the stake tx.
+    from clawmes.lib.ui_artifacts import enrich_tx_links
+
+    enrich_tx_links(result, tx_hash=tx_hash, chain_id=chain_id)
     return json_result(
-        {
-            "tx_hash": tx_hash,
-            "protocol": protocol,
-            "name": protocol_name(protocol),
-            "chain_id": chain_id,
-            "amount_eth": amount_raw,
-            "amount_wei": str(value_wei),
-            "contract": contract,
-        },
+        result,
         summary=(
             f"Staked {amount_raw} ETH via {protocol_name(protocol)}: {tx_hash}\n"
             f"  Receipt token will mint in the same block."

--- a/clawmes/tools/permit2.py
+++ b/clawmes/tools/permit2.py
@@ -199,15 +199,17 @@ def _handle_revoke(args, state, chain_id: int) -> str:
     except Exception as exc:  # noqa: BLE001
         return error_result(f"Revoke failed: {exc}", code="send_failed")
 
-    return json_result(
-        {
-            "tx_hash": tx_hash,
-            "token": token,
-            "spender": spender,
-            "permit2_address": PERMIT2_ADDRESS,
-        },
-        summary=f"Permit2 revoke: {tx_hash}",
-    )
+    result = {
+        "tx_hash": tx_hash,
+        "token": token,
+        "spender": spender,
+        "permit2_address": PERMIT2_ADDRESS,
+    }
+    # Desktop UI: clickable explorer link for the revoke tx.
+    from clawmes.lib.ui_artifacts import enrich_tx_links
+
+    enrich_tx_links(result, tx_hash=tx_hash, chain_id=chain_id)
+    return json_result(result, summary=f"Permit2 revoke: {tx_hash}")
 
 
 def _handle_list(args, state, chain_id: int) -> str:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.16.0
+version: 0.16.1
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.16.0"
+version = "0.16.1"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_v014_additions.py
+++ b/tests/commands/test_v014_additions.py
@@ -1197,6 +1197,36 @@ class TestResearchHelpers:
     def test_fmt_pct_string(self):
         assert research._fmt_pct("text") == "text"
 
+
+class TestResearchCard:
+    """Desktop UI: /research writes a research card surfaced as an artifact."""
+
+    def test_card_suffix_rich(self):
+        # Partial dex (price + liquidity present, others absent) exercises both
+        # the value-present and value-absent branches of the row loop.
+        report = {
+            "dex": {"symbol": "MNEME", "price_usd": 0.0001, "liquidity_usd": 5000.0},
+            "flags": ["low_liquidity"],
+            "resolved_address": "0x" + "a" * 40,
+        }
+        out = research._card_suffix(report, "MNEME")
+        assert "Research card:" in out
+        assert ".html" in out
+
+    def test_card_suffix_empty_report(self):
+        # No dex data, no flags → nothing to render → empty suffix.
+        assert research._card_suffix({}, "FOO") == ""
+
+    def test_card_suffix_swallows_errors(self, monkeypatch):
+        import clawmes.lib.ui_cards as ui_cards
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("render failed")
+
+        monkeypatch.setattr(ui_cards, "write_card", _boom)
+        report = {"dex": {"symbol": "X", "price_usd": 1.0}, "flags": []}
+        assert research._card_suffix(report, "X") == ""
+
     def test_fmt_usd_none(self):
         assert research._fmt_usd(None) == "?"
 


### PR DESCRIPTION
Follow-ups to #34 (v0.16.0 Hermes Desktop integration), continuing the same patterns across more surfaces.

## Changes

**Link enrichment** (clickable explorer/market Link artifacts, passive — never auto-open the preview pane, safe on scheduler call paths):
- `defi_lend` (Aave supply/withdraw/borrow/repay) — explorer tx link + DexScreener/Clanker/token-explorer links for the asset
- `defi_stake` (Lido stETH / Rocket Pool rETH) — explorer tx link
- `permit2` (revoke) — explorer tx link

**`/research <token>`** now renders a research card — price, liquidity, volume, market cap, 24h change, risk flags, plus DexScreener/Clanker/explorer links — and surfaces its path as a clickable artifact beneath the text report. Best-effort (a card failure never affects the report).

## Verification
- **4571 passed, 8 skipped**
- **100% line coverage** (16,208 statements, 0 missing)
- `ruff check` + `ruff format` clean
- `plugin.yaml` byte-identical (root + `clawmes/`)
- Tool count unchanged

## Remaining follow-ups
- `nft` (mint/transfer/burn) + `liquidity` (add/remove/collect) have multiple tx sites — enrich in a later pass.
- Read-tool token links (`defi_price`, `market_intel`, `cost_basis`).
- Scannable QR for `connect_card` (needs a QR dependency).
- Per-toolset descriptions for the desktop Settings → toolset panel.