### PR TITLE
feat(launch): handle the mandatory 1M $CLAWNCH burn across all launch surfaces (v0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 0.19.0 — 2026-06-09
+
+### Changed — mandatory 1M $CLAWNCH launch burn
+
+The Clawnch launchpad now requires a verified 1,000,000+ $CLAWNCH burn for
+**every** launch — `/api/prepare/deploy` and `/api/deploy` reject no-burn
+deploys with HTTP 402 `{code: "burn_required", meta: {minBurnTokens,
+burnAddress}}`. clawmes previously treated the burn as an optional
+vault-allocation perk; a no-burn confirm surfaced as a raw
+`Client error '402 Payment Required'` after ~3 pointless retries.
+
+- `ClawnchError` gains a `meta` dict and a `burn_required` classification.
+  `_reclassify` maps HTTP 402 / `burn_required` / `BURN_PAYMENT_REQUIRED`
+  to it, carrying the upstream `meta` (min tokens + burn address); the
+  `prepare_deploy` `ok:false` map handles the same code on 2xx bodies.
+- `/launch confirm` (both paths), `/launch check`, and `/launch export`
+  render the rejection as exact burn instructions — amount, dead address,
+  the `/launch burn <amount|tx_hash>` next step, and the vault % the same
+  burn earns — instead of a generic failure. `/launch check` keeps its
+  checklist tone ("params OK, but no verified burn attached").
+- `clawnch_launch` tool: new `burn_tx_hash` schema param forwarded to
+  `deploy()` (the tool previously had no way to launch under the burn
+  requirement); `burn_required` errors include retry instructions. Bypass
+  copy corrected to the real 0.005 ETH default.
+- `lib/http`: 4xx responses are no longer retried (the module docstring
+  always promised this; the tenacity predicate retried every
+  `HTTPStatusError`). 5xx + transport errors keep the existing backoff.
+  A burn-less prepare now fails in one request instead of three.
+- Docs/help: README launch section, `clawnch-launch` skill, plugin.yaml,
+  and `/burn` + `/launch` usage text all reframe the burn as required
+  (vault is the bonus), and document `burn_required` / `invalid_burn`
+  recovery.
+
+Verified against the live API: `GET /api/prepare/deploy` without
+`burnTxHash` returns 402 `burn_required` with the documented `meta` shape.
+
 ## 0.18.2 — 2026-06-09
 
 ### Added — unified inference provider router

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ Clawmes wires the following partner / ecosystem projects directly into the tool 
 
 ## Launch a token from chat
 
-Clawmes wires the Clawnch launchpad end-to-end so any user can deploy a token from a chat message. As of v0.4.0, the default is **non-custodial** — your wallet signs the deploy tx directly, no API key needed:
+Clawmes wires the Clawnch launchpad end-to-end so any user can deploy a token from a chat message. As of v0.4.0, the default is **non-custodial** — your wallet signs the deploy tx directly, no API key needed.
+
+**Every launch requires a verified burn of ≥1,000,000 $CLAWNCH** from the launching wallet to the dead address (within 24h of the deploy). Deploys without one are rejected with `burn_required`. The same burn claims the Clanker vault allocation (1M = 1%, up to 10M = 10%), so the minimum is never wasted.
 
 ```
 /connect_local                               # or /connect (WalletConnect) / /connect_bankr
@@ -165,6 +167,7 @@ Clawmes wires the Clawnch launchpad end-to-end so any user can deploy a token fr
 /launch telegram mycoinchat                  # optional
 /launch farcaster mycoin                     # optional
 /launch discord https://discord.gg/abc       # optional
+/launch burn 1000000                         # required — signs + submits the 1M CLAWNCH burn
 /launch confirm
 # clawmes calls https://www.clawn.ch/api/prepare/deploy for unsigned
 # Clanker factory calldata, then your wallet signs and submits.
@@ -174,20 +177,19 @@ Clawmes wires the Clawnch launchpad end-to-end so any user can deploy a token fr
 
 Social handles get normalized (`mycoin` → `https://x.com/mycoin`); full URLs pass through unchanged. They're persisted to `tokenParams.metadata.socialMediaUrls` on the launchpad side and may render as badges on the launch detail page.
 
-To claim a vault allocation, burn $CLAWNCH before confirming:
+The burn can also be done standalone — any time before the launch (within 24h):
 
 ```
-/burn 1000000                   # standalone burn: signs + submits 1M CLAWNCH = 1% vault
+/burn 1000000                   # standalone burn: required minimum; grants 1% vault
 /burn 10000000                  # max 10M CLAWNCH = 10% vault (Clanker maximum)
 /burn last                      # show the last burn tx hash you signed via clawmes
 
-# Or via the legacy /launch burn path (same outcome):
-/launch burn 1000000            # signs + submits a 1M CLAWNCH burn from the active wallet
-/launch burn 0x<tx_hash>        # or paste a tx hash if you burned externally
-/launch confirm                 # deploy with vault allocation applied
+# Then attach it to the draft:
+/launch burn 0x<tx_hash>        # paste the hash (also works for external burns)
+/launch confirm                 # deploy with the burn verified + vault applied
 ```
 
-Curve: 1k tokens allocated per 1 CLAWNCH burned (1M → 1%, 10M → 10%). Vault tokens are subject to the Clanker 7-day lockup. See [`api/lib/burn.ts`](https://github.com/clawnchdev/clawnch/blob/main/api/lib/burn.ts) for the exact verification rules. Server-side verification happens on every deploy — passing `tokenParams.vault.percentage` without a verified `burnTxHash` is rejected with `VAULT_REQUIRES_BURN`.
+Curve: 1k tokens allocated per 1 CLAWNCH burned (1M → 1%, 10M → 10%). Vault tokens are subject to the Clanker 7-day lockup. See [`api/lib/burn.ts`](https://github.com/clawnchdev/clawnch/blob/main/api/lib/burn.ts) for the exact verification rules (sender = launching wallet, recipient = dead address, ≥1M, <24h old). Confirming without a verified burn returns `burn_required` with the exact requirements; an invalid hash returns `invalid_burn`.
 
 ### Custodial deploys (legacy path)
 
@@ -198,13 +200,13 @@ For users who can't pay deploy gas themselves, or who want server-paid gas with 
 # clawmes posts a challenge, your wallet signs, clawn.ch returns an apiKey.
 # Save it as CLAWNCH_API_KEY in ~/.hermes/.env.
 
-/launch ... (same drafting steps)
+/launch ... (same drafting steps, including /launch burn — the 1M burn is required here too)
 /launch confirm --custodial
 # Clawnch's deployer wallet submits the Clanker tx server-side;
 # your wallet only signs the captcha. Subject to the 24h cooldown.
 ```
 
-Bypass the cooldown by sending `0.005 ETH` to the Clawnch bypass recipient on Base, then `/launch bypass <tx_hash>` + `/launch confirm --custodial`.
+Bypass the cooldown by sending `0.005 ETH` to the Clawnch bypass recipient on Base, then `/launch bypass <tx_hash>` + `/launch confirm --custodial`. The bypass covers the cooldown only — it does not replace the mandatory burn.
 
 ### Export-only mode (for Base MCP, Claude Desktop, Cursor, ChatGPT)
 
@@ -213,6 +215,7 @@ clawmes can also emit the unsigned calldata for you to paste into another agent 
 ```
 /launch name MyCoin
 /launch symbol MC
+/launch burn 0x<tx_hash>        # the export path needs the verified burn too
 /launch export
 # Prints a JSON {chain: "base", calls: [{to, data, value}]} block
 # ready to paste into Base MCP's send_calls.

--- a/clawmes/_version.py
+++ b/clawmes/_version.py
@@ -7,4 +7,4 @@ Read by:
   * Tooling that does not want to incur a full package import
 """
 
-__version__ = "0.18.2"
+__version__ = "0.19.0"

--- a/clawmes/commands/burn.py
+++ b/clawmes/commands/burn.py
@@ -1,9 +1,13 @@
 """``/burn`` slash command — standalone $CLAWNCH burn.
 
 Decoupled from the launch flow so users can burn at any time —
-before drafting a launch, between launches, or just to claim a
-Clanker vault allocation on a deploy they're planning to do
-later from Base MCP / Claude Desktop / another agent surface.
+before drafting a launch, between launches, or ahead of a deploy
+they're planning to do later from Base MCP / Claude Desktop /
+another agent surface.
+
+A verified 1,000,000+ $CLAWNCH burn is **required for every launch**
+(the launchpad rejects no-burn deploys with ``burn_required``); the
+same burn claims the Clanker vault allocation as a bonus.
 
 Two input modes:
 
@@ -71,7 +75,8 @@ def _parse_amount(raw: str) -> int | str:
         return f"Invalid amount {raw!r}. Expected a positive integer (e.g. 1000000)."
     if amount < _MIN_BURN_TOKENS:
         return (
-            f"Burn amount too low: {amount:,} CLAWNCH (minimum {_MIN_BURN_TOKENS:,} for 1% vault)."
+            f"Burn amount too low: {amount:,} CLAWNCH "
+            f"(minimum {_MIN_BURN_TOKENS:,} — required to launch; grants 1% vault)."
         )
     if amount > _MAX_BURN_TOKENS:
         return (
@@ -108,7 +113,7 @@ async def handle_burn(raw_args: str, **kwargs: Any) -> str:
 
 def _render_usage(last: dict[str, Any] | None) -> str:
     lines = [
-        "Burn $CLAWNCH for vault allocation on your next launch.",
+        "Burn $CLAWNCH — required for every launch (min 1M); claims vault allocation.",
         "",
         "Usage:",
         "  /burn <amount>          — sign + submit a CLAWNCH burn from your wallet",
@@ -189,6 +194,6 @@ def register(ctx) -> None:
     ctx.register_command(
         name="burn",
         handler=handle_burn,
-        description="Burn $CLAWNCH from the active wallet for vault allocation",
+        description="Burn $CLAWNCH from the active wallet (required to launch; claims vault %)",
         args_hint="<amount> | last",
     )

--- a/clawmes/commands/launch.py
+++ b/clawmes/commands/launch.py
@@ -20,7 +20,8 @@ Steps:
     ``/launch discord <url>``             (optional)
 
   Flow:
-    ``/launch bypass <tx_hash>``          (optional — skip 24h cooldown)
+    ``/launch burn <amount|tx_hash>``     (required — every launch needs a verified 1M+ $CLAWNCH burn)
+    ``/launch bypass <tx_hash>``          (optional — skip 24h cooldown, custodial only)
     ``/launch status``                    (show draft)
     ``/launch confirm``                   (deploy)
     ``/launch cancel``                    (clear)
@@ -223,7 +224,7 @@ async def handle_launch(raw_args: str, **kwargs: Any) -> str:
             "  /launch farcaster <handle>    — Farcaster\n"
             "  /launch discord <url>         — Discord\n"
             "  /launch bypass <tx_hash>      — skip 24h cooldown (custodial mode only)\n"
-            "  /launch burn <amount|tx_hash> — burn $CLAWNCH for vault allocation\n"
+            "  /launch burn <amount|tx_hash> — burn $CLAWNCH (required to launch: ≥1M; also sets vault %)\n"
             "  /launch status                — show current draft\n"
             "  /launch confirm               — deploy (non-custodial by default)\n"
             "  /launch confirm --custodial   — deploy via Clawnch's custodial deployer\n"
@@ -255,7 +256,7 @@ def _render_usage(draft: dict[str, Any]) -> str:
         "",
         "Flow:",
         "  /launch bypass <tx_hash>         (skip 24h cooldown — custodial only)",
-        "  /launch burn <amount|tx_hash>    (burn $CLAWNCH for vault allocation)",
+        "  /launch burn <amount|tx_hash>    (burn $CLAWNCH — required to launch: ≥1M; also sets vault %)",
         "  /launch status                   (show draft)",
         "  /launch confirm                  (deploy via wallet — non-custodial default)",
         "  /launch confirm --custodial      (deploy via Clawnch deployer wallet)",
@@ -312,13 +313,18 @@ async def _handle_burn(sender_id: str, rest: str) -> str:
     forwarded to the Clawnch ``/api/deploy`` endpoint on confirm.
     Clawnch's backend verifies the burn (sender, recipient, amount,
     timing) and applies the corresponding vault allocation.
+
+    The burn is **mandatory**: every launch path requires a verified
+    1M+ $CLAWNCH burn — deploys without one are rejected with
+    ``burn_required``. The vault % is the bonus the same burn earns.
     """
     draft = _get_draft(sender_id)
     if not rest:
         return (
             "Usage: /launch burn <amount> | /launch burn <tx_hash>\n"
-            "  Amount: whole CLAWNCH (>= 1,000,000 for 1% vault, max 10,000,000 for 10%).\n"
-            "  Tx hash: 0x... if you already burned externally."
+            "  Amount: whole CLAWNCH (>= 1,000,000 — required to launch; 1M = 1% vault, max 10,000,000 = 10%).\n"
+            "  Tx hash: 0x... if you already burned externally.\n"
+            "  A verified burn is required for every launch."
         )
 
     if _looks_like_tx_hash(rest):
@@ -331,8 +337,9 @@ async def _handle_burn(sender_id: str, rest: str) -> str:
         return f"Invalid burn input {rest!r}. Expected an amount (e.g. 1000000) or 0x tx hash."
     if amount < 1_000_000:
         return (
-            f"Burn amount too low: {amount:,} CLAWNCH (minimum 1,000,000 for 1% vault).\n"
-            "See https://clawn.ch/docs/burn for the vault curve."
+            f"Burn amount too low: {amount:,} CLAWNCH "
+            "(minimum 1,000,000 — required to launch; grants 1% vault).\n"
+            "See https://clawn.ch/docs.md for the burn rules + vault curve."
         )
 
     return await _submit_burn(draft, amount)
@@ -379,6 +386,33 @@ async def _submit_burn(draft: dict[str, Any], whole_tokens: int) -> str:
         f"  Tx: {tx_hash}\n"
         f"  Basescan: https://basescan.org/tx/{tx_hash}\n"
         "Wait for confirmation, then /launch confirm to deploy with vault allocation."
+    )
+
+
+def _render_burn_required(exc: Any) -> str:
+    """Render the mandatory-burn rejection with exact instructions.
+
+    The Clawnch backend rejects every launch that lacks a verified
+    1M+ $CLAWNCH burn (HTTP 402, ``code="burn_required"``). The error's
+    ``meta`` block carries the requirements — surface them verbatim so
+    the user knows exactly what to burn and where.
+    """
+    meta = getattr(exc, "meta", None) or {}
+    min_tokens = str(meta.get("minBurnTokens") or "1000000")
+    burn_addr = str(meta.get("burnAddress") or "0x000000000000000000000000000000000000dEaD")
+    try:
+        pretty_min = f"{int(min_tokens):,}"
+    except ValueError:
+        pretty_min = min_tokens
+    return (
+        f"Launching requires a verified burn of {pretty_min}+ $CLAWNCH "
+        f"from your wallet to {burn_addr} (within 24h of the deploy).\n"
+        "\n"
+        "  /launch burn <amount>    — sign + submit the burn now (e.g. /launch burn 1000000)\n"
+        "  /launch burn <tx_hash>   — attach a burn you already submitted\n"
+        "\n"
+        "Then re-run /launch confirm. The same burn claims your vault "
+        "allocation (1M = 1%, up to 10M = 10%), so the minimum is never wasted."
     )
 
 
@@ -505,6 +539,8 @@ async def _confirm_noncustodial(
             burn_tx_hash=burn,
         )
     except ClawnchError as exc:
+        if exc.code == "burn_required":
+            return _render_burn_required(exc)
         msg = f"Prepare failed ({exc.code}): {exc.message}"
         if exc.code == "rate_limited":
             msg += "\n\nPer-wallet prepare limit reached (10/day). Try again after 00:00 UTC."
@@ -602,6 +638,8 @@ async def _confirm_custodial(
             burn_tx_hash=burn,
         )
     except ClawnchError as exc:
+        if exc.code == "burn_required":
+            return _render_burn_required(exc)
         msg = f"Launch failed ({exc.code}): {exc.message}"
         if exc.code == "no_credentials":
             msg += "\n\nRun /register_agent <name> <description> to get a key, or drop --custodial to use the wallet-signed path."
@@ -741,6 +779,11 @@ async def _check(sender_id: str) -> str:
         # The whole point of `check` is to surface validation failures
         # cleanly without running a half-baked deploy. Render the error
         # as a checklist hint rather than a generic failure.
+        if exc.code == "burn_required":
+            return (
+                "Check: params OK, but no verified burn attached.\n\n"
+                + _render_burn_required(exc)
+            )
         if exc.code == "bad_request":
             hint = "Fix the param flagged below, then re-run /launch check."
         elif exc.code == "rate_limited":
@@ -765,7 +808,10 @@ async def _check(sender_id: str) -> str:
     elif burn:
         lines.append("  Vault:      0% — burn hash recorded but produced no vault %")
     else:
-        lines.append("  Vault:      0% (no burn — /burn <amount> to claim)")
+        # A no-burn prepare normally 402s (burn_required) before we get
+        # here; reaching this line without a burn means the wallet is
+        # exempted server-side.
+        lines.append("  Vault:      0% (no burn attached — /burn <amount> to claim)")
     if not state.address:
         lines.append("")
         lines.append(
@@ -820,6 +866,11 @@ async def _export(sender_id: str) -> str:
             burn_tx_hash=draft.get("burn_tx_hash"),
         )
     except ClawnchError as exc:
+        if exc.code == "burn_required":
+            return (
+                "Export failed: the launchpad requires a verified burn "
+                "before it will return calldata.\n\n" + _render_burn_required(exc)
+            )
         return f"Export failed ({exc.code}): {exc.message}"
     except Exception as exc:  # noqa: BLE001
         return f"Export failed: {exc}"

--- a/clawmes/commands/launch.py
+++ b/clawmes/commands/launch.py
@@ -780,9 +780,8 @@ async def _check(sender_id: str) -> str:
         # cleanly without running a half-baked deploy. Render the error
         # as a checklist hint rather than a generic failure.
         if exc.code == "burn_required":
-            return (
-                "Check: params OK, but no verified burn attached.\n\n"
-                + _render_burn_required(exc)
+            return "Check: params OK, but no verified burn attached.\n\n" + _render_burn_required(
+                exc
             )
         if exc.code == "bad_request":
             hint = "Fix the param flagged below, then re-run /launch check."

--- a/clawmes/lib/http.py
+++ b/clawmes/lib/http.py
@@ -195,7 +195,7 @@ def _request(
     import httpx
     from tenacity import (
         retry,
-        retry_if_exception_type,
+        retry_if_exception,
         stop_after_attempt,
         wait_exponential,
     )
@@ -204,10 +204,21 @@ def _request(
     if headers:
         merged_headers.update(headers)
 
+    def _retryable(exc: BaseException) -> bool:
+        """Retry transport errors and 5xx only.
+
+        4xx is deterministic — the request itself is wrong (or, e.g.,
+        402 burn_required / 429 rate-limit) and retrying just burns
+        time and rate-limit budget before surfacing the same error.
+        This enforces the module-docstring promise that 4xx is never
+        retried.
+        """
+        if isinstance(exc, httpx.HTTPStatusError):
+            return exc.response.status_code >= 500
+        return isinstance(exc, httpx.TransportError)
+
     @retry(
-        retry=retry_if_exception_type(
-            (httpx.TransportError, httpx.HTTPStatusError),
-        ),
+        retry=retry_if_exception(_retryable),
         wait=wait_exponential(multiplier=1, min=1, max=8),
         stop=stop_after_attempt(3),
         reraise=True,

--- a/clawmes/plugin.yaml
+++ b/clawmes/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.18.2
+version: 0.19.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone
@@ -103,7 +103,7 @@ requires_env:
     url: https://bv7x.ai/terminal#developer
     secret: true
   - name: CLAWNCH_API_KEY
-    description: Clawnch agent API key; required for /launch (token deploy via Clawnch launchpad). Issue via /register_agent in clawmes.
+    description: Clawnch agent API key; required for custodial /launch deploys (non-custodial path needs no key). Every launch additionally requires a verified 1M+ $CLAWNCH burn (/burn). Issue the key via /register_agent in clawmes.
     url: https://clawn.ch
     secret: true
   - name: OPENGATEWAY_API_KEY

--- a/clawmes/services/clawnch.py
+++ b/clawmes/services/clawnch.py
@@ -21,9 +21,9 @@ Why the API and not direct on-chain calls:
 
   * Clawnch holds the deployer wallet (custodial gas + atomicity);
     clawmes never has to manage launchpad-side keys.
-  * Rate limiting + spam controls (24h cooldown, ETH-bypass, optional
-    $CLAWNCH burn bypass) are enforced server-side; the open source
-    plugin inherits them automatically.
+  * Rate limiting + spam controls (24h cooldown, ETH-bypass, the
+    mandatory 1M $CLAWNCH launch burn) are enforced server-side; the
+    open source plugin inherits them automatically.
   * Backend migration (Clanker -> ClawnchFactory v2) preserves the
     HTTP API per ``clawncher/migration-v2.md``; clawmes stays valid
     through the swap.
@@ -68,16 +68,20 @@ class ClawnchError(RuntimeError):
         token params, HTTP 400).
       * ``no_credentials`` — API key missing or rejected (HTTP 401/403).
       * ``rate_limited`` — Clawnch's 24h cooldown or burst limit (HTTP 429).
+      * ``burn_required`` — launch attempted without the mandatory
+        1,000,000 $CLAWNCH burn (HTTP 402). ``meta`` carries the
+        upstream requirements (``minBurnTokens``, ``burnAddress``).
       * ``challenge_expired`` — captcha not solved within the 5s window
         (HTTP 408).
       * ``not_found`` — launch / agent / challenge not found (HTTP 404).
       * ``api_error`` — generic upstream failure.
     """
 
-    def __init__(self, code: str, message: str) -> None:
+    def __init__(self, code: str, message: str, *, meta: dict[str, Any] | None = None) -> None:
         super().__init__(message)
         self.code = code
         self.message = message
+        self.meta: dict[str, Any] = meta or {}
 
 
 class ClawnchService(Service):
@@ -313,9 +317,14 @@ class ClawnchService(Service):
         - The user's wallet pays gas.
         - Same 20% platform fee preserved in the rewards array.
 
-        ``burn_tx_hash`` is verified server-side; if valid, the
-        corresponding vault clause gets baked into the returned
-        calldata.
+        ``burn_tx_hash`` is **mandatory upstream**: every launch
+        requires a verified 1,000,000+ $CLAWNCH burn from
+        ``from_address`` to the dead address within 24h. Calling
+        without one raises ``ClawnchError`` with
+        ``code="burn_required"`` (HTTP 402) whose ``meta`` carries
+        ``minBurnTokens`` + ``burnAddress``. A verified burn also sets
+        the vault clause baked into the returned calldata (1M = 1%,
+        up to 10M = 10%).
         """
         if not from_address:
             raise ClawnchError("bad_request", "from_address is required")
@@ -356,6 +365,13 @@ class ClawnchService(Service):
             # Map a couple of upstream codes to clawmes' classification.
             if code == "rate_limited":
                 raise ClawnchError("rate_limited", msg)
+            if code == "burn_required":
+                meta = body.get("meta")
+                raise ClawnchError(
+                    "burn_required",
+                    msg,
+                    meta=meta if isinstance(meta, dict) else {},
+                )
             if code in (
                 "invalid_from",
                 "invalid_name",
@@ -402,7 +418,7 @@ class ClawnchService(Service):
         }
 
     def get_burn_config(self) -> dict[str, Any]:
-        """Return the $CLAWNCH burn config used by ``/launch burn``.
+        """Return the $CLAWNCH burn config used by ``/burn`` + ``/launch burn``.
 
         Returns the token address (the CLAWNCH ERC-20), the burn
         address (dead address — 0x…dEaD), and the minimum burn amount
@@ -410,11 +426,15 @@ class ClawnchService(Service):
         ``transfer(burn_address, amount * 1e18)`` calldata that the
         active wallet signs.
 
+        The minimum burn is **required for every launch** (deploys
+        without a verified burn are rejected with ``burn_required``);
+        it doubles as the vault claim (1M = 1% vault, up to 10M = 10%).
+
         Stable values today (override via env for staging):
 
           * ``CLAWNCH_TOKEN_ADDRESS``    — default ``0xa1F724…747be``
           * ``CLAWNCH_BURN_ADDRESS``     — default ``0x000…dEaD``
-          * ``CLAWNCH_MIN_BURN_TOKENS``  — default ``1_000_000`` (1% vault)
+          * ``CLAWNCH_MIN_BURN_TOKENS``  — default ``1_000_000`` (launch minimum, 1% vault)
         """
         return {
             "token_address": os.environ.get(
@@ -502,6 +522,16 @@ class ClawnchService(Service):
             raise ClawnchError("rate_limited", message)
         if code_hint == "BYPASS_INVALID" or code_hint == "INSUFFICIENT_FUNDS":
             raise ClawnchError("bad_request", message)
+        if code_hint in ("burn_required", "BURN_PAYMENT_REQUIRED") or status == 402:
+            # Mandatory 1M $CLAWNCH burn missing. Carry the upstream
+            # ``meta`` block (minBurnTokens, burnAddress) so the UX can
+            # render exact burn instructions.
+            meta = body.get("meta")
+            raise ClawnchError(
+                "burn_required",
+                message,
+                meta=meta if isinstance(meta, dict) else {},
+            )
         if status == 400:
             raise ClawnchError("bad_request", message)
         if status == 401 or status == 403:

--- a/clawmes/skills/clawnch-launch/SKILL.md
+++ b/clawmes/skills/clawnch-launch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clawnch-launch
-description: Deploy a token on Base via the Clawnch launchpad using the /launch command or clawnch_launch tool. Walks users through register-agent -> sign captcha -> custodial deploy via Clanker.
-tags: [clawnch, launchpad, deploy, token, agent, base, clanker]
+description: Deploy a token on Base via the Clawnch launchpad using the /launch command or clawnch_launch tool. Every launch requires a verified 1M+ $CLAWNCH burn (/burn). Walks users through burn -> register-agent -> sign captcha -> deploy via Clanker.
+tags: [clawnch, launchpad, deploy, token, agent, base, clanker, burn]
 ---
 
 # clawmes:clawnch-launch
@@ -24,6 +24,30 @@ Plus **`/register_agent`** to obtain the API key required for deploys.
 * User wants to read fee accrual or volume on a Clawnch-launched
   token.
 * User got a rate-limit error and asks about the bypass.
+* User got a `burn_required` error or asks what a launch costs.
+
+## Launch cost: the mandatory $CLAWNCH burn
+
+**Every launch requires a verified burn of >= 1,000,000 $CLAWNCH**
+(token `0xa1F72459dfA10BAD200Ac160eCd78C6b77a747be`) from the
+launching wallet to the dead address
+(`0x000000000000000000000000000000000000dEaD`) on Base, within 24h
+of the deploy. Deploys without one are rejected with
+`burn_required` (HTTP 402) — the error's `meta` carries
+`minBurnTokens` + `burnAddress`.
+
+The same burn claims the Clanker vault allocation as a bonus:
+1M = 1% vault, scaling linearly to 10M = 10% (the Clanker max).
+The minimum burn is never wasted.
+
+Flow: `/burn 1000000` (signs + submits the transfer from the active
+wallet) -> wait for confirmation -> `/launch burn <tx_hash>` (or it
+auto-attaches in the same draft via `/launch burn <amount>`) ->
+`/launch confirm`.
+
+The burn is an irreversible spend — state this explicitly and get a
+separate confirmation for the burn before submitting it. Never bundle
+the burn confirmation into the deploy confirmation.
 
 ## How a deploy actually happens
 
@@ -31,7 +55,7 @@ End-to-end flow when the user runs `/launch confirm`:
 
 ```
 1. Clawmes -> POST clawn.ch/api/deploy  (with CLAWNCH_API_KEY)
-       body: { tokenParams: {name, symbol, description, source: "clawmes"}, bypassTxHash? }
+       body: { tokenParams: {name, symbol, description, source: "clawmes"}, burnTxHash, bypassTxHash? }
 2. Clawnch returns a captcha challenge:
        { challengeId, message, nonce, contractAddress, storageSlot, deadline }
 3. Clawmes solves the challenge:
@@ -49,22 +73,26 @@ Clanker call. The user's wallet only signs the off-chain captcha.
 
 ## Requirements
 
-* `CLAWNCH_API_KEY` env var. Issued via `/register_agent` (two-step
-  signed flow against `clawn.ch/api/agents/register` +
-  `/api/agents/verify`).
+* A verified 1,000,000+ $CLAWNCH burn from the launching wallet
+  (see "Launch cost" above). Required for **every** deploy path —
+  custodial, non-custodial, and export.
+* `CLAWNCH_API_KEY` env var (custodial path only). Issued via
+  `/register_agent` (two-step signed flow against
+  `clawn.ch/api/agents/register` + `/api/agents/verify`).
 * An active wallet connected to clawmes (WC / local-key / Bankr).
   The wallet signs the captcha message; it doesn't pay deploy gas.
 * Base RPC reachable (any chain `8453` endpoint — public or paid).
 
 ## Rate limits + bypass
 
-Free deploys: 1 per 24h per agent. If hit, the deploy returns a
+Custodial deploys: 1 per 24h per agent. If hit, the deploy returns a
 `rate_limited` error with the bypass instructions.
 
-Bypass: send `>= 0.001 ETH` (current default) to the Clawnch bypass
+Bypass: send `>= 0.005 ETH` (current default) to the Clawnch bypass
 recipient on Base, then re-run with `bypass_tx_hash=<hash>` (or
 `/launch bypass <hash>` and `/launch confirm`). Single-use; must be
-< 24h old.
+< 24h old. The bypass covers the cooldown only — it does not replace
+the mandatory burn.
 
 ## Source attribution
 
@@ -87,7 +115,9 @@ the public launch detail page. Observable + intentional.
 | `/launch telegram <handle\|url>` | Telegram handle or invite URL. |
 | `/launch farcaster <handle\|url>` | Farcaster handle or Warpcast URL. |
 | `/launch discord <url>` | Discord invite URL. |
-| `/launch bypass <tx_hash>` | Optional: skip 24h cooldown. |
+| `/burn <amount>` | Sign + submit the required $CLAWNCH burn (min 1,000,000). |
+| `/launch burn <amount\|tx_hash>` | Attach the required burn to the draft (signs it if given an amount). |
+| `/launch bypass <tx_hash>` | Optional: skip 24h cooldown (custodial only; does not replace the burn). |
 | `/launch status` | Show current draft. |
 | `/launch confirm` | Deploy. |
 | `/launch cancel` | Clear draft. |
@@ -100,7 +130,7 @@ Social handles are normalized — `/launch twitter clawnchbot` becomes `https://
 
 | Action | Returns |
 |---|---|
-| `deploy` | `{txHash, tokenAddress, ...}` on success. Requires `name`, `symbol`; accepts `description`, `image`, `twitter`, `website`, `telegram`, `farcaster`, `discord`, `bypass_tx_hash`. |
+| `deploy` | `{txHash, tokenAddress, ...}` on success. Requires `name`, `symbol`, and `burn_tx_hash` (the verified 1M+ $CLAWNCH burn — deploys without it are rejected with `burn_required`); accepts `description`, `image`, `twitter`, `website`, `telegram`, `farcaster`, `discord`, `bypass_tx_hash`. |
 | `info` | Launch metadata for a deployed token. Requires `token` (address). |
 
 Each social arg is normalized the same way the slash command does — bare handles become full platform URLs, full URLs pass through. Pass `discord` and `website` as complete URLs.
@@ -114,6 +144,14 @@ Each social arg is normalized the same way the slash command does — bare handl
 
 ## Recovery + edge cases
 
+* **`burn_required`**: the deploy was attempted without a verified
+  burn. Run `/burn 1000000` (or `/launch burn 1000000`), wait for the
+  tx to confirm, then re-run `/launch confirm`. If the user already
+  burned externally, attach the hash with `/launch burn <tx_hash>`.
+* **`invalid_burn`**: the supplied hash failed verification — wrong
+  sender, wrong recipient, amount below 1M, or older than 24h. The
+  error message says which. A fresh burn from the launching wallet
+  fixes it.
 * **No wallet connected**: `/launch confirm` returns "No wallet
   connected. Run /connect first." Connect, then re-run confirm.
 * **CLAWNCH_API_KEY missing**: deploy returns `no_credentials`. Run
@@ -137,5 +175,6 @@ Each social arg is normalized the same way the slash command does — bare handl
   rules (creator = the agent's registered wallet).
 * It does not provide LP-fee claim transactions (Clanker handles
   fee accrual via FeeLocker; `clawnch_fees` reads metadata only).
-* It does not gate access on `$CLAWNCH` holdings. Anyone with an
-  API key (which is free to obtain) can use `/launch`.
+* It does not waive the launch burn. Every deploy requires the
+  verified 1M+ $CLAWNCH burn — there is no free-launch path. The
+  API key itself is free to obtain via `/register_agent`.

--- a/clawmes/tools/clawnch_launch.py
+++ b/clawmes/tools/clawnch_launch.py
@@ -7,7 +7,10 @@ launchpad HTTP API. Two actions:
   * ``deploy`` — submit a deploy. Service handles the captcha
     challenge (sign message + read storage slot + compute keccak
     proof), then posts the solution. Clawnch's deployer wallet pays
-    gas + submits the underlying Clanker tx server-side. Optional
+    gas + submits the underlying Clanker tx server-side. Requires
+    ``burn_tx_hash`` — every launch needs a verified 1,000,000+
+    $CLAWNCH burn (the launchpad rejects no-burn deploys with
+    ``burn_required``); the same burn sets the vault %. Optional
     ``bypass_tx_hash`` skips the 24h cooldown by paying ETH to the
     bypass recipient (see ``CLAWNCH_BYPASS_RECIPIENT``).
   * ``info`` — read launch metadata for an existing token.
@@ -115,9 +118,20 @@ _SCHEMA: dict[str, Any] = {
         "bypass_tx_hash": {
             "type": "string",
             "description": (
-                "Tx hash of >= 0.001 ETH paid to the Clawnch bypass "
+                "Tx hash of >= 0.005 ETH paid to the Clawnch bypass "
                 "recipient. Skips the 24h deploy cooldown (deploy, "
                 "optional)."
+            ),
+        },
+        "burn_tx_hash": {
+            "type": "string",
+            "description": (
+                "Tx hash of a verified 1,000,000+ $CLAWNCH burn from "
+                "the agent's wallet to the dead address within 24h. "
+                "Required for every deploy — the launchpad rejects "
+                "no-burn launches with code 'burn_required'. The same "
+                "burn sets the Clanker vault % (1M = 1%, 10M = 10%). "
+                "Use the /burn command to sign + submit one."
             ),
         },
         "token": {
@@ -140,9 +154,11 @@ _SCHEMA: dict[str, Any] = {
         "Deploy a token on Base via the Clawnch launchpad. Clawnch "
         "handles the deploy + initial liquidity atomically via the "
         "Clanker SDK; the user's wallet signs a captcha challenge to "
-        "prove identity. Supports image + social metadata (twitter / "
-        "website / telegram / farcaster / discord). Requires "
-        "CLAWNCH_API_KEY (register an agent with /register_agent)."
+        "prove identity. Every deploy requires burn_tx_hash — a "
+        "verified 1,000,000+ $CLAWNCH burn (use /burn to submit one). "
+        "Supports image + social metadata (twitter / website / "
+        "telegram / farcaster / discord). Requires CLAWNCH_API_KEY "
+        "(register an agent with /register_agent)."
     ),
     schema=_SCHEMA,
     emoji="\U0001f31f",
@@ -184,13 +200,27 @@ def _handle_deploy(args: dict[str, Any]) -> str:
         token_params["metadata"] = {"socialMediaUrls": socials}
 
     bypass = read_str(args, "bypass_tx_hash") or None
+    burn = read_str(args, "burn_tx_hash") or None
 
     try:
         result = get_clawnch_service().deploy(
             token_params=token_params,
             bypass_tx_hash=bypass,
+            burn_tx_hash=burn,
         )
     except ClawnchError as exc:
+        if exc.code == "burn_required":
+            meta = exc.meta or {}
+            min_tokens = str(meta.get("minBurnTokens") or "1000000")
+            burn_addr = str(
+                meta.get("burnAddress") or "0x000000000000000000000000000000000000dEaD"
+            )
+            return error_result(
+                f"{exc.message} Burn {min_tokens}+ CLAWNCH to {burn_addr} "
+                "from the agent's wallet (the /burn command signs + submits "
+                "one), then retry with burn_tx_hash=<tx hash>.",
+                code=exc.code,
+            )
         return error_result(exc.message, code=exc.code)
     except Exception as exc:  # noqa: BLE001
         return error_result(f"Launch failed: {exc}", code="api_error")

--- a/clawmes/tools/clawnch_launch.py
+++ b/clawmes/tools/clawnch_launch.py
@@ -212,9 +212,7 @@ def _handle_deploy(args: dict[str, Any]) -> str:
         if exc.code == "burn_required":
             meta = exc.meta or {}
             min_tokens = str(meta.get("minBurnTokens") or "1000000")
-            burn_addr = str(
-                meta.get("burnAddress") or "0x000000000000000000000000000000000000dEaD"
-            )
+            burn_addr = str(meta.get("burnAddress") or "0x000000000000000000000000000000000000dEaD")
             return error_result(
                 f"{exc.message} Burn {min_tokens}+ CLAWNCH to {burn_addr} "
                 "from the agent's wallet (the /burn command signs + submits "

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: clawmes
-version: 0.18.2
+version: 0.19.0
 description: Hermes Agent for crypto. Wallet, swaps, DeFi, launches, automation.
 author: Clawnch
 kind: standalone
@@ -103,7 +103,7 @@ requires_env:
     url: https://bv7x.ai/terminal#developer
     secret: true
   - name: CLAWNCH_API_KEY
-    description: Clawnch agent API key; required for /launch (token deploy via Clawnch launchpad). Issue via /register_agent in clawmes.
+    description: Clawnch agent API key; required for custodial /launch deploys (non-custodial path needs no key). Every launch additionally requires a verified 1M+ $CLAWNCH burn (/burn). Issue the key via /register_agent in clawmes.
     url: https://clawn.ch
     secret: true
   - name: OPENGATEWAY_API_KEY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawmes"
-version = "0.18.2"
+version = "0.19.0"
 description = "Hermes Agent plugin for crypto: wallets, DEX trading, lending and staking, governance, on-chain automation."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/commands/test_launch.py
+++ b/tests/commands/test_launch.py
@@ -302,6 +302,23 @@ class TestConfirm:
         assert "0.005 ETH" in out
         assert "/launch bypass" in out
 
+    async def test_burn_required_error_renders_burn_instructions(self, fake_svc):
+        fake_svc.deploy_raise = ClawnchError(
+            "burn_required",
+            "burn first",
+            meta={
+                "minBurnTokens": "1000000",
+                "burnAddress": "0x000000000000000000000000000000000000dEaD",
+            },
+        )
+        await launch_mod.handle_launch("name MyCoin", sender_id="alice")
+        await launch_mod.handle_launch("symbol MC", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "1,000,000+" in out
+        assert "0x000000000000000000000000000000000000dEaD" in out
+        assert "/launch burn" in out
+        assert "/launch confirm" in out
+
     async def test_other_clawnch_error(self, fake_svc):
         fake_svc.deploy_raise = ClawnchError("api_error", "boom")
         await launch_mod.handle_launch("name MyCoin", sender_id="alice")
@@ -657,6 +674,36 @@ class TestNonCustodialConfirm:
         assert "Prepare failed (bad_request)" in out
         assert "/launch status" in out
 
+    async def test_prepare_burn_required_renders_instructions(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode
+    ):
+        fake_prepare["raise"] = ClawnchError(
+            "burn_required",
+            "This launch path now requires a verified 1,000,000 $CLAWNCH burn.",
+            meta={
+                "minBurnTokens": "1000000",
+                "burnAddress": "0x000000000000000000000000000000000000dEaD",
+            },
+        )
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "1,000,000+" in out
+        assert "0x000000000000000000000000000000000000dEaD" in out
+        assert "/launch burn" in out
+        # Vault upside surfaced so the burn doesn't read as a pure cost
+        assert "vault" in out.lower()
+
+    async def test_prepare_burn_required_without_meta_uses_defaults(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode
+    ):
+        fake_prepare["raise"] = ClawnchError("burn_required", "burn first")
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "1,000,000+" in out
+        assert "dEaD" in out
+
     async def test_prepare_other_clawnch_error(
         self, fake_wallet_state, fake_prepare, fake_wallet_mode
     ):
@@ -852,6 +899,25 @@ class TestExport:
         assert "Export failed" in out
         assert "api_error" in out
 
+    async def test_burn_required_renders_instructions(
+        self, fake_wallet_optional, fake_prepare_for_export
+    ):
+        fake_wallet_optional["connected"] = True
+        fake_prepare_for_export["raise"] = ClawnchError(
+            "burn_required",
+            "burn first",
+            meta={
+                "minBurnTokens": "1000000",
+                "burnAddress": "0x000000000000000000000000000000000000dEaD",
+            },
+        )
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("export", sender_id="alice")
+        assert "Export failed" in out
+        assert "1,000,000+" in out
+        assert "/launch burn" in out
+
     async def test_prepare_unexpected_error(self, fake_wallet_optional, fake_prepare_for_export):
         fake_wallet_optional["connected"] = True
         fake_prepare_for_export["raise"] = RuntimeError("boom")
@@ -968,6 +1034,26 @@ class TestCheck:
         out = await launch_mod.handle_launch("check", sender_id="alice")
         assert "rate_limited" in out
         assert "00:00 UTC" in out
+
+    async def test_burn_required_renders_instructions(
+        self, fake_wallet_optional, fake_prepare_for_check
+    ):
+        fake_wallet_optional["connected"] = True
+        fake_prepare_for_check["raise"] = ClawnchError(
+            "burn_required",
+            "burn first",
+            meta={
+                "minBurnTokens": "1000000",
+                "burnAddress": "0x000000000000000000000000000000000000dEaD",
+            },
+        )
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("check", sender_id="alice")
+        assert "params OK" in out
+        assert "no verified burn" in out
+        assert "1,000,000+" in out
+        assert "/launch burn" in out
 
     async def test_other_error(self, fake_wallet_optional, fake_prepare_for_check):
         fake_wallet_optional["connected"] = True

--- a/tests/commands/test_launch.py
+++ b/tests/commands/test_launch.py
@@ -704,6 +704,21 @@ class TestNonCustodialConfirm:
         assert "1,000,000+" in out
         assert "dEaD" in out
 
+    async def test_prepare_burn_required_non_numeric_min_passes_through(
+        self, fake_wallet_state, fake_prepare, fake_wallet_mode
+    ):
+        """A non-numeric minBurnTokens is surfaced verbatim, not crashed on."""
+        fake_prepare["raise"] = ClawnchError(
+            "burn_required",
+            "burn first",
+            meta={"minBurnTokens": "one million"},
+        )
+        await launch_mod.handle_launch("name X", sender_id="alice")
+        await launch_mod.handle_launch("symbol X", sender_id="alice")
+        out = await launch_mod.handle_launch("confirm", sender_id="alice")
+        assert "one million+" in out
+        assert "dEaD" in out
+
     async def test_prepare_other_clawnch_error(
         self, fake_wallet_state, fake_prepare, fake_wallet_mode
     ):

--- a/tests/lib/test_http_request.py
+++ b/tests/lib/test_http_request.py
@@ -143,3 +143,37 @@ class TestRetry:
             http_get("https://api.0x.org/quote")
         # No retry — only one attempt
         assert len(client._calls) == 1
+
+    @pytest.mark.parametrize("status", [400, 402, 404, 429])
+    def test_does_not_retry_4xx(self, monkeypatch, status):
+        """4xx is deterministic — retrying burns time + rate-limit budget.
+
+        402 especially matters: Clawnch's mandatory-burn rejection
+        (burn_required) must surface immediately, not after 3 attempts
+        and seconds of backoff.
+        """
+        import httpx
+
+        responses = [FakeResponse({"ok": False}, status_code=status)]
+        client = FakeClient(responses)
+        monkeypatch.setattr(httpx, "Client", lambda *a, **kw: client)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            http_get("https://api.0x.org/quote")
+        # Single attempt — no retries on 4xx
+        assert len(client._calls) == 1
+
+    def test_retries_5xx(self, monkeypatch):
+        """Transient 5xx still gets the retry treatment."""
+        import httpx
+
+        responses = [
+            FakeResponse({"error": "upstream"}, status_code=502),
+            FakeResponse({"ok": True}),
+        ]
+        client = FakeClient(responses)
+        monkeypatch.setattr(httpx, "Client", lambda *a, **kw: client)
+
+        result = http_get("https://api.0x.org/quote")
+        assert result == {"ok": True}
+        assert len(client._calls) == 2

--- a/tests/services/test_clawnch.py
+++ b/tests/services/test_clawnch.py
@@ -637,6 +637,36 @@ class TestPrepareDeploy:
             svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="X")
         assert exc_info.value.code == "rate_limited"
 
+    def test_ok_false_burn_required_carries_meta(self, svc, monkeypatch):
+        """The mandatory-burn rejection maps to burn_required with meta."""
+        monkeypatch.setattr(
+            "clawmes.services.clawnch.http_get",
+            lambda *a, **k: {
+                "ok": False,
+                "error": "This launch path now requires a verified 1,000,000 $CLAWNCH burn.",
+                "code": "burn_required",
+                "meta": {
+                    "minBurnTokens": "1000000",
+                    "burnAddress": "0x000000000000000000000000000000000000dEaD",
+                },
+            },
+        )
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="X")
+        assert exc_info.value.code == "burn_required"
+        assert exc_info.value.meta["minBurnTokens"] == "1000000"
+        assert exc_info.value.meta["burnAddress"].endswith("dEaD")
+
+    def test_ok_false_burn_required_without_meta(self, svc, monkeypatch):
+        monkeypatch.setattr(
+            "clawmes.services.clawnch.http_get",
+            lambda *a, **k: {"ok": False, "error": "burn it", "code": "burn_required"},
+        )
+        with pytest.raises(ClawnchError) as exc_info:
+            svc.prepare_deploy(from_address="0x" + "1" * 40, name="X", symbol="X")
+        assert exc_info.value.code == "burn_required"
+        assert exc_info.value.meta == {}
+
     @pytest.mark.parametrize(
         "code",
         ["invalid_from", "invalid_name", "invalid_symbol", "missing_required", "invalid_burn"],
@@ -835,6 +865,45 @@ class TestErrorReclassify:
         with pytest.raises(ClawnchError) as exc_info:
             svc_with_key.start_deploy(token_params={"name": "x", "symbol": "X"})
         assert exc_info.value.code == "bad_request"
+
+    def test_402_burn_required_code_carries_meta(self, svc_with_key, monkeypatch):
+        """HTTP 402 burn_required maps to burn_required with the meta block."""
+        exc = _HTTPErr(
+            _FakeResponse(
+                402,
+                {
+                    "ok": False,
+                    "error": "This launch path now requires a verified 1,000,000 $CLAWNCH burn.",
+                    "code": "burn_required",
+                    "meta": {
+                        "minBurnTokens": "1000000",
+                        "burnAddress": "0x000000000000000000000000000000000000dEaD",
+                    },
+                },
+            )
+        )
+        monkeypatch.setattr("clawmes.services.clawnch.http_post", self._trigger(svc_with_key, exc))
+        with pytest.raises(ClawnchError) as exc_info:
+            svc_with_key.start_deploy(token_params={"name": "x", "symbol": "X"})
+        assert exc_info.value.code == "burn_required"
+        assert exc_info.value.meta["minBurnTokens"] == "1000000"
+
+    def test_burn_payment_required_legacy_code(self, svc_with_key, monkeypatch):
+        """The custodial path's BURN_PAYMENT_REQUIRED hint maps the same way."""
+        exc = _HTTPErr(_FakeResponse(402, {"error": "burn first", "code": "BURN_PAYMENT_REQUIRED"}))
+        monkeypatch.setattr("clawmes.services.clawnch.http_post", self._trigger(svc_with_key, exc))
+        with pytest.raises(ClawnchError) as exc_info:
+            svc_with_key.start_deploy(token_params={"name": "x", "symbol": "X"})
+        assert exc_info.value.code == "burn_required"
+        assert exc_info.value.meta == {}
+
+    def test_402_without_code_hint_to_burn_required(self, svc_with_key, monkeypatch):
+        """Bare 402 (body unparseable / code missing) still classifies."""
+        exc = _HTTPErr(_FakeResponse(402, {"error": "payment required"}))
+        monkeypatch.setattr("clawmes.services.clawnch.http_post", self._trigger(svc_with_key, exc))
+        with pytest.raises(ClawnchError) as exc_info:
+            svc_with_key.start_deploy(token_params={"name": "x", "symbol": "X"})
+        assert exc_info.value.code == "burn_required"
 
     def test_unclassifiable_propagates(self, svc_with_key, monkeypatch):
         """When we can't translate, the original exception is re-raised."""

--- a/tests/tools/test_clawnch_launch.py
+++ b/tests/tools/test_clawnch_launch.py
@@ -27,8 +27,14 @@ class _FakeSvc:
         self.info_return: dict = {"name": "X"}
         self.info_raise: Exception | None = None
 
-    def deploy(self, *, token_params, bypass_tx_hash=None):
-        self.deploys.append({"params": token_params, "bypass": bypass_tx_hash})
+    def deploy(self, *, token_params, bypass_tx_hash=None, burn_tx_hash=None):
+        self.deploys.append(
+            {
+                "params": token_params,
+                "bypass": bypass_tx_hash,
+                "burn": burn_tx_hash,
+            }
+        )
         if self.deploy_raise:
             raise self.deploy_raise
         return self.deploy_return
@@ -193,11 +199,45 @@ class TestDeploy:
         )
         assert fake_svc.deploys[0]["bypass"] == "0xbeef"
 
+    def test_with_burn(self, fake_svc):
+        clawnch_launch(
+            {
+                "action": "deploy",
+                "name": "Foo",
+                "symbol": "FOO",
+                "burn_tx_hash": "0x" + "a" * 64,
+            }
+        )
+        assert fake_svc.deploys[0]["burn"] == "0x" + "a" * 64
+
     def test_clawnch_error_surfaces_code(self, fake_svc):
         fake_svc.deploy_raise = ClawnchError("rate_limited", "wait 24h")
         out = json.loads(clawnch_launch({"action": "deploy", "name": "Foo", "symbol": "FOO"}))
         assert out["isError"] is True
         assert out["details"]["error_code"] == "rate_limited"
+
+    def test_burn_required_error_includes_instructions(self, fake_svc):
+        fake_svc.deploy_raise = ClawnchError(
+            "burn_required",
+            "This launch path now requires a verified 1,000,000 $CLAWNCH burn.",
+            meta={
+                "minBurnTokens": "1000000",
+                "burnAddress": "0x000000000000000000000000000000000000dEaD",
+            },
+        )
+        out = json.loads(clawnch_launch({"action": "deploy", "name": "Foo", "symbol": "FOO"}))
+        assert out["isError"] is True
+        assert out["details"]["error_code"] == "burn_required"
+        text = out["content"][0]["text"]
+        assert "1000000" in text
+        assert "0x000000000000000000000000000000000000dEaD" in text
+        assert "burn_tx_hash" in text
+
+    def test_burn_required_error_without_meta_uses_defaults(self, fake_svc):
+        fake_svc.deploy_raise = ClawnchError("burn_required", "burn first")
+        out = json.loads(clawnch_launch({"action": "deploy", "name": "Foo", "symbol": "FOO"}))
+        assert out["details"]["error_code"] == "burn_required"
+        assert "dEaD" in out["content"][0]["text"]
 
     def test_unexpected_error(self, fake_svc):
         fake_svc.deploy_raise = RuntimeError("boom")


### PR DESCRIPTION
## Why

The Clawnch launchpad now requires a verified **1,000,000+ $CLAWNCH burn for every launch** (clawnchdev/clawnch#7). `/api/prepare/deploy` and `/api/deploy` reject no-burn deploys with HTTP 402:

```json
{"ok":false,"code":"burn_required","meta":{"minBurnTokens":"1000000","burnAddress":"0x000000000000000000000000000000000000dEaD"}}
```

clawmes still treated the burn as an optional vault-allocation perk. The failure mode today:

1. A burn-less `/launch confirm` gets the 402, which `lib/http`'s tenacity predicate **retries 3× with backoff** (despite the module docstring promising 4xx is never retried)
2. `_reclassify` has no 402/`burn_required` mapping, so the raw `httpx.HTTPStatusError` bubbles up
3. The user sees `Prepare failed: Client error '402 Payment Required'` — no mention of the burn, the amount, or the address
4. The `clawnch_launch` LLM tool has **no `burn_tx_hash` param at all**, so that surface can't launch under the new rules, period

## What changed

**`services/clawnch.py`**
- `ClawnchError` gains a `meta` dict (carries `minBurnTokens` / `burnAddress` from upstream)
- `_reclassify` maps HTTP 402 / `burn_required` / `BURN_PAYMENT_REQUIRED` → `burn_required` with meta
- `prepare_deploy`'s `ok:false` map handles `burn_required` on 2xx bodies too

**`commands/launch.py`** — `burn_required` renders exact burn instructions on all four surfaces (`confirm` non-custodial + custodial, `check`, `export`): required amount, dead address, the `/launch burn <amount|tx_hash>` next step, and the vault % the same burn earns. Help text reframed (burn = required, vault = bonus).

**`tools/clawnch_launch.py`** — new `burn_tx_hash` schema param forwarded to `deploy()`; `burn_required` errors include retry instructions; bypass copy corrected 0.001 → 0.005 ETH (the actual default).

**`lib/http.py`** — retry predicate now skips all 4xx (5xx + transport errors keep the existing backoff). A burn-less prepare fails in one request instead of three.

**Docs** — README launch section, `clawnch-launch` skill (drops "free deploys", adds a Launch cost section + `burn_required`/`invalid_burn` recovery), plugin.yaml (both copies), `/burn` + `/launch` usage text.

## Tests

- `burn_required` mapping with + without `meta`, `BURN_PAYMENT_REQUIRED` legacy hint, bare-402 fallback (`test_clawnch.py`)
- Command rendering on confirm/check/export (`test_launch.py`)
- Tool `burn_tx_hash` passthrough + error copy (`test_clawnch_launch.py`)
- 4xx-never-retried (400/402/404/429) + 5xx-still-retried (`test_http_request.py`)

`4658 passed, 8 skipped` · `ruff` clean · verified live: `GET /api/prepare/deploy` without `burnTxHash` → 402 `burn_required` with the documented meta shape.

## Version

0.18.2 → **0.19.0** (`_version.py` + both `plugin.yaml` copies + `pyproject.toml`, changelog entry under Keep-a-Changelog format).