### PR TITLE
feat(desktop): complete tx-tool explorer links — nft + liquidity (v0.16.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.16.2 — 2026-06-02
+
+### Added — Hermes Desktop UI: complete tx-tool link coverage
+
+- Link enrichment threaded into `nft` (mint / transfer / burn) and
+  `liquidity` (provide / withdraw / compound) via their shared `_send`
+  helpers — each now surfaces a clickable explorer link for the tx.
+  (ERC-721 market links are intentionally omitted from `nft`; DexScreener
+  and Clanker don't apply to NFTs.) This completes explorer-link coverage
+  across every clawmes transaction-producing tool.
+
+### Notes — intentionally deferred
+
+- **Read-tool token links** (`defi_price`, `market_intel`, `cost_basis`):
+  these don't carry a token address + chain pair (CoinGecko ids;
+  chain-agnostic cost tracking), so a correct market link can't be built
+  without guessing — skipped rather than emit wrong links.
+- **Scannable QR** for the connect card needs a QR dependency; kept the
+  plugin dependency-free pending an explicit decision.
+- **Per-toolset descriptions**: the Hermes registration API exposes
+  per-*tool* descriptions only (no per-toolset metadata), so there's
+  nothing to add for the desktop Settings panel.
+
 ## 0.16.1 — 2026-06-02
 
 ### Added — Hermes Desktop UI follow-ups

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.16.1"
+__version__ = "0.16.2"

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.16.1
+version: 0.16.2
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/tools/liquidity.py
+++ b/clawmes/tools/liquidity.py
@@ -403,10 +403,12 @@ def _send(state, calldata: str, chain_id: int, action: str) -> str:
         )
     except Exception as exc:  # noqa: BLE001
         return error_result(f"{action} failed: {exc}", code="send_failed")
-    return json_result(
-        {"tx_hash": tx_hash, "action": action},
-        summary=f"liquidity {action}: {tx_hash}",
-    )
+    result = {"tx_hash": tx_hash, "action": action, "chain_id": chain_id}
+    # Desktop UI: clickable explorer link for the LP-management tx.
+    from clawmes.lib.ui_artifacts import enrich_tx_links
+
+    enrich_tx_links(result, tx_hash=tx_hash, chain_id=chain_id)
+    return json_result(result, summary=f"liquidity {action}: {tx_hash}")
 
 
 def register(ctx) -> None:

--- a/clawmes/tools/nft.py
+++ b/clawmes/tools/nft.py
@@ -241,15 +241,18 @@ def _send(*, state, to, value, data, chain_id, action) -> str:
     except Exception as exc:  # noqa: BLE001
         return error_result(f"{action} failed: {exc}", code="send_failed")
 
-    return json_result(
-        {
-            "tx_hash": tx_hash,
-            "action": action,
-            "contract": to,
-            "chain_id": chain_id,
-        },
-        summary=f"NFT {action}: {tx_hash}",
-    )
+    result = {
+        "tx_hash": tx_hash,
+        "action": action,
+        "contract": to,
+        "chain_id": chain_id,
+    }
+    # Desktop UI: clickable explorer link for the NFT tx. (DexScreener/Clanker
+    # don't apply to ERC-721s, so token-market links are intentionally omitted.)
+    from clawmes.lib.ui_artifacts import enrich_tx_links
+
+    enrich_tx_links(result, tx_hash=tx_hash, chain_id=chain_id)
+    return json_result(result, summary=f"NFT {action}: {tx_hash}")
 
 
 def _handle_read(action: str, args, state, chain_id: int) -> str:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.16.1
+version: 0.16.2
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.16.1"
+version = "0.16.2"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Completes explorer-link coverage across **every** clawmes transaction-producing tool, following #34 (v0.16.0) and #35 (v0.16.1).

## Changes
- **`nft`** (mint / transfer / burn) — explorer tx link via the shared `_send` helper. ERC-721 market links intentionally omitted (DexScreener/Clanker don't apply to NFTs).
- **`liquidity`** (provide / withdraw / compound) — explorer tx link via its shared `_send` helper; also adds `chain_id` to the result.

Both tools route all writes through one `_send` helper, so this is a single enrichment site each.

## Deferred (with reasons)
- **Read-tool token links** (`defi_price`/`market_intel`/`cost_basis`) — no token-address + chain pair available (CoinGecko ids; chain-agnostic cost tracking). Emitting a link would require guessing the chain, so skipped rather than ship wrong links.
- **Scannable QR** for the connect card — needs a QR dependency; kept the plugin dependency-free pending an explicit decision.
- **Per-toolset descriptions** — the Hermes registration API exposes per-*tool* descriptions only; there's no per-toolset metadata to populate.

## Verification
- **4571 passed, 8 skipped**
- **100% line coverage** (16,214 statements, 0 missing)
- `ruff check` + `ruff format` clean
- `plugin.yaml` byte-identical (root + `clawmes/`)
- Tool count unchanged