### PR TITLE
fix(clawnch): target www canonical host so the backend is reachable (v0.17.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.17.3 — 2026-06-02
+
+### Fixed — clawmes couldn't reach the Clawnch backend in production
+
+The Clawnch apex host `clawn.ch` 307-redirects to the `www.clawn.ch` canonical
+host, but (a) `www.clawn.ch` was not on the network allowlist and (b) the HTTP
+client deliberately does not follow cross-host redirects (an allowlisted host
+redirecting to a non-allowlisted one would otherwise bypass the allowlist). The
+combination meant every Clawnch API call — agent registration, token deploys,
+`leaderboard` / `my_launches` reads — failed with either a 307 error or a
+`NetworkAllowlistError`.
+
+- `lib/http.py`: added `www.clawn.ch` to `_DEFAULT_ALLOWLIST` alongside the
+  apex.
+- `services/clawnch.py`: the default base URL is now `https://www.clawn.ch`
+  (the canonical host, no redirect). `CLAWNCH_BASE_URL` still overrides for
+  staging / local dev.
+
+No config change is needed; existing installs pick this up on update.
+
 ## 0.17.2 — 2026-06-02
 
 ### Reverted — no bundled WalletConnect project ID (security)

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"

--- a/clawmes/lib/http.py
+++ b/clawmes/lib/http.py
@@ -98,7 +98,10 @@ _DEFAULT_ALLOWLIST: frozenset[str] = frozenset(
         "bv7x.ai",
         # Clawnch launchpad HTTP API — see services.clawnch for the deploy /
         # agent-registration flow used by /launch and clawnch_launch tool.
+        # The apex 307-redirects to the www canonical host, so both must be
+        # allowed (the client doesn't follow cross-host redirects by design).
         "clawn.ch",
+        "www.clawn.ch",
         # Simulation
         "api.tenderly.co",
         # Fiat ramps

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.17.2
+version: 0.17.3
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/clawmes/services/clawnch.py
+++ b/clawmes/services/clawnch.py
@@ -48,7 +48,10 @@ _log = logger_for("services.clawnch")
 
 #: Base URL of the Clawnch HTTP API. Override via ``CLAWNCH_BASE_URL`` for
 #: staging / local dev. The service uses ``/api/...`` paths underneath.
-_BASE_URL = os.environ.get("CLAWNCH_BASE_URL", "https://clawn.ch")
+#: Defaults to the ``www`` canonical host: the apex ``clawn.ch`` 307-redirects
+#: to ``www.clawn.ch`` and our HTTP client doesn't follow cross-host redirects,
+#: so targeting the apex would fail every request.
+_BASE_URL = os.environ.get("CLAWNCH_BASE_URL", "https://www.clawn.ch")
 
 #: Source tag attached to every deploy made through clawmes. Lets the
 #: launchpad render a "launched via clawmes" badge on launch detail pages.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.17.2
+version: 0.17.3
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.17.2"
+version = "0.17.3"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/lib/test_http.py
+++ b/tests/lib/test_http.py
@@ -24,6 +24,12 @@ class TestAllowlist:
         _check_allowlist("https://api.coingecko.com/api/v3/simple/price")
         _check_allowlist("https://api.basescan.org/api")
 
+    def test_allows_clawnch_apex_and_www(self):
+        # The apex 307-redirects to the www canonical host; both must be
+        # allowed since the client doesn't follow cross-host redirects.
+        _check_allowlist("https://clawn.ch/api/agents/register")
+        _check_allowlist("https://www.clawn.ch/api/agents/register")
+
     def test_rejects_unknown_host(self):
         with pytest.raises(NetworkAllowlistError, match="not on the clawmes network allowlist"):
             _check_allowlist("https://evil.example.com/whatever")

--- a/tests/services/test_clawnch.py
+++ b/tests/services/test_clawnch.py
@@ -51,6 +51,12 @@ class TestLifecycle:
         svc.start()
         assert svc.health()["status"] == "authenticated"
 
+    def test_base_url_defaults_to_www(self, svc):
+        # Apex clawn.ch 307-redirects to www; the client doesn't follow
+        # cross-host redirects, so the default targets the www host directly.
+        svc.start()
+        assert svc.health()["base_url"] == "https://www.clawn.ch"
+
     def test_base_url_override(self, monkeypatch, svc):
         monkeypatch.setenv("CLAWNCH_BASE_URL", "https://staging.clawn.ch/")
         svc.start()


### PR DESCRIPTION
## Problem
The Clawnch apex `clawn.ch` 307-redirects to the `www.clawn.ch` canonical host. But:
- `www.clawn.ch` was **not** on `_DEFAULT_ALLOWLIST` (only the apex was), and
- the HTTP client **doesn't follow cross-host redirects** (by design — otherwise an allowlisted host could redirect to a non-allowlisted one and bypass the allowlist).

Net effect: **every Clawnch API call failed** — agent registration, token deploys, and `leaderboard` / `my_launches` reads — with either a 307 or a `NetworkAllowlistError`.

## Fix
- `lib/http.py`: add `www.clawn.ch` to `_DEFAULT_ALLOWLIST` alongside the apex.
- `services/clawnch.py`: default base URL → `https://www.clawn.ch` (canonical, no redirect). `CLAWNCH_BASE_URL` still overrides for staging/local.

Redirect-following stays off (allowlist integrity). No user config change needed.

## Verification
- 4577 passed, 8 skipped; 100% coverage (16,249 stmts, 0 missing); ruff clean; plugin.yaml byte-identical.
- Added tests: `www.clawn.ch` allowlisted, and clawnch default base == `https://www.clawn.ch`.