### PR TITLE
feat(wallet): bundle a default WalletConnect project ID (v0.17.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.17.1 — 2026-06-02
+
+### Changed — WalletConnect works out of the box (bundled project ID)
+
+A WalletConnect project ID is a *per-application*, public client identifier (a
+dapp ships one for all its users; it's embedded in browser bundles and isn't a
+secret), not a per-user secret. clawmes previously required every user to
+create their own at cloud.walletconnect.com and set `WALLETCONNECT_PROJECT_ID`
+before `/connect` / `clawnchconnect(mode=walletconnect)` would work.
+
+- Bundled a default project ID so WalletConnect pairing works immediately with
+  no setup. `WALLETCONNECT_PROJECT_ID` (e.g. in `~/.hermes/.env`) still
+  **overrides** it for users who want their own relay quota / analytics, and an
+  explicitly-empty value falls back to the default.
+- `hermes clawmes doctor` now reports the WC project ID as OK by default and
+  notes when the bundled default is in use.
+
+Tradeoff: default-id traffic counts against one shared Reown relay quota; set
+your own `WALLETCONNECT_PROJECT_ID` to use a separate quota.
+
 ## 0.17.0 — 2026-06-02
 
 ### Added — `clawmes_info`: agent-callable bridge for the read-only command surface

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/clawmes/bridges/wc_client.py
+++ b/clawmes/bridges/wc_client.py
@@ -17,6 +17,7 @@ queue; the wallet service reads it to drive ``pairing_approved``,
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -25,10 +26,37 @@ from clawmes.lib.logger import logger_for
 
 _log = logger_for("bridges.wc")
 
+# Clawnch's shared Reown (WalletConnect v2) project ID. A WC project ID is a
+# *public, per-application* client identifier — dapps ship a single one for all
+# their users; it's embedded in browser bundles and is NOT a secret. Bundling a
+# default here means wallet connection works out of the box instead of erroring
+# until each user creates their own at cloud.walletconnect.com.
+#
+# Tradeoff: all default-id traffic counts against this one Reown project's relay
+# quota. Power users (or anyone wanting their own analytics / to avoid the
+# shared quota) override it by setting WALLETCONNECT_PROJECT_ID in
+# ~/.hermes/.env, which always wins (see :func:`_bridge_env`).
+_DEFAULT_WALLETCONNECT_PROJECT_ID = "f3a18ce66d092a392f3075ff566db1cf"
+
+
+def _bridge_env() -> dict[str, str]:
+    """Environment for the WC bridge subprocess.
+
+    Inherits the parent environment and guarantees a WalletConnect project id:
+    the ``WALLETCONNECT_PROJECT_ID`` env var wins when set (and non-empty),
+    otherwise the bundled default is used. The ``or`` (not ``setdefault``) means
+    an explicitly-empty env var also falls back to the default.
+    """
+    env = dict(os.environ)
+    env["WALLETCONNECT_PROJECT_ID"] = (
+        os.environ.get("WALLETCONNECT_PROJECT_ID") or _DEFAULT_WALLETCONNECT_PROJECT_ID
+    )
+    return env
+
 
 class WalletConnectClient:
     def __init__(self, entry: Path, *, node_bin: str = "node") -> None:
-        self._proc = BridgeProcess("clawmes-wc", entry, node_bin=node_bin)
+        self._proc = BridgeProcess("clawmes-wc", entry, node_bin=node_bin, env=_bridge_env())
 
     def start(self) -> None:
         self._proc.start()

--- a/clawmes/commands/doctor.py
+++ b/clawmes/commands/doctor.py
@@ -206,14 +206,16 @@ def _bridge_section() -> _Section:
         )
     )
 
-    # Project ID
+    # Project ID — a bundled default ships so WalletConnect works out of the
+    # box; the env var overrides it. So this is always "ok"; we just note when
+    # the default is in use.
     pid = os.environ.get("WALLETCONNECT_PROJECT_ID")
     rows.append(
         (
-            "[ok]   " if pid else "[----] ",
+            "[ok]   ",
             "WC project ID",
             "WALLETCONNECT_PROJECT_ID",
-            "" if pid else "free at https://cloud.walletconnect.com",
+            "" if pid else "bundled default (set WALLETCONNECT_PROJECT_ID to use your own)",
         )
     )
 

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.17.0
+version: 0.17.1
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.17.0
+version: 0.17.1
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.17.0"
+version = "0.17.1"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/bridges/test_wc_client.py
+++ b/tests/bridges/test_wc_client.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from clawmes.bridges.wc_client import WalletConnectClient
+from clawmes.bridges.wc_client import (
+    _DEFAULT_WALLETCONNECT_PROJECT_ID,
+    WalletConnectClient,
+    _bridge_env,
+)
 
 
 @pytest.fixture
@@ -16,6 +20,30 @@ def client():
     c = WalletConnectClient(Path("/fake/wc.mjs"))
     c._proc = MagicMock()
     return c
+
+
+class TestBridgeEnv:
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("WALLETCONNECT_PROJECT_ID", raising=False)
+        env = _bridge_env()
+        assert env["WALLETCONNECT_PROJECT_ID"] == _DEFAULT_WALLETCONNECT_PROJECT_ID
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv("WALLETCONNECT_PROJECT_ID", "my-own-project-id")
+        assert _bridge_env()["WALLETCONNECT_PROJECT_ID"] == "my-own-project-id"
+
+    def test_empty_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("WALLETCONNECT_PROJECT_ID", "")
+        assert _bridge_env()["WALLETCONNECT_PROJECT_ID"] == _DEFAULT_WALLETCONNECT_PROJECT_ID
+
+    def test_preserves_other_env(self, monkeypatch):
+        monkeypatch.setenv("CLAWMES_TEST_KEEP", "keepme")
+        assert _bridge_env()["CLAWMES_TEST_KEEP"] == "keepme"
+
+    def test_client_passes_default_env_to_bridge(self, monkeypatch):
+        monkeypatch.delenv("WALLETCONNECT_PROJECT_ID", raising=False)
+        c = WalletConnectClient(Path("/fake/wc.mjs"))
+        assert c._proc._env["WALLETCONNECT_PROJECT_ID"] == _DEFAULT_WALLETCONNECT_PROJECT_ID
 
 
 class TestLifecycle:

--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -160,6 +160,16 @@ class TestBridgeSection:
         section = _bridge_section()
         lines = [ln for ln in section.body.splitlines() if "WC project ID" in ln]
         assert "[ok]" in lines[0]
+        assert "bundled default" not in lines[0]
+
+    def test_project_id_default_when_unset(self, monkeypatch):
+        # A bundled default ships, so WC project ID is always [ok]; when the env
+        # var is unset we note that the default is in use.
+        monkeypatch.delenv("WALLETCONNECT_PROJECT_ID", raising=False)
+        section = _bridge_section()
+        lines = [ln for ln in section.body.splitlines() if "WC project ID" in ln]
+        assert "[ok]" in lines[0]
+        assert "bundled default" in lines[0]
 
 
 class TestPluginSection:


### PR DESCRIPTION
## Why
You asked the right question: a WalletConnect project ID should be **project-level, not per-user**. Correct — a WC project ID is a *per-application, public client identifier* (dapps embed a single one for all users; it ships in browser bundles and isn't a secret). clawmes was wrongly requiring every user to create their own and set `WALLETCONNECT_PROJECT_ID` before WalletConnect would work.

## Change
Bundle Clawnch's Reown project ID as the default so `/connect` and `clawnchconnect(mode=walletconnect)` work out of the box:
- **`bridges/wc_client.py`**: new `_bridge_env()` injects `WALLETCONNECT_PROJECT_ID` into the WC bridge subprocess env. The env var **wins** when set + non-empty; otherwise the bundled default is used (an explicitly-empty value also falls back).
- **`commands/doctor.py`**: WC project ID now shows `[ok]` by default and notes when the bundled default is in use.

Override with your own `WALLETCONNECT_PROJECT_ID` (e.g. in `~/.hermes/.env`) to use a separate Reown relay quota / analytics.

## Tradeoff (documented)
All default-id traffic counts against one shared Reown relay quota (Reown free tier has connection caps; a single shared ID is also a single point of failure if it gets rate-limited). Mitigations: monitor usage / upgrade the Reown plan, and the env override lets heavy users split off. It's a **public** identifier, so bundling it in the repo is fine; consider adding allowed-origins in the Reown dashboard if abuse appears.

## Verification
- **4580 passed, 8 skipped**; **100% line coverage** (16,255 stmts, 0 missing)
- `ruff check` + `ruff format --check` clean
- `plugin.yaml` byte-identical
- Existing doctor WC test still green; added unset-default + override + empty-fallback tests