### PR TITLE
fix(desktop): emit preview at envelope top level so cards actually render (v0.16.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.16.4 — 2026-06-02
+
+### Fixed — preview cards now actually reach the desktop
+
+A source-level audit of NousResearch/hermes-agent (the gateway event publisher
++ the desktop renderer) revealed the v0.16.0 card mechanism was emitting the
+preview path one level too deep:
+
+- The desktop chat tool-card (`tool-fallback-model.ts` `toolPreviewTarget`)
+  reads the **top level** of the tool-result envelope — `result.preview` /
+  `result.url` — **not** `result.details.preview`. clawmes was placing the
+  card path inside `details`, so cards never rendered as in-app preview
+  attachments (they only appeared as external-open File artifacts).
+
+Fix:
+
+- `json_result` gained a `preview=` keyword that emits an **envelope
+  top-level** `preview` key (sibling of `content`/`details`). `defi_balance`
+  (portfolio) and `clawnch_launch` (receipt) now pass their card path there,
+  so the desktop opens them in the preview pane.
+- Removed `attach_preview` / `will_auto_open` / `PREVIEW_TRIGGER_KEYS` from
+  `ui_artifacts` — they encoded the disproven "details.preview auto-opens"
+  assumption.
+- `write_card` filenames now include a random suffix (not just a ms timestamp)
+  so rapid same-millisecond renders can't collide.
+
+Link enrichment was unaffected by the bug — the desktop Artifacts view
+deep-recurses the result JSON, so `details.*_url` links surfaced correctly all
+along; this release only fixes the card/preview path.
+
 ## 0.16.3 — 2026-06-02
 
 ### Added — scannable QR on the connect card

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.16.3"
+__version__ = "0.16.4"

--- a/clawmes/lib/tool_result.py
+++ b/clawmes/lib/tool_result.py
@@ -36,20 +36,33 @@ def text_result(text: str, *, details: Any = None) -> str:
     return json.dumps(payload)
 
 
-def json_result(data: dict[str, Any], *, summary: str | None = None) -> str:
+def json_result(
+    data: dict[str, Any],
+    *,
+    summary: str | None = None,
+    preview: str | None = None,
+) -> str:
     """Return a successful tool result whose details are a structured dict.
 
     The human-readable ``content`` is either ``summary`` (preferred) or a
     pretty-printed JSON dump of ``data``.
+
+    ``preview`` is surfaced as an envelope **top-level** key (sibling of
+    ``content`` / ``details``). The Hermes Desktop chat tool-card reads the
+    tool result's top level — ``result.preview`` — to render an in-app preview
+    attachment (``apps/desktop`` ``tool-fallback-model.ts`` ``toolPreviewTarget``).
+    A path/URL placed inside ``details`` is one level too deep for that
+    extractor, so an HTML card only opens in the desktop's preview pane when
+    its path is passed here. Omitted from the envelope when falsy.
     """
     text = summary if summary is not None else json.dumps(data, indent=2, default=str)
-    return json.dumps(
-        {
-            "content": [{"type": "text", "text": text}],
-            "details": data,
-        },
-        default=str,
-    )
+    envelope: dict[str, Any] = {
+        "content": [{"type": "text", "text": text}],
+        "details": data,
+    }
+    if preview:
+        envelope["preview"] = preview
+    return json.dumps(envelope, default=str)
 
 
 def error_result(message: str, *, code: str | None = None) -> str:

--- a/clawmes/lib/ui_artifacts.py
+++ b/clawmes/lib/ui_artifacts.py
@@ -1,33 +1,28 @@
-"""UI artifact enrichment for the Hermes Desktop app.
+"""Link enrichment for the Hermes Desktop app.
 
 The Hermes Desktop renderer (``apps/desktop`` in NousResearch/hermes-agent)
-surfaces tool output through three generic systems, all driven by the *shape*
-of a tool's ``details`` dict — there is no plugin-UI API, so a Python plugin
-injects UI purely by emitting the right keys:
+has no plugin-UI API, so a Python plugin influences the UI purely through the
+*shape* of a tool's result. Verified against the desktop source, two layers
+read clawmes output differently — and the distinction is load-bearing:
 
-1. **Artifacts view** scrapes every string value in the result; any value that
-   looks like an ``http(s)://`` URL or a file path is collected into the
-   Images / Files / Links tabs. So *any* link we put in ``details`` becomes a
-   clickable artifact regardless of its key name.
+* The **Artifacts view** (``artifacts/index.tsx``) deep-recurses the entire
+  parsed result JSON, so any ``http(s)://`` value — even nested inside
+  ``details`` — is collected as a clickable **Link artifact**. This is the
+  layer this module targets: explorer / DexScreener / Clanker links live under
+  descriptive keys in ``details`` and surface here.
 
-2. **Structured tool-card summary** renders ``details`` keys as bullet lines,
-   prioritising ``title / name / path / url / status / …``.
+* The **chat tool-card** structured extractors (``tool-fallback-model.ts``
+  ``toolPreviewTarget`` / ``toolImageUrl``) read only the **top level** of the
+  result envelope (``result.preview`` / ``result.url`` / ``result.image_url``),
+  NOT ``details``. So a preview/card path must be emitted at the envelope top
+  level — see :func:`clawmes.lib.tool_result.json_result`'s ``preview=`` arg —
+  *not* placed in ``details``. (An earlier ``attach_preview`` helper put it in
+  ``details``; tracing the desktop source proved that's one level too deep, so
+  it was removed.)
 
-3. **Auto-opening side preview pane** inspects, in order, the keys
-   ``url, target, path, file, filepath, preview`` and *auto-opens the first one
-   that looks like a URL or path* in the right-rail webview.
-
-This module centralises the link construction + the precise key discipline:
-
-* Explorer / DexScreener / Clanker links go under **descriptive keys**
-  (``explorer_url``, ``dexscreener_url``, ``clanker_url``) so they become
-  passive clickable Link artifacts **without** hijacking the preview pane on
-  every call.
-* A generated HTML card is attached under the **``preview``** key (via
-  :func:`attach_preview`) so — and only so — the desktop auto-opens it.
-
-Everything here is pure (no I/O, no network) so it is cheap to unit-test and
-safe to call from inside any tool handler.
+This module therefore only constructs the descriptive ``details`` links
+(``explorer_url`` / ``dexscreener_url`` / ``clanker_url``). Everything here is
+pure (no I/O, no network), cheap to unit-test, and safe to call from any tool.
 """
 
 from __future__ import annotations
@@ -54,11 +49,6 @@ _DEXSCREENER_SLUGS: dict[int, str] = {
 _CLANKER_CHAIN_ID = 8453
 _CLANKER_BASE_URL = "https://clanker.world/clanker"
 _DEXSCREENER_BASE_URL = "https://dexscreener.com"
-
-# Keys the desktop's preview router inspects, in priority order, to decide what
-# to auto-open in the side rail. Exposed for tests + callers that need to reason
-# about whether a details dict will trigger an auto-open.
-PREVIEW_TRIGGER_KEYS: tuple[str, ...] = ("url", "target", "path", "file", "filepath", "preview")
 
 
 def _is_tx_hash(value: str) -> bool:
@@ -164,38 +154,3 @@ def enrich_token_links(
             details["clanker_url"] = clank
 
     return details
-
-
-def attach_preview(details: dict[str, Any], path: str) -> dict[str, Any]:
-    """Set ``details['preview']`` so the desktop auto-opens ``path`` in the rail.
-
-    Use this ONLY for genuinely panel-worthy output (a generated HTML card,
-    a report). ``path`` should be an absolute filesystem path or an
-    ``http(s)://`` URL — anything the desktop's ``normalizePreviewTarget`` can
-    resolve. Returns ``details`` for chaining.
-    """
-    if path:
-        details["preview"] = str(path)
-    return details
-
-
-def will_auto_open(details: dict[str, Any]) -> bool:
-    """True if ``details`` would trigger the desktop to auto-open a preview.
-
-    Mirrors the desktop's ``structuredPreviewCandidate`` logic: the first of
-    :data:`PREVIEW_TRIGGER_KEYS` whose value looks like a URL or path wins.
-    Useful in tests to assert a read-only tool won't spam the preview pane.
-    """
-    for key in PREVIEW_TRIGGER_KEYS:
-        value = details.get(key)
-        if isinstance(value, str) and _looks_like_target(value):
-            return True
-    return False
-
-
-def _looks_like_target(value: str) -> bool:
-    """Match the desktop's ``looksLikePreviewTarget`` heuristic."""
-    v = value.strip()
-    if v.startswith(("http://", "https://", "file://", "/", "./", "../", "~/")):
-        return True
-    return False

--- a/clawmes/lib/ui_cards.py
+++ b/clawmes/lib/ui_cards.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import html
 import re
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -265,11 +266,13 @@ def connect_card(*, uri: str) -> str:
 def write_card(html_str: str, name: str) -> Path:
     """Write a card to ``${HERMES_HOME}/clawmes/cards/`` and return its path.
 
-    The filename is slugified from ``name`` and suffixed with a timestamp so
-    repeated renders don't clobber each other (the desktop reads the path
-    once at preview time). Returns the absolute path for ``attach_preview``.
+    The filename is slugified from ``name`` and suffixed with a timestamp plus
+    a short random token, so even cards written within the same millisecond
+    (e.g. rapid tool calls) never clobber each other. Returns the absolute path
+    to pass to ``json_result(preview=...)``.
     """
     slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "card"
-    path = state_dir("cards") / f"{slug}-{int(time.time() * 1000)}.html"
+    suffix = f"{int(time.time() * 1000)}-{uuid.uuid4().hex[:6]}"
+    path = state_dir("cards") / f"{slug}-{suffix}.html"
     path.write_text(html_str, encoding="utf-8")
     return path

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.16.3
+version: 0.16.4
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/tools/clawnch_launch.py
+++ b/clawmes/tools/clawnch_launch.py
@@ -207,11 +207,12 @@ def _handle_deploy(args: dict[str, Any]) -> str:
     enrich_tx_links(result, tx_hash=tx_hash or "", chain_id=8453)
     enrich_token_links(result, token=token_address or "", chain_id=8453)
 
-    # Desktop UI: render a launch-receipt card and auto-open it in the side
-    # rail. clawnch_launch is user/LLM-invoked (never scheduler-driven), so a
-    # card-per-call is fine. Best-effort: never fail the launch on UI errors.
+    # Desktop UI: render a launch-receipt card and surface its path at the
+    # envelope top level (json_result ``preview=``) so the desktop opens it in
+    # the preview pane. clawnch_launch is user/LLM-invoked (never
+    # scheduler-driven). Best-effort: never fail the launch on UI errors.
+    preview_path: str | None = None
     try:
-        from clawmes.lib.ui_artifacts import attach_preview
         from clawmes.lib.ui_cards import receipt_card, write_card
 
         rows = [("Symbol", symbol)]
@@ -225,16 +226,16 @@ def _handle_deploy(args: dict[str, Any]) -> str:
             ("Explorer", result.get("explorer_url", "")),
         ]
         card_html = receipt_card(title=f"Launched {symbol}", rows=rows, links=links)
-        attach_preview(result, str(write_card(card_html, f"launch-{symbol}")))
+        preview_path = str(write_card(card_html, f"launch-{symbol}"))
     except Exception:  # noqa: BLE001 — UI is best-effort
-        pass
+        preview_path = None
 
     summary_parts = [f"Launched {symbol} via Clawnch."]
     if token_address:
         summary_parts.append(f"Token: {token_address}")
     if tx_hash:
         summary_parts.append(f"Tx: {tx_hash}")
-    return json_result(result, summary=" ".join(summary_parts))
+    return json_result(result, summary=" ".join(summary_parts), preview=preview_path)
 
 
 def _handle_info(args: dict[str, Any]) -> str:

--- a/clawmes/tools/defi_balance.py
+++ b/clawmes/tools/defi_balance.py
@@ -235,24 +235,24 @@ def _handle_summary(address: str, chain) -> str:
         "chain": chain.short_name,
         "balances": payload,
     }
-    # Desktop UI: render a portfolio card and auto-open it in the side rail via
-    # the ``preview`` key. defi_balance is never on a scheduler path, so this
-    # only fires on user/LLM-invoked balance summaries. UI enrichment must
-    # never break the underlying read, so failures are swallowed.
+    # Desktop UI: render a portfolio card and surface its path at the envelope
+    # top level (via json_result's ``preview=``) so the desktop chat tool-card
+    # opens it in the preview pane. defi_balance is never on a scheduler path,
+    # so this only fires on user/LLM-invoked balance summaries. UI enrichment
+    # must never break the underlying read, so failures are swallowed.
+    preview_path: str | None = None
     try:
-        from clawmes.lib.ui_artifacts import attach_preview
         from clawmes.lib.ui_cards import portfolio_card, write_card
 
         holdings = [{"symbol": p["symbol"], "amount": p["human"]} for p in payload]
         card_html = portfolio_card(
             address=address, chain=chain.name, total_usd=None, holdings=holdings
         )
-        card_path = write_card(card_html, f"portfolio-{chain.short_name}")
-        attach_preview(result, str(card_path))
+        preview_path = str(write_card(card_html, f"portfolio-{chain.short_name}"))
     except Exception:  # noqa: BLE001 — UI is best-effort, never fail the read
-        pass
+        preview_path = None
 
-    return json_result(result, summary="\n".join(lines))
+    return json_result(result, summary="\n".join(lines), preview=preview_path)
 
 
 def register(ctx) -> None:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.16.3
+version: 0.16.4
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.16.3"
+version = "0.16.4"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/lib/test_tool_result.py
+++ b/tests/lib/test_tool_result.py
@@ -51,6 +51,21 @@ class TestJsonResult:
         out = json.loads(out_text)
         assert "2026-01-01" in out["content"][0]["text"]
 
+    def test_preview_at_envelope_top_level(self):
+        # The desktop chat tool-card reads result.preview (envelope top level),
+        # NOT details.preview — so it must land beside content/details.
+        out = json.loads(json_result({"a": 1}, preview="/tmp/card.html"))
+        assert out["preview"] == "/tmp/card.html"
+        assert "preview" not in out["details"]
+
+    def test_preview_omitted_when_none(self):
+        out = json.loads(json_result({"a": 1}))
+        assert "preview" not in out
+
+    def test_preview_omitted_when_empty(self):
+        out = json.loads(json_result({"a": 1}, preview=""))
+        assert "preview" not in out
+
 
 class TestErrorResult:
     def test_isError_true(self):

--- a/tests/lib/test_ui_artifacts.py
+++ b/tests/lib/test_ui_artifacts.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from clawmes.lib.ui_artifacts import (
-    PREVIEW_TRIGGER_KEYS,
-    attach_preview,
     clanker_url,
     dexscreener_url,
     enrich_token_links,
@@ -12,7 +10,6 @@ from clawmes.lib.ui_artifacts import (
     explorer_address_url,
     explorer_token_url,
     explorer_tx_url,
-    will_auto_open,
 )
 
 _TX = "0x" + "a" * 64
@@ -126,12 +123,6 @@ class TestEnrichTxLinks:
         enrich_tx_links(details, tx_hash=_BAD, chain_id=8453)
         assert "explorer_url" not in details
 
-    def test_explorer_url_does_not_auto_open(self):
-        # explorer_url is NOT a preview-trigger key, so it must not auto-open.
-        details: dict = {}
-        enrich_tx_links(details, tx_hash=_TX, chain_id=8453)
-        assert will_auto_open(details) is False
-
 
 class TestEnrichTokenLinks:
     def test_adds_all_base_links(self):
@@ -169,64 +160,3 @@ class TestEnrichTokenLinks:
     def test_returns_same_dict(self):
         details: dict = {}
         assert enrich_token_links(details, token=_ADDR, chain_id=8453) is details
-
-    def test_token_links_do_not_auto_open(self):
-        details: dict = {}
-        enrich_token_links(details, token=_ADDR, chain_id=8453)
-        assert will_auto_open(details) is False
-
-
-class TestAttachPreview:
-    def test_sets_preview(self):
-        details: dict = {}
-        attach_preview(details, "/tmp/card.html")
-        assert details["preview"] == "/tmp/card.html"
-
-    def test_empty_path_noop(self):
-        details: dict = {}
-        attach_preview(details, "")
-        assert "preview" not in details
-
-    def test_coerces_to_str(self, tmp_path):
-        details: dict = {}
-        card = tmp_path / "card.html"
-        attach_preview(details, card)  # type: ignore[arg-type]
-        assert details["preview"] == str(card)
-
-    def test_returns_same_dict(self):
-        details: dict = {}
-        assert attach_preview(details, "/x.html") is details
-
-    def test_preview_triggers_auto_open(self):
-        details: dict = {}
-        attach_preview(details, "/tmp/card.html")
-        assert will_auto_open(details) is True
-
-
-class TestWillAutoOpen:
-    def test_url_key_triggers(self):
-        assert will_auto_open({"url": "https://example.com"}) is True
-
-    def test_http_target(self):
-        assert will_auto_open({"target": "http://x.io"}) is True
-
-    def test_file_uri(self):
-        assert will_auto_open({"path": "file:///tmp/x"}) is True
-
-    def test_relative_path(self):
-        assert will_auto_open({"file": "./out.html"}) is True
-
-    def test_home_path(self):
-        assert will_auto_open({"filepath": "~/out.html"}) is True
-
-    def test_non_target_value(self):
-        assert will_auto_open({"url": "just a string"}) is False
-
-    def test_non_string_value(self):
-        assert will_auto_open({"url": 123}) is False
-
-    def test_empty(self):
-        assert will_auto_open({}) is False
-
-    def test_trigger_keys_constant(self):
-        assert PREVIEW_TRIGGER_KEYS == ("url", "target", "path", "file", "filepath", "preview")

--- a/tests/tools/test_clawnch_launch.py
+++ b/tests/tools/test_clawnch_launch.py
@@ -68,10 +68,12 @@ class TestDeploy:
         assert fake_svc.deploys[0]["params"] == {"name": "Foo", "symbol": "FOO"}
 
     def test_deploy_attaches_receipt_preview(self, fake_svc):
-        # Desktop UI: a launch-receipt card is written + surfaced for auto-open.
+        # Desktop UI: a launch-receipt card path is surfaced at the envelope
+        # top level (result.preview) where the desktop chat tool-card reads it.
         out = json.loads(clawnch_launch({"action": "deploy", "name": "Foo", "symbol": "FOO"}))
-        assert out["details"]["preview"].endswith(".html")
-        assert "launch-foo" in out["details"]["preview"].lower()
+        assert out["preview"].endswith(".html")
+        assert "launch-foo" in out["preview"].lower()
+        assert "preview" not in out["details"]
 
     def test_deploy_card_failure_is_swallowed(self, fake_svc, monkeypatch):
         # A UI rendering failure must never break the actual launch.
@@ -83,7 +85,7 @@ class TestDeploy:
         monkeypatch.setattr(ui_cards, "write_card", _boom)
         out = json.loads(clawnch_launch({"action": "deploy", "name": "Foo", "symbol": "FOO"}))
         assert out["details"]["txHash"] == "0xtx"
-        assert "preview" not in out["details"]
+        assert "preview" not in out
 
     def test_with_description_image(self, fake_svc):
         clawnch_launch(

--- a/tests/tools/test_defi_balance.py
+++ b/tests/tools/test_defi_balance.py
@@ -139,10 +139,14 @@ class TestSummaryAction:
 
         fake_rpc.balance_responses[(HOLDER.lower(), 8453)] = 10**18
         out = json.loads(defi_balance({"action": "summary", "address": HOLDER, "chain": "base"}))
-        preview = out["details"]["preview"]
+        # preview is an ENVELOPE top-level key (sibling of details) — that's
+        # where the desktop chat tool-card reads it (result.preview), not
+        # details.preview.
+        preview = out["preview"]
         assert preview.endswith(".html")
         assert "portfolio" in preview
         assert os.path.exists(preview)
+        assert "preview" not in out["details"]
 
     def test_summary_card_failure_is_swallowed(self, fake_rpc, monkeypatch):
         # If card rendering blows up, the balance read must still succeed and
@@ -155,7 +159,7 @@ class TestSummaryAction:
         monkeypatch.setattr(ui_cards, "write_card", _boom)
         fake_rpc.balance_responses[(HOLDER.lower(), 8453)] = 10**18
         out = json.loads(defi_balance({"action": "summary", "address": HOLDER, "chain": "base"}))
-        assert "preview" not in out["details"]
+        assert "preview" not in out
         assert any(b["symbol"] == "ETH" for b in out["details"]["balances"])
 
     def test_native_rpc_error(self, fake_rpc):


### PR DESCRIPTION
## The bug (found by the production-readiness source audit)

Verifying #34's card mechanism against the actual NousResearch/hermes-agent source proved the cards **never rendered** — the preview path was one level too deep.

**The trace:**
1. `tui_gateway/server.py:1795` — the gateway emits the tool result at `payload["result"] = json.loads(result)` (the clawmes envelope `{content, details}`).
2. `apps/desktop` `chat-messages.ts:394` spreads it: `part.result = {...parsedEnvelope}` → `{content, details}`.
3. `tool-fallback-model.ts:757` `toolPreviewTarget` reads `firstStringField(result, ['preview','url','target'])` — i.e. `result.preview`, the **envelope top level**, not `result.details.preview`.

clawmes put the card path in `details`, so `toolPreviewTarget` never found it → cards never became in-app preview attachments. (They only showed as external-open File artifacts via the Artifacts view's deep recursion.)

## The fix
- `json_result` gains `preview=` → emits an **envelope top-level** `preview` key (sibling of `content`/`details`).
- `defi_balance` (portfolio) + `clawnch_launch` (receipt) pass their card path via `preview=`.
- Removed `attach_preview` / `will_auto_open` / `PREVIEW_TRIGGER_KEYS` — they encoded the disproven "`details.preview` auto-opens" assumption.
- `write_card` filenames get a random suffix (collision-proof for same-ms renders).

## What was NOT broken
Link enrichment — the desktop Artifacts view deep-recurses the result JSON, so `details.*_url` links surfaced correctly all along. This PR only fixes the card/preview path.

## Honest scope note
The live auto-open pane (`structuredPreviewCandidate`, reads `payload.preview` at the *event* top level) remains gateway-only — a plugin can't reach it. With this fix, cards render as **click-to-open preview attachments** in the chat tool-card, which is the reachable mechanism. Command-emitted cards (`/connect`, `/research`) remain external-open File artifacts (commands return strings, not envelopes).

## Verification
- **4562 passed, 8 skipped**
- **100% line coverage** (16,215 statements, 0 missing)
- `ruff check` + `ruff format --check` clean **repo-wide**
- `plugin.yaml` byte-identical